### PR TITLE
Recover avatars/covers stored only in legacy json_metadata

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -134,6 +134,42 @@ export interface HiveProfile {
     }}
 }
 
+const isHttpUrl = (v: unknown): v is string =>
+    typeof v === 'string' && (v.startsWith('http://') || v.startsWith('https://'))
+
+/** Parse a `*_json_metadata` string and return its `.profile` object, or undefined. */
+function parseProfile(raw: unknown): Record<string, any> | undefined {
+    if (typeof raw !== 'string' || raw.length === 0) return undefined
+    try {
+        const obj = JSON.parse(raw)
+        const prof = obj && obj.profile
+        return prof && typeof prof === 'object' ? prof : undefined
+    } catch { return undefined }
+}
+
+/**
+ * Field-level legacy image lookup: posting_json_metadata.profile.<field> dominates,
+ * else fall back to json_metadata.profile.<field>. Returns the value only when it is
+ * an http(s) URL.
+ *
+ * Needed because `bridge.get_profile` (PostgREST hivemind) reads ONLY
+ * posting_json_metadata and no longer falls back to the legacy json_metadata when
+ * posting_json_metadata is a non-empty object without a usable `profile` image
+ * (older hivemind's get_db_profile did). Avatars/covers stored only in json_metadata
+ * therefore come back empty from bridge; we recover them from the raw account here.
+ */
+function legacyProfileImage(
+    account: HiveAccount | undefined,
+    field: 'profile_image' | 'cover_image',
+): string | undefined {
+    if (!account) return undefined
+    const posting = parseProfile(account.posting_json_metadata)
+    if (posting && isHttpUrl(posting[field])) return posting[field]
+    const legacy = parseProfile(account.json_metadata)
+    if (legacy && isHttpUrl(legacy[field])) return legacy[field]
+    return undefined
+}
+
 /** Get account profile (simplified data for avatar/cover, no JSON parsing needed) */
 export const getProfile = async (user: string, isCached= true): Promise<HiveProfile | undefined> => {
     const cacheKey = `profile:hive:${user}`
@@ -149,7 +185,33 @@ export const getProfile = async (user: string, isCached= true): Promise<HiveProf
     try {
         profile = await rpc.call<HiveProfile>('bridge.get_profile', {account: user})
         if (profile) {
-            await redisSet(cacheKey, profile, 300)
+            let ttl = 300
+            const p = profile.metadata && profile.metadata.profile
+            // Legacy fallback: when bridge returns no avatar, the image may live only in the
+            // account's legacy json_metadata (which the PostgREST hivemind ignores). Do ONE
+            // extra (cached) account lookup to recover it. We gate strictly on a MISSING
+            // AVATAR — deliberately NOT on a missing cover: most accounts have an avatar but
+            // no cover, so triggering on cover would fire this second RPC on the hot avatar
+            // path for nearly everyone. The cover is still recovered opportunistically from
+            // the same lookup, so the common broken case (posting profile-less, both images
+            // only in json_metadata) is fully healed; the rare "working posting avatar +
+            // legacy-only cover" case intentionally keeps the default cover.
+            if (p && !isHttpUrl(p.profile_image)) {
+                const account = (await getAccount(user, isCached))[0]
+                if (account) {
+                    const avatar = legacyProfileImage(account, 'profile_image')
+                    if (avatar) p.profile_image = avatar
+                    if (!isHttpUrl(p.cover_image)) {
+                        const cover = legacyProfileImage(account, 'cover_image')
+                        if (cover) p.cover_image = cover
+                    }
+                } else {
+                    // bridge said the account exists, so an empty getAccount result means a
+                    // transient get_accounts failure — cache briefly so we retry the merge soon.
+                    ttl = 30
+                }
+            }
+            await redisSet(cacheKey, profile, ttl)
         } else {
             // Null/undefined result — negative cache with short TTL
             await redisSet(cacheKey, null, 30)

--- a/src/common.ts
+++ b/src/common.ts
@@ -135,7 +135,9 @@ export interface HiveProfile {
 }
 
 const isHttpUrl = (v: unknown): v is string =>
-    typeof v === 'string' && (v.startsWith('http://') || v.startsWith('https://'))
+    typeof v === 'string' &&
+    (v.startsWith('http://') || v.startsWith('https://')) &&
+    v.includes('.') // require a host (domain/IP) — rejects pathological 'https://'
 
 /** Parse a `*_json_metadata` string and return its `.profile` object, or undefined. */
 function parseProfile(raw: unknown): Record<string, any> | undefined {

--- a/test/index.ts
+++ b/test/index.ts
@@ -37,6 +37,30 @@ export const mockAccounts: any = {
             account_auths: [],
             key_auths: [[testKeys.foo.createPublic().toString(), 1]]
         }
+    },
+    // Avatar only in legacy json_metadata; posting_json_metadata is a non-`profile`
+    // object (so bridge.get_profile returns an empty avatar). Recoverable via fallback.
+    legacyonly: {
+        name: 'legacyonly',
+        active: '2024-01-01T00:00:00',
+        posting_json_metadata: '{"combflow":{"voteFloor":50}}',
+        json_metadata: '{"profile":{"profile_image":"https://cdn.steemitimages.com/legacy/Kozmos.jpg","cover_image":"https://cdn.steemitimages.com/legacy/cover.jpg","location":"Tirana"}}',
+    },
+    // posting_json_metadata.profile exists with a cover but NO avatar; avatar lives in
+    // json_metadata. Field-level fallback must keep the posting cover and recover the
+    // json_metadata avatar.
+    splitprofile: {
+        name: 'splitprofile',
+        active: '2024-01-01T00:00:00',
+        posting_json_metadata: '{"profile":{"cover_image":"https://files.peakd.com/posting/cover.jpg","version":2}}',
+        json_metadata: '{"profile":{"profile_image":"https://files.steempeak.com/legacy/avatar.jpg"}}',
+    },
+    // Avatar wiped from BOTH fields (pin-clobber). Nothing to recover.
+    noavatar: {
+        name: 'noavatar',
+        active: '2024-01-01T00:00:00',
+        posting_json_metadata: '{"profile":{"pinned":"some-permlink","version":2}}',
+        json_metadata: '',
     }
 }
 
@@ -74,6 +98,42 @@ export const mockProfiles: any = {
                 profile_image: 'https://example.com/bar-avatar.jpg',
             }
         }
+    },
+    // bridge returns an empty avatar/cover — these live only in legacy json_metadata.
+    legacyonly: {
+        name: 'legacyonly',
+        active: '2024-01-01T00:00:00',
+        created: '2016-01-01T00:00:00',
+        id: 3,
+        post_count: 10,
+        reputation: 40,
+        blacklists: [],
+        stats: { followers: 5, following: 5, rank: 0 },
+        metadata: { profile: { name: '', profile_image: '', cover_image: '' } }
+    },
+    // bridge surfaces the posting cover but no avatar.
+    splitprofile: {
+        name: 'splitprofile',
+        active: '2024-01-01T00:00:00',
+        created: '2016-01-01T00:00:00',
+        id: 4,
+        post_count: 10,
+        reputation: 40,
+        blacklists: [],
+        stats: { followers: 5, following: 5, rank: 0 },
+        metadata: { profile: { name: 'Split', profile_image: '', cover_image: 'https://files.peakd.com/posting/cover.jpg' } }
+    },
+    // bridge empty and nothing recoverable on chain.
+    noavatar: {
+        name: 'noavatar',
+        active: '2024-01-01T00:00:00',
+        created: '2016-01-01T00:00:00',
+        id: 5,
+        post_count: 10,
+        reputation: 40,
+        blacklists: [],
+        stats: { followers: 5, following: 5, rank: 0 },
+        metadata: { profile: { name: '', profile_image: '', cover_image: '' } }
     }
 }
 
