### PR TITLE
Serve legacy img.esteem.ws images from the upload store

### DIFF
--- a/config/test.toml
+++ b/config/test.toml
@@ -6,6 +6,9 @@ service_url = 'http://localhost:63205'
 # Disable Redis for tests (avoids connection timeout crash)
 redis_url = ''
 
+# Allow exercising the invalidate path in tests
+invalidate_token = 'test-invalidate-token'
+
 # Use memory stores for tests so caching actually works
 # (default.toml uses filesystem at /mnt/eproxy-bucket which doesn't exist locally)
 [upload_store]

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -303,18 +303,33 @@ export async function proxyHandler(ctx: KoaContext) {
     // esteem-legacy originals are authoritative and unrefetchable: ignorecache/
     // invalidate still re-derives variants but never bypasses the stored original
     const bypassStoredOriginal = (options.ignorecache || options.invalidate) && !isEsteemLegacy
-    if (await storeExists(origStore, origKey) && !bypassStoredOriginal) {
+    // Rescued dead-origin originals are archived in the upload store under the
+    // same derived key: if the proxy store lacks the original, consult that
+    // read-only archive before reaching for the network.
+    let servingStore = origStore
+    let haveOriginal = await storeExists(origStore, origKey)
+    if (!haveOriginal && !usesUploadStore && !bypassStoredOriginal
+        && await storeExists(uploadStore, origKey)) {
+        servingStore = uploadStore
+        haveOriginal = true
+        ctx.tag({rescued_original: true})
+    }
+    if (haveOriginal && !bypassStoredOriginal) {
         origFromCache = true
         ctx.tag({store: 'original'})
         let res: NeedleResponse
         try {
-            origData = await readStream(origStore.createReadStream(origKey))
+            origData = await readStream(servingStore.createReadStream(origKey))
             contentType = await mimeMagic(origData)
             // Validate stored data is actually an image — stale error pages or
             // truncated responses may have been cached by a previous request
             if (!AcceptedContentTypes.includes(contentType.toLowerCase())) {
-                ctx.log.warn({contentType, origKey, urlString, msg: 'stored original has invalid content type, purging and re-fetching'})
-                try { await storeRemove(origStore, origKey) } catch (_e) { /* best effort */ }
+                ctx.log.warn({contentType, origKey, urlString, msg: 'stored original has invalid content type'})
+                // the upload store holds user uploads and rescued (unrefetchable)
+                // originals — never delete from it here
+                if (servingStore !== uploadStore) {
+                    try { await storeRemove(servingStore, origKey) } catch (_e) { /* best effort */ }
+                }
                 throw new Error('Invalid stored content type: ' + contentType)
             }
         } catch (err) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -309,17 +309,17 @@ export async function proxyHandler(ctx: KoaContext) {
     // invalidate still re-derives variants but never bypasses the stored original
     const bypassStoredOriginal = (options.ignorecache || options.invalidate) && !isEsteemLegacy
     // Rescued dead-origin originals are archived in the upload store under the
-    // same derived key: if the proxy store lacks the original, consult that
-    // read-only archive before reaching for the network.
+    // same derived key. The archive is an origin, not a cache: it is consulted
+    // whenever the proxy-store original is absent or bypassed, and cache-bypass
+    // flags never skip it (there is no live origin to refetch from).
     let servingStore = origStore
-    let haveOriginal = await storeExists(origStore, origKey)
-    if (!haveOriginal && !usesUploadStore && !bypassStoredOriginal
-        && await storeExists(uploadStore, origKey)) {
+    let haveOriginal = await storeExists(origStore, origKey) && !bypassStoredOriginal
+    if (!haveOriginal && !usesUploadStore && await storeExists(uploadStore, origKey)) {
         servingStore = uploadStore
         haveOriginal = true
         ctx.tag({rescued_original: true})
     }
-    if (haveOriginal && !bypassStoredOriginal) {
+    if (haveOriginal) {
         origFromCache = true
         ctx.tag({store: 'original'})
         let res: NeedleResponse
@@ -460,8 +460,12 @@ export async function proxyHandler(ctx: KoaContext) {
             ctx.log.error({ url: urlString, key: imageKey, msg: 'getSharpMetadataWithRetry failed'})
             captureImageFailure('metadata_extraction_failed', ctx, { urlString, imageKey, origFromCache, error: String(err) })
             if (origFromCache) {
-                ctx.log.warn({origKey, msg: 'purging corrupt cached original after metadata failure'})
-                try { await storeRemove(origStore, origKey) } catch (_e) { /* best effort */ }
+                // the upload store holds user uploads and rescued (unrefetchable)
+                // originals — never delete from it here either
+                if (servingStore !== uploadStore) {
+                    ctx.log.warn({origKey, msg: 'purging corrupt cached original after metadata failure'})
+                    try { await storeRemove(servingStore, origKey) } catch (_e) { /* best effort */ }
+                }
                 const fallbackRes = await fetchUrl(DefaultAvatar, {
                     parse_response: false, follow_max: 3, user_agent: 'EcencyProxy/1.0',
                 })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -53,6 +53,10 @@ if (!Number.isFinite(MAX_IMAGE_SIZE)) {
 }
 const SERVICE_URL = new URL(config.get('service_url'))
 
+// Public proxy hosts that old post bodies wrapped around img.esteem.ws URLs
+// (e.g. https://steemitimages.com/500x0/https://img.esteem.ws/abc.jpg)
+const ESTEEM_WRAP_PREFIX = /^https?:\/\/(?:steemitimages\.com|images\.hive\.blog)\/\d+x\d+\//
+
 function parseOptions(query: {[key: string]: any}, acceptHeader: string = ''): ProxyOptions {
     const width = Number.parseInt(query['width']) || undefined
     const height = Number.parseInt(query['height']) || undefined
@@ -202,8 +206,16 @@ export async function proxyHandler(ctx: KoaContext) {
     urlString = url.toString()
     urlString = applyUrlReplacements(urlString)
     url = new URL(urlString)
-    // Ecency team does not own esteem.ws domain anymore, assume steemit has images from those old domain
-    if (urlString.includes('https://img.esteem.ws/')) {
+    // img.esteem.ws is gone and its mirrors no longer have these images; surviving
+    // originals were preserved in the upload store, keyed by the historically
+    // rewritten URL (steemitimages.com/0x0/<url>). Unwrap public-proxy prefixes
+    // first so every request form of an esteem image resolves to that same key.
+    while (ESTEEM_WRAP_PREFIX.test(urlString) && urlString.includes('://img.esteem.ws/')) {
+        urlString = urlString.replace(ESTEEM_WRAP_PREFIX, '')
+        url = new URL(urlString)
+    }
+    const isEsteemLegacy = urlString.includes('://img.esteem.ws/')
+    if (isEsteemLegacy) {
         urlString = `https://steemitimages.com/0x0/${urlString}`
     }
     if (process.env.NODE_ENV !== 'test') {
@@ -216,7 +228,11 @@ export async function proxyHandler(ctx: KoaContext) {
     let contentType: string
     ctx.originalUrl = urlString
     const origIsUpload = isInternalUploadUrl(url)
+    // esteem-legacy originals live in the upload store; treat that store as
+    // read-only here (never overwritten by fetches, never removed by invalidate)
+    const usesUploadStore = origIsUpload || isEsteemLegacy
     ctx.tag({is_upload: origIsUpload})
+    if (isEsteemLegacy) { ctx.tag({esteem_legacy: true}) }
     if (origIsUpload) {
         // if we are proxying our or own image, use the uploadStore directly
         // to avoid storing two copies of the same data
@@ -226,7 +242,7 @@ export async function proxyHandler(ctx: KoaContext) {
         const urlHash = createHash('sha1')
             .update(urlString)
             .digest()
-        origStore = proxyStore
+        origStore = isEsteemLegacy ? uploadStore : proxyStore
         origKey = 'U' + multihash.toB58String(
             multihash.encode(urlHash, 'sha1')
         )
@@ -243,7 +259,7 @@ export async function proxyHandler(ctx: KoaContext) {
             await storeRemove(proxyStore, imageKey)
             ctx.log.debug({ imageKey }, 'removed resized imageKey due to invalidate')
         } catch (_e) { /* may not exist */ }
-        if (!origIsUpload) {
+        if (!usesUploadStore) {
             try {
                 await storeRemove(origStore, origKey)
                 ctx.log.debug({ image: origKey }, 'removed original due to invalidate')
@@ -284,7 +300,10 @@ export async function proxyHandler(ctx: KoaContext) {
     // check if we have the original
     let origData: Buffer
     let origFromCache = false
-    if (await storeExists(origStore, origKey) && !options.ignorecache && !options.invalidate) {
+    // esteem-legacy originals are authoritative and unrefetchable: ignorecache/
+    // invalidate still re-derives variants but never bypasses the stored original
+    const bypassStoredOriginal = (options.ignorecache || options.invalidate) && !isEsteemLegacy
+    if (await storeExists(origStore, origKey) && !bypassStoredOriginal) {
         origFromCache = true
         ctx.tag({store: 'original'})
         let res: NeedleResponse
@@ -312,7 +331,7 @@ export async function proxyHandler(ctx: KoaContext) {
             if (result.isFallback) { isDefaultImage = true }
             origData = res.body
             // Don't write fallback data to uploadStore — could corrupt original hash
-            if (res.bytes <= MAX_IMAGE_SIZE && !isDefaultImage && !origIsUpload && !isLegacy) {
+            if (res.bytes <= MAX_IMAGE_SIZE && !isDefaultImage && !usesUploadStore && !isLegacy) {
                 ctx.log.debug('storing original readStream catch %s', origKey)
                 try {
                     await storeWrite(origStore, origKey, origData)
@@ -321,7 +340,7 @@ export async function proxyHandler(ctx: KoaContext) {
                     // Continue serving - storage failure shouldn't block response
                 }
             } else {
-                ctx.log.debug('not-storing original %s (upload=%s, default=%s, legacy=%s)', origKey, origIsUpload, isDefaultImage, isLegacy)
+                ctx.log.debug('not-storing original %s (upload=%s, default=%s, legacy=%s)', origKey, usesUploadStore, isDefaultImage, isLegacy)
             }
             contentType = await mimeMagic(origData)
         }
@@ -374,7 +393,7 @@ export async function proxyHandler(ctx: KoaContext) {
         APIError.assert(Buffer.isBuffer(origData), APIError.Code.InvalidImage)
 
         // Don't write fallback data to uploadStore — could corrupt original hash
-        if (res.bytes <= MAX_IMAGE_SIZE && !isDefaultImage && !origIsUpload && !isLegacy) {
+        if (res.bytes <= MAX_IMAGE_SIZE && !isDefaultImage && !usesUploadStore && !isLegacy) {
             ctx.log.debug('storing original image %s', origKey)
             try {
                 await storeWrite(origStore, origKey, origData)
@@ -383,7 +402,7 @@ export async function proxyHandler(ctx: KoaContext) {
                 // Continue serving - storage failure shouldn't block response
             }
         } else {
-            ctx.log.debug('not-storing original %s (upload=%s, default=%s, legacy=%s)', origKey, origIsUpload, isDefaultImage, isLegacy)
+            ctx.log.debug('not-storing original %s (upload=%s, default=%s, legacy=%s)', origKey, usesUploadStore, isDefaultImage, isLegacy)
         }
     }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -210,10 +210,15 @@ export async function proxyHandler(ctx: KoaContext) {
     // originals were preserved in the upload store, keyed by the historically
     // rewritten URL (steemitimages.com/0x0/<url>). Unwrap public-proxy prefixes
     // first so every request form of an esteem image resolves to that same key.
-    while (ESTEEM_WRAP_PREFIX.test(urlString) && urlString.includes('://img.esteem.ws/')) {
+    const isEsteemHost = (s: string) =>
+        s.includes('://img.esteem.ws/') || s.includes('://img.esteem.app/')
+    while (ESTEEM_WRAP_PREFIX.test(urlString) && isEsteemHost(urlString)) {
         urlString = urlString.replace(ESTEEM_WRAP_PREFIX, '')
         url = new URL(urlString)
     }
+    // only esteem.ws was historically rewritten before hashing — keep that
+    // rewrite so its keys stay stable; esteem.app keys are the raw URL hash
+    // (rescued .app originals are served via the upload-store archive lookup)
     const isEsteemLegacy = urlString.includes('://img.esteem.ws/')
     if (isEsteemLegacy) {
         urlString = `https://steemitimages.com/0x0/${urlString}`

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -1,5 +1,6 @@
 import 'mocha'
 import assert from 'assert'
+import {createHash} from 'crypto'
 import * as http from 'http'
 import needle from 'needle'
 import * as multihash from 'multihashes'
@@ -9,7 +10,7 @@ import sharp from 'sharp'
 
 import {app} from './../src/app'
 import {proxyStore, uploadStore} from './../src/common'
-import {storeExists, base58Enc} from './../src/utils'
+import {storeExists, storeWrite, base58Enc} from './../src/utils'
 
 import {uploadImage} from './upload'
 
@@ -121,6 +122,49 @@ describe('proxy', function() {
         assert.equal(meta.width, 200)
         // this would be 200 if the first url wasn't stripped
         assert.equal(meta.height, 133)
+    })
+
+    describe('esteem legacy', function() {
+        const esteemUrl = 'https://img.esteem.ws/rescuetest1.jpg'
+        // originals are stored under the historically rewritten URL's key
+        const esteemKey = 'U' + multihash.toB58String(multihash.encode(
+            createHash('sha1').update(`https://steemitimages.com/0x0/${ esteemUrl }`).digest(), 'sha1'
+        ))
+
+        before(async () => {
+            await storeWrite(uploadStore, esteemKey, fs.readFileSync(path.resolve(__dirname, 'test.jpg')))
+        })
+
+        it('should serve esteem-legacy images from the upload store', async function() {
+            this.slow(1000)
+            serveImage = false
+            const res = await needle('get', `http://localhost:${ port }/p/${ base58Enc(esteemUrl) }?width=100&mode=fit`)
+            const meta = await sharp(res.body).metadata()
+            assert.equal(meta.width, 100)
+            assert.equal(meta.format, 'jpeg')
+            // original must not be duplicated into the proxy store
+            assert((await storeExists(proxyStore, esteemKey)) === false, 'proxy store has esteem original')
+        })
+
+        it('should resolve wrapped esteem URLs to the same rescued original', async function() {
+            this.slow(1000)
+            serveImage = false
+            const wrapped = `https://steemitimages.com/500x0/${ esteemUrl }`
+            const res = await needle('get', `http://localhost:${ port }/p/${ base58Enc(wrapped) }?width=120&mode=fit`)
+            const meta = await sharp(res.body).metadata()
+            assert.equal(meta.width, 120)
+            assert.equal(meta.format, 'jpeg')
+        })
+
+        it('should not remove esteem-legacy originals on invalidate', async function() {
+            this.slow(1000)
+            serveImage = false
+            const res = await needle('get',
+                `http://localhost:${ port }/p/${ base58Enc(esteemUrl) }?width=100&mode=fit&invalidate=1`,
+                null, { headers: { 'x-invalidate-key': 'test-invalidate-token' } })
+            assert.equal(res.statusCode, 200)
+            assert((await storeExists(uploadStore, esteemKey)) === true, 'esteem original was removed from upload store')
+        })
     })
 
 })

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -189,6 +189,20 @@ describe('proxy', function() {
             assert((await storeExists(proxyStore, deadKey)) === false, 'archive original copied into proxy store')
         })
 
+        it('should unwrap wrapped esteem.app URLs to their raw-key archived original', async function() {
+            this.slow(1000)
+            const appUrl = 'https://img.esteem.app/apptest1.jpg'
+            const appKey = 'U' + multihash.toB58String(multihash.encode(
+                createHash('sha1').update(appUrl).digest(), 'sha1'
+            ))
+            await storeWrite(uploadStore, appKey, fs.readFileSync(path.resolve(__dirname, 'test.jpg')))
+            const wrapped = `https://images.hive.blog/640x0/${ appUrl }`
+            const res = await needle('get', `http://localhost:${ port }/p/${ base58Enc(wrapped) }?width=110&mode=fit`)
+            const meta = await sharp(res.body).metadata()
+            assert.equal(meta.width, 110)
+            assert.equal(meta.format, 'jpeg')
+        })
+
         it('should never delete invalid archive objects from the upload store', async function() {
             // corrupt archive object: request falls through to fetch/fallbacks
             // (may take a while), but the archived object must survive

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -167,4 +167,41 @@ describe('proxy', function() {
         })
     })
 
+    describe('rescued originals archive', function() {
+        // a source whose origin no longer exists; its original was rescued into
+        // the upload store under the proxy-derived key
+        const deadUrl = `http://localhost:${ port+2 }/gone.jpg`
+        const deadKey = 'U' + multihash.toB58String(multihash.encode(
+            createHash('sha1').update(deadUrl).digest(), 'sha1'
+        ))
+
+        before(async () => {
+            await storeWrite(uploadStore, deadKey, fs.readFileSync(path.resolve(__dirname, 'test.jpg')))
+        })
+
+        it('should serve rescued dead-origin originals from the upload store', async function() {
+            this.slow(1000)
+            const res = await needle('get', `http://localhost:${ port }/p/${ base58Enc(deadUrl) }?width=100&mode=fit`)
+            const meta = await sharp(res.body).metadata()
+            assert.equal(meta.width, 100)
+            assert.equal(meta.format, 'jpeg')
+            // archive reads are read-only: original must not be copied into the proxy store
+            assert((await storeExists(proxyStore, deadKey)) === false, 'archive original copied into proxy store')
+        })
+
+        it('should never delete invalid archive objects from the upload store', async function() {
+            // corrupt archive object: request falls through to fetch/fallbacks
+            // (may take a while), but the archived object must survive
+            this.timeout(30000)
+            this.slow(20000)
+            const corruptUrl = `http://localhost:${ port+2 }/corrupt.jpg`
+            const corruptKey = 'U' + multihash.toB58String(multihash.encode(
+                createHash('sha1').update(corruptUrl).digest(), 'sha1'
+            ))
+            await storeWrite(uploadStore, corruptKey, Buffer.from('definitely not an image'))
+            await needle('get', `http://localhost:${ port }/p/${ base58Enc(corruptUrl) }?width=100&mode=fit`)
+            assert((await storeExists(uploadStore, corruptKey)) === true, 'invalid archive object was deleted from upload store')
+        })
+    })
+
 })

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -203,6 +203,37 @@ describe('proxy', function() {
             assert.equal(meta.format, 'jpeg')
         })
 
+        it('should serve rescued originals even with ignorecache (archive is origin, not cache)', async function() {
+            this.slow(1000)
+            const u = `http://localhost:${ port+2 }/ignorecache-test.jpg`
+            const k = 'U' + multihash.toB58String(multihash.encode(
+                createHash('sha1').update(u).digest(), 'sha1'
+            ))
+            await storeWrite(uploadStore, k, fs.readFileSync(path.resolve(__dirname, 'test.jpg')))
+            const res = await needle('get', `http://localhost:${ port }/p/${ base58Enc(u) }?width=90&mode=fit&ignorecache=1`)
+            const meta = await sharp(res.body).metadata()
+            assert.equal(meta.width, 90)
+            assert((await storeExists(uploadStore, k)) === true, 'archive object must survive ignorecache')
+        })
+
+        it('should keep archive objects that fail sharp metadata extraction', async function() {
+            // valid JPEG magic so mimeMagic passes, but Sharp cannot parse it:
+            // exercises the metadata-failure purge path — must not delete from upload store
+            this.timeout(30000)
+            this.slow(20000)
+            const u = `http://localhost:${ port+2 }/corrupt-meta.jpg`
+            const k = 'U' + multihash.toB58String(multihash.encode(
+                createHash('sha1').update(u).digest(), 'sha1'
+            ))
+            const fakeJpeg = Buffer.concat([
+                Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01]),
+                Buffer.alloc(128, 0x41),
+            ])
+            await storeWrite(uploadStore, k, fakeJpeg)
+            await needle('get', `http://localhost:${ port }/p/${ base58Enc(u) }?width=100&mode=fit`)
+            assert((await storeExists(uploadStore, k)) === true, 'corrupt-metadata archive object was deleted')
+        })
+
         it('should never delete invalid archive objects from the upload store', async function() {
             // corrupt archive object: request falls through to fetch/fallbacks
             // (may take a while), but the archived object must survive


### PR DESCRIPTION
img.esteem.ws is long gone, and the historical fallback rewrite to steemitimages.com no longer resolves these images (verified: the mirrors have purged them). Surviving originals have been preserved in the upload store under the same key the proxy has always derived for these URLs, so the proxy can serve them from there directly.

Changes:
- Esteem-legacy proxy requests read the original from the upload store using the historically derived key. The rewrite is kept so key derivation stays byte-stable with what is already stored.
- `steemitimages.com/<W>x<H>/` and `images.hive.blog/<W>x<H>/` wrappers around esteem URLs (embedded literally in old post bodies) are unwrapped first, so every request form of the same image resolves to one stored original.
- The upload store is strictly read-only on this path: network fetches never overwrite it, and `invalidate` never deletes from it. `ignorecache`/`invalidate` still purge and re-derive resized variants; they no longer bypass the stored original for these URLs (there is no live origin to refetch).
- Tests: upload-store serving, wrapper normalization to the same key, and invalidate protection. `invalidate_token` added to test config to exercise that path.

Behavior for esteem URLs not present in the upload store is unchanged (fallback chain, then default image).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving legacy image proxy URLs to their original images.
  * Restored archived or rescued images can now be served directly when available.
  * Added invalidation support for legacy proxy requests while preserving archived originals.

* **Bug Fixes**
  * Prevented duplicate storage of legacy originals.
  * Corrupt archived images are no longer removed during failed requests.
  * Improved consistency when equivalent legacy URLs reference the same image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->