### PR TITLE
Drop retired hapi.ecency.com node, expand public RPC fallbacks, bump @ecency/sdk to 2.3.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.700.0",
-    "@ecency/sdk": "^2.2.3",
+    "@ecency/sdk": "^2.3.34",
     "@koa/cors": "^5.0.0",
     "@koa/router": "^13.1.0",
     "@sentry/node": "^10.44.0",

--- a/src/common.ts
+++ b/src/common.ts
@@ -44,12 +44,13 @@ export interface HiveAccount {
 /** hived RPC config — @ecency/sdk uses module-level config, not a client instance. */
 hiveTxConfig.nodes = [
     config.get('rpc_node') as string,
-    'https://hapi.ecency.com',
     'https://api.deathwing.me',
-    'https://rpc.mahdiyari.info',
     'https://api.openhive.network',
-    'https://techcoderx.com',
+    'https://rpc.mahdiyari.info',
     'https://api.syncad.com',
+    'https://techcoderx.com',
+    'https://hiveapi.actifit.io',
+    'https://api.c0ff33a.uk',
 ]
 // Per-request timeout. dhive's effective first-try timeout was ~500ms (hardcoded
 // in client.js fetchTimeout), which caused frequent spurious failovers on slow

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,10 +705,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@ecency/sdk@^2.2.3":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.2.3.tgz#4f908b0bdf01d33f0b134db7dfec9f1bf38eb066"
-  integrity sha512-waybgump9KoI1NiGH0u340KY1S8AbPhqz+anVxtYHbJ2xwFYR0hGDDtHlx7JCi5G1/Ewt10sRnW8FsA8rBHxWA==
+"@ecency/sdk@^2.3.34":
+  version "2.3.34"
+  resolved "https://registry.yarnpkg.com/@ecency/sdk/-/sdk-2.3.34.tgz#4bc1a80e7fcaa56d7eda5eb1fea7e586758dcee4"
+  integrity sha512-ofy4AWIm0BpI6OUhGEsirHME9gwiszZquX/puuX2KSH7Sb8avUPofvKd4UrISDpdhdqO6HynHnbpD4zKP3g5Ow==
   dependencies:
     "@noble/ciphers" "^2.1.1"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
### What
- Remove `hapi.ecency.com` from the hived RPC node list (endpoint retired).
- Expand the public-node fallback set so read failover has more healthy alternatives: `api.deathwing.me`, `api.openhive.network`, `rpc.mahdiyari.info`, `api.syncad.com`, `techcoderx.com`, `hiveapi.actifit.io`, `api.c0ff33a.uk` (alongside the configured `rpc_node`, `api.hive.blog`).
- Bump `@ecency/sdk` `2.2.3` -> `2.3.34` for improved per-node failover and adaptive timeouts.

### Notes
- `yarn.lock` regenerated (Docker build uses `--frozen-lockfile`).
- `tsc --noEmit` is clean; the `config.nodes` / `config.timeout` module-config API is unchanged across the bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core SDK to a newer version for improved compatibility and reliability.
* **Bug Fixes**
  * Refined the app’s blockchain RPC connection options to improve network availability and reduce connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->