### PR TITLE
Blur option

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -99,7 +99,8 @@ function parseOptions(query: {[key: string]: any}, acceptHeader: string = ''): P
         default:
             format = OutputFormat.Match
     }
-    return {width, height, mode, format, ignorecache, invalidate}
+    const blur = query['blur'] === '1' || query['blur'] === 'true'
+    return {width, height, mode, format, ignorecache, invalidate, blur}
 }
 
 export async function proxyHandler(ctx: KoaContext) {
@@ -488,6 +489,12 @@ export async function proxyHandler(ctx: KoaContext) {
                 default:
                     break
             }
+        }
+
+        // Blur placeholder: tiny ~20px wide JPEG for LQIP
+        if (options.blur) {
+            image.resize(20, undefined, { fit: 'inside' }).blur(2).jpeg({ quality: 15, force: true })
+            contentType = 'image/jpeg'
         }
 
         try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,6 +161,7 @@ export interface ProxyOptions {
     format: OutputFormat
     ignorecache?: number
     invalidate?: number
+    blur?: boolean
 }
 
 export function getImageKey(origKey: string, options: ProxyOptions): string {
@@ -170,6 +171,7 @@ export function getImageKey(origKey: string, options: ProxyOptions): string {
     const rv = [origKey, ScalingMode[options.mode], OutputFormat[options.format]]
     if (options.width) { rv.push(options.width.toFixed(0)) }
     if (options.height) { rv.push(options.height.toFixed(0)) }
+    if (options.blur) { rv.push('blur') }
     return rv.join('_')
 }
 export function getUrlHashKey(input: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -166,7 +166,7 @@ export interface ProxyOptions {
 
 export function getImageKey(origKey: string, options: ProxyOptions): string {
     if (options.mode === ScalingMode.Fit && options.format === OutputFormat.Match) {
-        return `${origKey}_${options.width || 0}x${options.height || 0}`
+        return `${origKey}_${options.width || 0}x${options.height || 0}${options.blur ? '_blur' : ''}`
     }
     const rv = [origKey, ScalingMode[options.mode], OutputFormat[options.format]]
     if (options.width) { rv.push(options.width.toFixed(0)) }

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -92,6 +92,18 @@ describe('proxy', function() {
         assert.equal(meta.space, 'srgb')
     })
 
+    it('should return tiny blur placeholder', async function() {
+        this.slow(1000)
+        serveImage = false
+        const imageUrl = base58Enc(`http://localhost:${ port+1 }/test.jpg`)
+        const res = await needle('get', `http://localhost:${ port }/p/${ imageUrl }?blur=1`)
+        const image = sharp(res.body)
+        const meta = await image.metadata()
+        assert.equal(meta.format, 'jpeg')
+        assert(meta.width! <= 20, `blur width should be <=20, got ${meta.width}`)
+        assert(res.body.length < 2000, `blur image should be small, got ${res.body.length} bytes`)
+    })
+
     it('should resolve double proxied images', async function() {
         this.slow(1000)
         serveImage = false

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -94,7 +94,7 @@ describe('proxy', function() {
 
     it('should return tiny blur placeholder', async function() {
         this.slow(1000)
-        serveImage = false
+        serveImage = true
         const imageUrl = base58Enc(`http://localhost:${ port+1 }/test.jpg`)
         const res = await needle('get', `http://localhost:${ port }/p/${ imageUrl }?blur=1`)
         const image = sharp(res.body)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added blur query parameter support to generate tiny blurred image placeholders; previews are resized to ~20px, lightly blurred, and served as low-quality JPEGs for faster loading.

* **Tests**
  * Added test coverage to validate blurred placeholder output (JPEG format, small dimensions, and reduced file size).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->