### PR TITLE
Negative cache for failed fetches + cacheable legacy redirects

### DIFF
--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -156,7 +156,7 @@ async function handleAvatar(ctx: KoaContext) {
   } else {
     ctx.tag({ store: 'fetch' })
     try {
-      const result = await fetchImageWithFallbacks(urlString, urlParams, ctx.get('user-agent') || 'EcencyProxy/1.0 (+https://github.com/ecency)', DefaultAvatar, ctx.log)
+      const result = await fetchImageWithFallbacks(urlString, urlParams, ctx.get('user-agent') || 'EcencyProxy/1.0 (+https://github.com/ecency)', DefaultAvatar, ctx.log, { skipNegativeCache: !!invalidate })
       const res = result.res
       isFetchFallback = result.isFallback
       origData = res.body

--- a/src/common.ts
+++ b/src/common.ts
@@ -94,6 +94,16 @@ export async function redisSet(key: string, value: any, ttl: number): Promise<vo
     } catch { /* best effort */ }
 }
 
+/** Delete a value from Redis shared cache. */
+export async function redisDel(key: string): Promise<void> {
+    if (!redisClient) return
+    if (redisReady) await redisReady
+    if (!redisClient.isReady) return
+    try {
+        await redisClient.del(key)
+    } catch { /* best effort */ }
+}
+
 /** Get account with full authority data (for signature verification) */
 export const getAccount = async (user: string, isCached= true): Promise<HiveAccount[]> => {
     const cacheKey = `profile:account:${user}`

--- a/src/common.ts
+++ b/src/common.ts
@@ -74,7 +74,7 @@ export const rpc = {
 }
 
 /** Try to get a value from Redis shared cache. */
-async function redisGet(key: string): Promise<any | undefined> {
+export async function redisGet(key: string): Promise<any | undefined> {
     if (!redisClient) return undefined
     if (redisReady) await redisReady
     if (!redisClient.isReady) return undefined
@@ -85,7 +85,7 @@ async function redisGet(key: string): Promise<any | undefined> {
 }
 
 /** Set a value in Redis shared cache with TTL in seconds. */
-async function redisSet(key: string, value: any, ttl: number): Promise<void> {
+export async function redisSet(key: string, value: any, ttl: number): Promise<void> {
     if (!redisClient) return
     if (redisReady) await redisReady
     if (!redisClient.isReady) return

--- a/src/cover.ts
+++ b/src/cover.ts
@@ -152,7 +152,7 @@ async function handleCover(ctx: KoaContext) {
   } else {
     ctx.tag({ store: 'fetch' })
     try {
-      const result = await fetchImageWithFallbacks(urlString, urlParams, ctx.get('user-agent') || 'EcencyProxy/1.0 (+https://github.com/ecency)', DefaultCover, ctx.log)
+      const result = await fetchImageWithFallbacks(urlString, urlParams, ctx.get('user-agent') || 'EcencyProxy/1.0 (+https://github.com/ecency)', DefaultCover, ctx.log, { skipNegativeCache: !!invalidate })
       const res = result.res
       isFetchFallback = result.isFallback
       origData = res.body

--- a/src/fetch-image.ts
+++ b/src/fetch-image.ts
@@ -1,5 +1,5 @@
 import { URL } from 'url'
-import { redisGet, redisSet } from './common'
+import { redisDel, redisGet, redisSet } from './common'
 import { captureImageFailure } from './sentry'
 import { assertPublicUrl, fetchUrl, getUrlHashKey, NeedleResponse } from './utils'
 
@@ -68,6 +68,11 @@ export async function markDeadUrl(urlString: string, ttlSeconds: number = NEGATI
     await redisSet(negativeCacheKey(urlString), 1, Math.max(1, Math.round(ttlSeconds)))
 }
 
+export async function clearDeadUrl(urlString: string): Promise<void> {
+    localNegativeCache.delete(urlString)
+    await redisDel(negativeCacheKey(urlString))
+}
+
 export function clearNegativeFetchCache(): void {
     localNegativeCache.clear()
 }
@@ -117,6 +122,9 @@ export async function fetchImageWithFallbacks(
                     Buffer.isBuffer(res.body)
                 ) {
                     ctxLog.info({ candidate }, 'Fetch succeeded')
+                    // A bypassed re-fetch (e.g. invalidate) may have proven a
+                    // negatively cached URL alive again — drop the stale entry
+                    await clearDeadUrl(urlString)
                     return { res, isFallback: false }
                 }
 

--- a/src/fetch-image.ts
+++ b/src/fetch-image.ts
@@ -1,6 +1,7 @@
 import { URL } from 'url'
-import { assertPublicUrl, fetchUrl, NeedleResponse } from './utils'
+import { redisGet, redisSet } from './common'
 import { captureImageFailure } from './sentry'
+import { assertPublicUrl, fetchUrl, getUrlHashKey, NeedleResponse } from './utils'
 
 const buildFallbackUrls = (urlString: string, urlParams: string): string[] => {
     const hasQuery = urlString.indexOf('?') !== -1
@@ -37,13 +38,47 @@ const buildFallbackUrls = (urlString: string, urlParams: string): string[] => {
     return urls
 }
 
+// Negative cache for exhausted fetches. Walking the whole mirror chain costs
+// up to ~8 outbound requests with multi-second timeouts each, and the caller
+// holds its upstream connection open for the duration — so dead URLs are
+// remembered briefly and skipped straight to the default image. The local map
+// bounds the blast radius when Redis is unavailable; Redis shares entries
+// across cluster workers and survives worker restarts.
+const NEGATIVE_TTL_SECONDS = 600
+const NEGATIVE_LOCAL_MAX = 10000
+const localNegativeCache = new Map<string, number>() // urlString -> expiry epoch ms
+
+const negativeCacheKey = (urlString: string) => 'negfetch:' + getUrlHashKey(urlString)
+
+export async function isKnownDeadUrl(urlString: string): Promise<boolean> {
+    const expiry = localNegativeCache.get(urlString)
+    if (expiry !== undefined) {
+        if (expiry > Date.now()) { return true }
+        localNegativeCache.delete(urlString)
+    }
+    return await redisGet(negativeCacheKey(urlString)) !== undefined
+}
+
+export async function markDeadUrl(urlString: string, ttlSeconds: number = NEGATIVE_TTL_SECONDS): Promise<void> {
+    // Map iterates in insertion order, so evicting the first key drops the oldest entry
+    while (localNegativeCache.size >= NEGATIVE_LOCAL_MAX) {
+        localNegativeCache.delete(localNegativeCache.keys().next().value as string)
+    }
+    localNegativeCache.set(urlString, Date.now() + ttlSeconds * 1000)
+    await redisSet(negativeCacheKey(urlString), 1, Math.max(1, Math.round(ttlSeconds)))
+}
+
+export function clearNegativeFetchCache(): void {
+    localNegativeCache.clear()
+}
+
 export async function fetchImageWithFallbacks(
     urlString: string,
     urlParams: string,
     userAgent: string,
     defaultUrl: string,
     ctxLog: any,
-    options: { timeout?: number; skipUrls?: string[] } = {}
+    options: { timeout?: number; skipUrls?: string[]; skipNegativeCache?: boolean } = {}
 ): Promise<{ res: NeedleResponse; isFallback: boolean }> {
     const timeout = options.timeout !== undefined && options.timeout !== null ? options.timeout : 10000
     const skipUrls = (options.skipUrls !== undefined && options.skipUrls !== null) ? options.skipUrls : []
@@ -52,40 +87,45 @@ export async function fetchImageWithFallbacks(
         return !skipUrls.includes(url.trim())
     })
 
-    for (const candidate of urls) {
-        if (process.env.NODE_ENV !== 'test') {
+    if (!options.skipNegativeCache && await isKnownDeadUrl(urlString)) {
+        ctxLog.info({ urlString }, 'Skipping mirror chain for recently failed URL')
+    } else {
+        for (const candidate of urls) {
+            if (process.env.NODE_ENV !== 'test') {
+                try {
+                    assertPublicUrl(new URL(candidate))
+                } catch (e) {
+                    ctxLog.warn({ candidate }, 'Skipping private URL in fallback chain')
+                    continue
+                }
+            }
             try {
-                assertPublicUrl(new URL(candidate))
+                ctxLog.info({ candidate }, 'Trying fallback fetch')
+                const res = await fetchUrl(candidate, {
+                    parse_response: false,
+                    follow_max: 5,
+                    open_timeout: timeout,
+                    response_timeout: timeout,
+                    read_timeout: timeout,
+                    user_agent: userAgent,
+                } as any)
+
+                if (
+                    res &&
+                    res.statusCode &&
+                    Math.floor(res.statusCode / 100) === 2 &&
+                    Buffer.isBuffer(res.body)
+                ) {
+                    ctxLog.info({ candidate }, 'Fetch succeeded')
+                    return { res, isFallback: false }
+                }
+
+                ctxLog.warn({ candidate, code: res && res.statusCode }, 'Fetch failed status')
             } catch (e) {
-                ctxLog.warn({ candidate }, 'Skipping private URL in fallback chain')
-                continue
+                ctxLog.error(e, `Fetch error at ${candidate}`)
             }
         }
-        try {
-            ctxLog.info({ candidate }, 'Trying fallback fetch')
-            const res = await fetchUrl(candidate, {
-                parse_response: false,
-                follow_max: 5,
-                open_timeout: timeout,
-                response_timeout: timeout,
-                read_timeout: timeout,
-                user_agent: userAgent,
-            } as any)
-
-            if (
-                res &&
-                res.statusCode &&
-                Math.floor(res.statusCode / 100) === 2 &&
-                Buffer.isBuffer(res.body)
-            ) {
-                ctxLog.info({ candidate }, 'Fetch succeeded')
-                return { res, isFallback: false }
-            }
-
-            ctxLog.warn({ candidate, code: res && res.statusCode }, 'Fetch failed status')
-        } catch (e) {
-            ctxLog.error(e, `Fetch error at ${candidate}`)
-        }
+        await markDeadUrl(urlString)
     }
 
     // Final fallback: default image (avatar or cover)

--- a/src/legacy-proxy.ts
+++ b/src/legacy-proxy.ts
@@ -68,6 +68,9 @@ export async function legacyProxyHandler(ctx: KoaContext) {
     const qs = querystring.stringify(options)
     const b58url = base58Enc(url.toString())
 
+    // The redirect mapping is deterministic, so let CDNs cache it instead of
+    // re-fetching it from the origin for every viewer
+    ctx.set('Cache-Control', 'public,max-age=86400')
     ctx.status = 301
     ctx.redirect(`/p/${ b58url }?${ qs }`)
 }
@@ -100,6 +103,7 @@ export async function legacyWProxyHandler(ctx: KoaContext) {
 
     // Redirect to non-webp legacy endpoint, let Accept header determine format
     const redirectPath = `/${width}x${height}/${uu}`
+    ctx.set('Cache-Control', 'public,max-age=86400')
     ctx.status = 301
     ctx.redirect(redirectPath)
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -345,7 +345,8 @@ export async function proxyHandler(ctx: KoaContext) {
                 urlParams,
                 'EcencyProxy/1.0 (+https://github.com/ecency)',
                 DefaultAvatar,
-                ctx.log
+                ctx.log,
+                { skipNegativeCache: !!options.invalidate }
             )
             res = result.res
             if (result.isFallback) { isDefaultImage = true }
@@ -374,7 +375,8 @@ export async function proxyHandler(ctx: KoaContext) {
                 urlParams,
                 'EcencyProxy/1.0 (+https://github.com/ecency)',
                 DefaultAvatar,
-                ctx.log
+                ctx.log,
+                { skipNegativeCache: !!options.invalidate }
             )
             res = result.res
             isDefaultImage = result.isFallback

--- a/test/legacy-proxy.ts
+++ b/test/legacy-proxy.ts
@@ -35,6 +35,7 @@ describe('legacy-proxy', function() {
             `http://localhost:${port}/500x300/http://localhost:${imagePort}/test.jpg`,
             { follow_max: 0 })
         assert.equal(res.statusCode, 301)
+        assert.equal(res.headers['cache-control'], 'public,max-age=86400', 'redirect should be cacheable')
         const location = res.headers['location']
         assert(location.startsWith('/p/'), 'should redirect to /p/ endpoint')
         assert(location.includes('width=500'), 'should include width')
@@ -89,6 +90,7 @@ describe('legacy-proxy', function() {
             `http://localhost:${port}/webp/100x100/http://localhost:${imagePort}/test.jpg`,
             { follow_max: 0 })
         assert.equal(res.statusCode, 301)
+        assert.equal(res.headers['cache-control'], 'public,max-age=86400', 'redirect should be cacheable')
         const location = res.headers['location']
         // Should redirect to non-webp legacy URL
         assert(location.includes('/100x100/'), 'should redirect to legacy URL')

--- a/test/negative-cache.ts
+++ b/test/negative-cache.ts
@@ -14,10 +14,12 @@ describe('negative fetch cache', function() {
 
     let port: number
     let originHits = 0
+    let flakyAlive = false
     // /default* serves a real image (stands in for the configured default);
-    // every other path counts the hit and fails, standing in for a dead origin
+    // /flaky* serves one only while flakyAlive is set; every other path counts
+    // the hit and fails, standing in for a dead origin
     const server = http.createServer((req, res) => {
-        if (req.url && req.url.startsWith('/default')) {
+        if (req.url && (req.url.startsWith('/default') || (req.url.startsWith('/flaky') && flakyAlive))) {
             fs.createReadStream(path.resolve(__dirname, 'test.jpg')).pipe(res)
         } else {
             originHits++
@@ -84,6 +86,19 @@ describe('negative fetch cache', function() {
         const result = await fetchDead(liveUrl)
         assert.equal(result.isFallback, false, 'should serve the fetched image')
         assert.equal(await isKnownDeadUrl(liveUrl), false, 'should not be negatively cached')
+    })
+
+    it('clears the negative entry when a bypassed re-fetch succeeds', async function() {
+        const flakyUrl = `http://localhost:${ port }/flaky-1.jpg`
+        flakyAlive = false
+        await fetchDead(flakyUrl)
+        assert.equal(await isKnownDeadUrl(flakyUrl), true, 'should be negatively cached while dead')
+        flakyAlive = true
+        const revived = await fetchDead(flakyUrl, {skipNegativeCache: true})
+        assert.equal(revived.isFallback, false, 'bypassed re-fetch should serve the real image')
+        assert.equal(await isKnownDeadUrl(flakyUrl), false, 'successful fetch should clear the entry')
+        const followUp = await fetchDead(flakyUrl)
+        assert.equal(followUp.isFallback, false, 'normal requests should fetch the revived URL again')
     })
 
     it('expires local entries after their TTL', async function() {

--- a/test/negative-cache.ts
+++ b/test/negative-cache.ts
@@ -1,0 +1,96 @@
+import 'mocha'
+import assert from 'assert'
+import * as fs from 'fs'
+import * as http from 'http'
+import * as path from 'path'
+
+import {clearNegativeFetchCache, fetchImageWithFallbacks, isKnownDeadUrl, markDeadUrl} from './../src/fetch-image'
+import {base58Enc} from './../src/utils'
+
+describe('negative fetch cache', function() {
+    this.timeout(20000)
+
+    const log: any = {debug() {}, info() {}, warn() {}, error() {}}
+
+    let port: number
+    let originHits = 0
+    // /default* serves a real image (stands in for the configured default);
+    // every other path counts the hit and fails, standing in for a dead origin
+    const server = http.createServer((req, res) => {
+        if (req.url && req.url.startsWith('/default')) {
+            fs.createReadStream(path.resolve(__dirname, 'test.jpg')).pipe(res)
+        } else {
+            originHits++
+            res.writeHead(500)
+            res.end()
+        }
+    })
+
+    before((done) => {
+        server.listen(0, 'localhost', () => {
+            port = (server.address() as any).port
+            done()
+        })
+    })
+    after((done) => { server.close(done) })
+    beforeEach(() => { clearNegativeFetchCache() })
+
+    // Exclude the public mirrors so tests never leave localhost
+    const externalMirrors = (urlString: string, urlParams: string) => [
+        `https://images.hive.blog/p/${ urlParams }`,
+        `https://steemitimages.com/p/${ urlParams }`,
+        `https://images.hive.blog/0x0/${ urlString }`,
+        `https://steemitimages.com/0x0/${ urlString }`,
+        `https://img.leopedia.io/0x0/${ urlString }`,
+        `https://wsrv.nl/?url=${ encodeURIComponent(urlString) }`,
+    ]
+
+    const fetchDead = (urlString: string, opts: any = {}) => {
+        const urlParams = base58Enc(urlString)
+        return fetchImageWithFallbacks(urlString, urlParams, 'test-agent', `http://localhost:${ port }/default.jpg`, log, {
+            timeout: 1000,
+            skipUrls: externalMirrors(urlString, urlParams),
+            ...opts,
+        })
+    }
+
+    it('marks a URL dead after the mirror chain is exhausted', async function() {
+        const deadUrl = `http://localhost:${ port }/dead-1.jpg`
+        const result = await fetchDead(deadUrl)
+        assert.equal(result.isFallback, true, 'should serve the default image')
+        assert(originHits >= 1, 'should have tried the origin')
+        assert.equal(await isKnownDeadUrl(deadUrl), true, 'should be negatively cached')
+    })
+
+    it('skips the mirror chain for a known-dead URL', async function() {
+        const deadUrl = `http://localhost:${ port }/dead-2.jpg`
+        await fetchDead(deadUrl)
+        const hitsAfterFirst = originHits
+        const result = await fetchDead(deadUrl)
+        assert.equal(result.isFallback, true, 'should still serve the default image')
+        assert.equal(originHits, hitsAfterFirst, 'should not contact the origin again')
+    })
+
+    it('walks the chain again when skipNegativeCache is set', async function() {
+        const deadUrl = `http://localhost:${ port }/dead-3.jpg`
+        await fetchDead(deadUrl)
+        const hitsAfterFirst = originHits
+        await fetchDead(deadUrl, {skipNegativeCache: true})
+        assert(originHits > hitsAfterFirst, 'should contact the origin again')
+    })
+
+    it('does not affect URLs that fetch successfully', async function() {
+        const liveUrl = `http://localhost:${ port }/default-live.jpg`
+        const result = await fetchDead(liveUrl)
+        assert.equal(result.isFallback, false, 'should serve the fetched image')
+        assert.equal(await isKnownDeadUrl(liveUrl), false, 'should not be negatively cached')
+    })
+
+    it('expires local entries after their TTL', async function() {
+        const deadUrl = `http://localhost:${ port }/dead-4.jpg`
+        await markDeadUrl(deadUrl, 0.05)
+        assert.equal(await isKnownDeadUrl(deadUrl), true)
+        await new Promise((resolve) => setTimeout(resolve, 120))
+        assert.equal(await isKnownDeadUrl(deadUrl), false)
+    })
+})


### PR DESCRIPTION
## What

**Negative cache for exhausted image fetches.** When an origin image can't be fetched, the proxy walks the full mirror fallback chain (up to ~8 outbound requests, each with a multi-second timeout) — and does it again on every subsequent request, indefinitely, for URLs that will never come back. Each walk also holds the upstream connection open for its duration.

This adds a short-lived negative cache: when the whole chain is exhausted, the URL is remembered for 10 minutes and requests within that window skip straight to the default image. Entries live in Redis (shared across cluster workers, TTL-pruned automatically) with a bounded in-process map as fallback when Redis is unavailable. Authenticated `?invalidate=` requests bypass the cached entry; a fresh failure still refreshes it.

**CDN-cacheable legacy redirects.** The `/{W}x{H}/{url}` → `/p/{base58}` 301 mapping is deterministic but was sent without `Cache-Control`, so CDNs re-fetched the redirect from the origin for every viewer. Both legacy handlers now send `public,max-age=86400`.

## Tests

- New `test/negative-cache.ts` suite (hermetic — external mirrors excluded via `skipUrls`, default image served locally): marks-on-exhaustion, chain skip on repeat, `skipNegativeCache` bypass, no effect on successful fetches, local TTL expiry.
- `test/legacy-proxy.ts` asserts the new header on both redirect routes.
- Full suite: 200 passing, same 4 pre-existing env failures as `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved image fallback handling by temporarily avoiding repeatedly unavailable image sources.
  * Cache invalidation requests now retry image sources instead of relying on previous failure results.
  * Legacy proxy redirects can now be cached by CDNs for improved performance.

* **Bug Fixes**
  * Improved reliability when retrieving avatars, covers, and proxied images after source failures.

* **Tests**
  * Added coverage for fallback behavior, retry handling, cache expiration, and redirect caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->