@@ -84,11 +144,15 @@ before(() => {
             case 'condenser_api.get_accounts': {
                 const names = (params as string[][])[0]
                 assert.equal(names.length, 1, 'can only mock single account lookups')
-                return [mockAccounts[names[0]]]
+                const account = mockAccounts[names[0]]
+                // Return a fresh copy each call, like a real RPC response.
+                return [account ? structuredClone(account) : account]
             }
             case 'bridge.get_profile': {
                 const username = (params as any).account || (params as any[])[0]
-                return mockProfiles[username] || null
+                const profile = mockProfiles[username]
+                // Fresh copy so consumers that mutate the profile don't corrupt the fixture.
+                return profile ? structuredClone(profile) : null
             }
             default:
                 throw new Error(`No mock data for: ${ method }`)

--- a/test/index.ts
+++ b/test/index.ts
@@ -134,6 +134,20 @@ export const mockProfiles: any = {
         blacklists: [],
         stats: { followers: 5, following: 5, rank: 0 },
         metadata: { profile: { name: '', profile_image: '', cover_image: '' } }
+    },
+    // bridge returns an empty avatar; deliberately has NO mockAccounts entry so
+    // condenser_api.get_accounts resolves to [undefined] — simulating a transient
+    // get_accounts failure during the fallback.
+    ghostbridge: {
+        name: 'ghostbridge',
+        active: '2024-01-01T00:00:00',
+        created: '2016-01-01T00:00:00',
+        id: 9,
+        post_count: 1,
+        reputation: 25,
+        blacklists: [],
+        stats: { followers: 0, following: 0, rank: 0 },
+        metadata: { profile: { name: '', profile_image: '', cover_image: '' } }
     }
 }
 

--- a/test/profile.ts
+++ b/test/profile.ts
@@ -1,0 +1,85 @@
+import 'mocha'
+import assert from 'assert'
+
+import {getProfile, rpc} from './../src/common'
+import {mockProfiles} from './index'
+
+// bridge returns a valid profile object but with an empty avatar; the account is not
+// in mockAccounts, so condenser_api.get_accounts resolves to [undefined] — simulating a
+// transient get_accounts failure during the fallback.
+mockProfiles.ghostbridge = {
+    name: 'ghostbridge',
+    active: '2024-01-01T00:00:00',
+    created: '2016-01-01T00:00:00',
+    id: 9,
+    post_count: 1,
+    reputation: 25,
+    blacklists: [],
+    stats: { followers: 0, following: 0, rank: 0 },
+    metadata: { profile: { name: '', profile_image: '', cover_image: '' } }
+}
+
+/** Run `fn` while counting the RPC methods invoked, then restore the mock. */
+async function countingRpc<T>(fn: () => Promise<T>): Promise<{ result: T, methods: string[] }> {
+    const orig = rpc.call
+    const methods: string[] = []
+    rpc.call = async (method: string, params?: any) => {
+        methods.push(method)
+        return orig(method, params)
+    }
+    try {
+        const result = await fn()
+        return { result, methods }
+    } finally {
+        rpc.call = orig
+    }
+}
+
+describe('getProfile legacy json_metadata fallback', () => {
+
+    it('recovers an avatar stored only in json_metadata (posting has no profile)', async () => {
+        const p = await getProfile('legacyonly', false)
+        assert(p, 'profile should be defined')
+        assert.equal(p!.metadata.profile.profile_image, 'https://cdn.steemitimages.com/legacy/Kozmos.jpg')
+        // cover is recovered from the same json_metadata in the one lookup
+        assert.equal(p!.metadata.profile.cover_image, 'https://cdn.steemitimages.com/legacy/cover.jpg')
+    })
+
+    it('recovers the json_metadata avatar but keeps the posting cover (field-level)', async () => {
+        const p = await getProfile('splitprofile', false)
+        assert(p)
+        assert.equal(p!.metadata.profile.profile_image, 'https://files.steempeak.com/legacy/avatar.jpg')
+        // bridge already surfaced the posting cover — it must NOT be overwritten
+        assert.equal(p!.metadata.profile.cover_image, 'https://files.peakd.com/posting/cover.jpg')
+    })
+
+    it('leaves the avatar empty when it is absent from both metadata fields', async () => {
+        const p = await getProfile('noavatar', false)
+        assert(p)
+        assert.equal(p!.metadata.profile.profile_image, '')
+    })
+
+    it('does not fetch the account for a modern profile (single RPC fast path)', async () => {
+        const { result, methods } = await countingRpc(() => getProfile('foo', false))
+        assert.equal(result!.metadata.profile.profile_image, 'https://example.com/avatar.jpg')
+        assert.deepEqual(methods, ['bridge.get_profile'])
+        assert.equal(methods.filter((m) => m === 'condenser_api.get_accounts').length, 0)
+    })
+
+    it('makes exactly one extra account lookup when the avatar is missing', async () => {
+        const { methods } = await countingRpc(() => getProfile('legacyonly', false))
+        assert.deepEqual(methods, ['bridge.get_profile', 'condenser_api.get_accounts'])
+    })
+
+    it('survives a get_accounts miss/failure during the fallback', async () => {
+        const p = await getProfile('ghostbridge', false)
+        assert(p, 'still returns the bridge profile')
+        assert.equal(p!.metadata.profile.profile_image, '')
+    })
+
+    it('returns undefined for an unknown account (bridge null, no account lookup)', async () => {
+        const { result, methods } = await countingRpc(() => getProfile('doesnotexist', false))
+        assert.equal(result, undefined)
+        assert.equal(methods.filter((m) => m === 'condenser_api.get_accounts').length, 0)
+    })
+})

--- a/test/profile.ts
+++ b/test/profile.ts
@@ -2,22 +2,6 @@ import 'mocha'
 import assert from 'assert'
 
 import {getProfile, rpc} from './../src/common'
-import {mockProfiles} from './index'
-
-// bridge returns a valid profile object but with an empty avatar; the account is not
-// in mockAccounts, so condenser_api.get_accounts resolves to [undefined] — simulating a
-// transient get_accounts failure during the fallback.
-mockProfiles.ghostbridge = {
-    name: 'ghostbridge',
-    active: '2024-01-01T00:00:00',
-    created: '2016-01-01T00:00:00',
-    id: 9,
-    post_count: 1,
-    reputation: 25,
-    blacklists: [],
-    stats: { followers: 0, following: 0, rank: 0 },
-    metadata: { profile: { name: '', profile_image: '', cover_image: '' } }
-}
 
 /** Run `fn` while counting the RPC methods invoked, then restore the mock. */
 async function countingRpc<T>(fn: () => Promise<T>): Promise<{ result: T, methods: string[] }> {


### PR DESCRIPTION
## Problem

`bridge.get_profile` builds the profile from `posting_json_metadata` only. When `posting_json_metadata` is a non-empty object that has no usable `profile` image, the current PostgREST hivemind no longer falls back to the legacy `json_metadata` (the older `get_db_profile` did). Accounts whose avatar/cover lives only in `json_metadata` therefore come back with an empty `profile_image` and get served the default placeholder, even though the image is still on chain.

Two common shapes hit this:
- `posting_json_metadata` is a non-`profile` object (e.g. an app's settings) while the avatar is only in `json_metadata`.
- `posting_json_metadata.profile` exists with a cover but no avatar, while the avatar is in `json_metadata`.

## Fix

`getProfile` keeps `bridge.get_profile` as the fast path. Only when bridge returns no avatar does it make one extra (Redis-cached) `condenser_api.get_accounts` lookup and fill `profile_image`/`cover_image` from the raw account, with `posting_json_metadata.profile` → `json_metadata.profile` field-level priority. Accounts that already have an avatar keep a single RPC. `avatar.ts`/`cover.ts` are unchanged (they already read `metadata.profile.*`).

Notes:
- Gated on a missing avatar (not cover), so the extra lookup does not fire on the hot avatar path for the many accounts that have an avatar but no cover; the cover is recovered opportunistically in the same lookup.
- A transient `get_accounts` failure shortens the cache TTL so the merge is retried soon instead of caching an incomplete profile for the full window.
- Accounts whose image is absent from both fields still serve the default (nothing to recover).

## Tests

New `test/profile.ts`: recovery of a `json_metadata`-only avatar; field-level cover precedence (posting cover kept, `json_metadata` avatar recovered); no second RPC on the modern fast path; exactly one extra lookup when the avatar is missing; graceful `get_accounts` failure; unknown account returns undefined without an account lookup. The RPC mock now returns a fresh copy per call.
