### PR TITLE
Limit concurrent Sharp encodes per worker

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -12,6 +12,11 @@ name = 'imagehoster'
 # number of worker processes to spawn, 0 = autodetect
 num_workers = 0
 
+# Max Sharp encodes running at once PER WORKER (service-wide = this x num_workers).
+# Sharp shares the libuv threadpool with fs reads, so unbounded encodes starve
+# cached-variant reads and oversubscribe the CPU. 0/unset = auto (cpus/workers).
+max_concurrent_encodes = 0
+
 # url to hive node used for verifying signatures
 rpc_node = 'https://api.hive.blog'
 

--- a/config/test.toml
+++ b/config/test.toml
@@ -1,3 +1,6 @@
+# Fixed encode-concurrency limit so tests exercise a real ceiling (>1)
+max_concurrent_encodes = 3
+
 log_level = 'fatal'
 
 # Match the test server URL so double-proxy detection works

--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -5,6 +5,7 @@ import config from 'config'
 import etag from 'etag'
 import {URL} from 'url'
 import {fetchImageWithFallbacks} from './fetch-image'
+import {clientGoneSignal} from './encode-limit'
 import {resizeImageWithOptions} from './image-resizer'
 
 import { getProfile, KoaContext, proxyStore, uploadStore } from './common'
@@ -193,7 +194,8 @@ async function handleAvatar(ctx: KoaContext) {
       urlParams,
       ctx.get('user-agent') || '',
       DefaultAvatar,
-      ctx.log
+      ctx.log,
+      clientGoneSignal(ctx)
   )
   contentType = finalType
   isResizeFallback = isFallback

--- a/src/cover.ts
+++ b/src/cover.ts
@@ -8,6 +8,7 @@ import {URL} from 'url'
 import { getProfile, KoaContext, proxyStore, uploadStore } from './common'
 import { APIError } from './error'
 import {fetchImageWithFallbacks} from './fetch-image'
+import {clientGoneSignal} from './encode-limit'
 import {resizeImageWithOptions} from './image-resizer'
 import {
   getDefaultUrlAndParams,
@@ -186,7 +187,8 @@ async function handleCover(ctx: KoaContext) {
       urlParams,
       ctx.get('user-agent') || '',
       DefaultCover,
-      ctx.log
+      ctx.log,
+      clientGoneSignal(ctx)
   )
   contentType = finalType
   isResizeFallback = isFallback

--- a/src/encode-limit.ts
+++ b/src/encode-limit.ts
@@ -39,43 +39,101 @@ function resolveLimit(): number {
 
 const LIMIT = resolveLimit()
 
+export const ENCODE_ABORTED = 'EncodeAborted'
+
+/** True when an encode was dropped because its client went away, not because Sharp failed. */
+export function isEncodeAborted(err: any): boolean {
+    return !!err && err.name === ENCODE_ABORTED
+}
+
+function abortedError(): Error {
+    const err = new Error('encode abandoned: client disconnected while queued')
+    err.name = ENCODE_ABORTED
+    return err
+}
+
+interface Waiter {
+    settled: boolean
+    grant: () => void
+}
+
 let active = 0
-const waiting: Array<() => void> = []
+const waiting: Waiter[] = []
+
+function acquire(signal?: AbortSignal): Promise<void> {
+    if (signal && signal.aborted) { return Promise.reject(abortedError()) }
+    if (active < LIMIT) {
+        active++
+        return Promise.resolve()
+    }
+    return new Promise<void>((resolve, reject) => {
+        const waiter: Waiter = {settled: false, grant: () => undefined}
+        const onAbort = () => {
+            if (waiter.settled) { return }
+            waiter.settled = true
+            const idx = waiting.indexOf(waiter)
+            if (idx >= 0) { waiting.splice(idx, 1) }
+            reject(abortedError())
+        }
+        waiter.grant = () => {
+            if (waiter.settled) { return }
+            waiter.settled = true
+            if (signal) { signal.removeEventListener('abort', onAbort) }
+            resolve()
+        }
+        waiting.push(waiter)
+        if (signal) { signal.addEventListener('abort', onAbort, {once: true}) }
+    })
+}
+
+function release(): void {
+    // Hand the slot straight to a waiter without dropping `active`. If we
+    // decremented and let the waiter re-increment, a caller arriving in the gap
+    // (the waiter resumes on a microtask) would see a free slot and take it too,
+    // putting us over the limit. Skip waiters that already aborted.
+    while (waiting.length > 0) {
+        const next = waiting.shift() as Waiter
+        if (!next.settled) {
+            next.grant()
+            return
+        }
+    }
+    active--
+}
 
 /**
  * Runs `fn` once a slot is free. Keep the wrapped region as small as possible —
  * ideally the single encode call — so a slot is never held across other awaits,
  * and so a gated call can never nest inside another (which would deadlock at
  * low limits).
+ *
+ * Pass `signal` so a request whose client has already gone away drops out of the
+ * queue instead of claiming a slot to build a response nobody will read. That
+ * matters under load: the cache in front of us gives up long before a deep queue
+ * drains, so without it the queue fills with work for dead sockets while live
+ * requests wait behind it.
  */
-function acquire(): Promise<void> {
-    if (active < LIMIT) {
-        active++
-        return Promise.resolve()
-    }
-    return new Promise<void>((resolve) => { waiting.push(resolve) })
-}
-
-function release(): void {
-    const next = waiting.shift()
-    if (next) {
-        // Hand the slot straight to the waiter without dropping `active`. If we
-        // decremented and let the waiter re-increment, a caller arriving in the
-        // gap (the waiter resumes on a microtask) would see a free slot and take
-        // it too, putting us over the limit.
-        next()
-    } else {
-        active--
-    }
-}
-
-export async function withEncodeSlot<T>(fn: () => Promise<T>): Promise<T> {
-    await acquire()
+export async function withEncodeSlot<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    await acquire(signal)
     try {
         return await fn()
     } finally {
         release()
     }
+}
+
+/**
+ * AbortSignal that fires if the connection closes before the response was fully
+ * written — i.e. the client, or the cache in front of us, gave up waiting.
+ */
+export function clientGoneSignal(ctx: any): AbortSignal | undefined {
+    const res = ctx && ctx.res
+    if (!res || typeof res.once !== 'function') { return undefined }
+    const controller = new AbortController()
+    res.once('close', () => {
+        if (!res.writableEnded) { controller.abort() }
+    })
+    return controller.signal
 }
 
 /** Exposed for tests and diagnostics. */

--- a/src/encode-limit.ts
+++ b/src/encode-limit.ts
@@ -1,0 +1,84 @@
+import config from 'config'
+import os from 'os'
+
+/**
+ * Bounds how many Sharp encodes run concurrently in this worker.
+ *
+ * Sharp's async work runs on the libuv threadpool — the SAME pool Node uses for
+ * `fs` reads. That pool defaults to 4 slots per process. An AVIF encode occupies
+ * a slot for seconds, so with encodes unbounded two things go wrong:
+ *
+ *   1. Cheap work starves. Serving an already-converted variant is just a file
+ *      read, but it queues behind multi-second encodes. Measured on a loaded
+ *      box: a 32KB cached variant took 0.46-8.08s to serve while the pure-JS
+ *      healthcheck answered in 2ms — the event loop was fine, the pool was full.
+ *   2. The CPU oversubscribes. More simultaneous encodes than cores does not
+ *      increase throughput, it just makes every encode slower.
+ *
+ * Capping concurrency keeps slots free for the cheap reads that make up most
+ * requests, and lets each encode finish sooner.
+ *
+ * NOTE: this limit is per worker process. Service-wide concurrency is
+ * `max_concurrent_encodes * num_workers`.
+ */
+
+const CONFIG_KEY = 'max_concurrent_encodes'
+
+function resolveLimit(): number {
+    if (config.has(CONFIG_KEY)) {
+        const configured = Number.parseInt(config.get(CONFIG_KEY) as string, 10)
+        if (Number.isFinite(configured) && configured > 0) { return configured }
+    }
+    // Default: divide the machine across the workers that will compete for it,
+    // so the service-wide total lands near the core count rather than a multiple
+    // of it. Workers are what app.ts will actually fork (0 = autodetect).
+    let numWorkers = Number.parseInt(config.get('num_workers') as string, 10)
+    if (!Number.isFinite(numWorkers) || numWorkers <= 0) { numWorkers = os.cpus().length }
+    return Math.max(1, Math.floor(os.cpus().length / numWorkers))
+}
+
+const LIMIT = resolveLimit()
+
+let active = 0
+const waiting: Array<() => void> = []
+
+/**
+ * Runs `fn` once a slot is free. Keep the wrapped region as small as possible —
+ * ideally the single encode call — so a slot is never held across other awaits,
+ * and so a gated call can never nest inside another (which would deadlock at
+ * low limits).
+ */
+function acquire(): Promise<void> {
+    if (active < LIMIT) {
+        active++
+        return Promise.resolve()
+    }
+    return new Promise<void>((resolve) => { waiting.push(resolve) })
+}
+
+function release(): void {
+    const next = waiting.shift()
+    if (next) {
+        // Hand the slot straight to the waiter without dropping `active`. If we
+        // decremented and let the waiter re-increment, a caller arriving in the
+        // gap (the waiter resumes on a microtask) would see a free slot and take
+        // it too, putting us over the limit.
+        next()
+    } else {
+        active--
+    }
+}
+
+export async function withEncodeSlot<T>(fn: () => Promise<T>): Promise<T> {
+    await acquire()
+    try {
+        return await fn()
+    } finally {
+        release()
+    }
+}
+
+/** Exposed for tests and diagnostics. */
+export function encodeLimitStats() {
+    return { limit: LIMIT, active, queued: waiting.length }
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,6 +1,7 @@
 /** API Errors. */
 
 import {KoaContext} from './common'
+import {isEncodeAborted} from './encode-limit'
 import {camelToSnake} from './utils'
 
 enum ErrorCode {
@@ -111,6 +112,18 @@ export async function errorMiddleware(ctx: KoaContext, next: () => Promise<any>)
     try {
         await next()
     } catch (err) {
+        if (isEncodeAborted(err)) {
+            // The client, or the cache in front of us, gave up before we could
+            // build a response. Nothing failed and there is no open socket left
+            // to write to, so treat this as a cancellation rather than a server
+            // error. Wrapping it as an APIError would default to InternalError,
+            // returning 500 and logging 'unexpected API error' — turning routine
+            // upstream timeouts into false server failures in logs and metrics.
+            ctx.status = 499 // nginx's "client closed request"
+            ctx.body = null
+            if (ctx.log) { ctx.log.debug({url: ctx.url}, 'request cancelled while queued for an encode') }
+            return
+        }
         const error = err instanceof APIError ? err : new APIError({cause: err})
         ctx.status = error.statusCode
         ctx.set('Cache-Control', 'no-cache')

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -1,6 +1,7 @@
 import etag from 'etag'
 import Sharp from 'sharp'
 import {KoaContext} from './common'
+import {withEncodeSlot} from './encode-limit'
 import {getImageKey, OutputFormat, ProxyOptions, ScalingMode} from './utils'
 
 export async function serveOrBuildFallbackImage(
@@ -57,7 +58,7 @@ export async function serveOrBuildFallbackImage(
             contentType = 'image/jpeg'
     }
 
-    const rv = await image.toBuffer()
+    const rv = await withEncodeSlot(() => image.toBuffer())
 
     ctx.set('Content-Type', contentType)
     ctx.set('Vary', 'Accept')

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -1,7 +1,7 @@
 import etag from 'etag'
 import Sharp from 'sharp'
 import {KoaContext} from './common'
-import {withEncodeSlot} from './encode-limit'
+import {clientGoneSignal, withEncodeSlot} from './encode-limit'
 import {getImageKey, OutputFormat, ProxyOptions, ScalingMode} from './utils'
 
 export async function serveOrBuildFallbackImage(
@@ -58,7 +58,7 @@ export async function serveOrBuildFallbackImage(
             contentType = 'image/jpeg'
     }
 
-    const rv = await withEncodeSlot(() => image.toBuffer())
+    const rv = await withEncodeSlot(() => image.toBuffer(), clientGoneSignal(ctx))
 
     ctx.set('Content-Type', contentType)
     ctx.set('Vary', 'Accept')

--- a/src/image-resizer.ts
+++ b/src/image-resizer.ts
@@ -15,7 +15,8 @@ export async function resizeImageWithOptions(
     urlParams: string,
     userAgent: string,
     fallbackUrl: string,
-    logger: any
+    logger: any,
+    signal?: AbortSignal
 ): Promise<{ buffer: Buffer; contentType: string; isFallback: boolean }> {
     let isAnimated = contentType === 'image/gif' || contentType === 'image/apng'
 
@@ -107,6 +108,6 @@ export async function resizeImageWithOptions(
             break
     }
 
-    const buffer = await withEncodeSlot(() => image.toBuffer())
+    const buffer = await withEncodeSlot(() => image.toBuffer(), signal)
     return { buffer, contentType, isFallback }
 }

--- a/src/image-resizer.ts
+++ b/src/image-resizer.ts
@@ -16,7 +16,11 @@ export async function resizeImageWithOptions(
     userAgent: string,
     fallbackUrl: string,
     logger: any,
-    signal?: AbortSignal
+    // Required, not optional: a request-backed resize must say whether its client
+    // is still there. Leaving it optional let a caller silently omit it and
+    // reintroduce unremovable queue waiters. Pass `undefined` deliberately for
+    // non-request callers.
+    signal: AbortSignal | undefined
 ): Promise<{ buffer: Buffer; contentType: string; isFallback: boolean }> {
     let isAnimated = contentType === 'image/gif' || contentType === 'image/apng'
 

--- a/src/image-resizer.ts
+++ b/src/image-resizer.ts
@@ -1,5 +1,6 @@
 // utils/image-resizer.ts
 import Sharp from 'sharp'
+import { withEncodeSlot } from './encode-limit'
 import { APIError } from './error'
 import {
     buildSharpPipeline, getProxyImageLimits, mimeMagic,
@@ -106,6 +107,6 @@ export async function resizeImageWithOptions(
             break
     }
 
-    const buffer = await image.toBuffer()
+    const buffer = await withEncodeSlot(() => image.toBuffer())
     return { buffer, contentType, isFallback }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -13,6 +13,7 @@ import {KoaContext, proxyStore, uploadStore} from './common'
 import {applyUrlReplacements, isEmptyImageUrl, EMPTY_IMAGE_URL_PATTERNS} from './constants'
 import {APIError} from './error'
 import {serveOrBuildFallbackImage} from './fallback'
+import {withEncodeSlot} from './encode-limit'
 import {fetchImageWithFallbacks} from './fetch-image'
 import {captureImageFailure} from './sentry'
 import {
@@ -569,7 +570,7 @@ export async function proxyHandler(ctx: KoaContext) {
         }
 
         try {
-            rv = await image.toBuffer()
+            rv = await withEncodeSlot(() => image.toBuffer())
         } catch (err) {
             ctx.log.error({ err, urlString, imageKey, msg: 'sharp.toBuffer() failed' })
             captureImageFailure('sharp_tobuffer_failed', ctx, { urlString, imageKey, origIsUpload, origFromCache, error: String(err) })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -13,7 +13,7 @@ import {KoaContext, proxyStore, uploadStore} from './common'
 import {applyUrlReplacements, isEmptyImageUrl, EMPTY_IMAGE_URL_PATTERNS} from './constants'
 import {APIError} from './error'
 import {serveOrBuildFallbackImage} from './fallback'
-import {withEncodeSlot} from './encode-limit'
+import {clientGoneSignal, isEncodeAborted, withEncodeSlot} from './encode-limit'
 import {fetchImageWithFallbacks} from './fetch-image'
 import {captureImageFailure} from './sentry'
 import {
@@ -570,8 +570,15 @@ export async function proxyHandler(ctx: KoaContext) {
         }
 
         try {
-            rv = await withEncodeSlot(() => image.toBuffer())
+            rv = await withEncodeSlot(() => image.toBuffer(), clientGoneSignal(ctx))
         } catch (err) {
+            if (isEncodeAborted(err)) {
+                // The client gave up while we were queued. Nothing failed, and
+                // there is no socket left to serve the fallback bytes to, so do
+                // not walk the recovery path or report it as a Sharp failure.
+                ctx.log.debug({ urlString, imageKey, msg: 'encode abandoned, client gone' })
+                throw err
+            }
             ctx.log.error({ err, urlString, imageKey, msg: 'sharp.toBuffer() failed' })
             captureImageFailure('sharp_tobuffer_failed', ctx, { urlString, imageKey, origIsUpload, origFromCache, error: String(err) })
             if (origIsUpload) {

--- a/test/encode-limit.ts
+++ b/test/encode-limit.ts
@@ -2,6 +2,7 @@ import 'mocha'
 import assert from 'assert'
 
 import {clientGoneSignal, encodeLimitStats, isEncodeAborted, withEncodeSlot} from './../src/encode-limit'
+import {errorMiddleware} from './../src/error'
 
 describe('encode concurrency limit', function() {
 
@@ -112,6 +113,41 @@ describe('encode concurrency limit', function() {
 
         handlers.close()
         assert.equal(signal.aborted, true, 'closing before the body is written means the client left')
+    })
+
+    it('is treated as a cancellation by the error middleware, not a server error', async function() {
+        // An abort escaping any encode path reaches the shared error middleware.
+        // Wrapped as an APIError it would default to InternalError: a 500 plus an
+        // 'unexpected API error' log. Since upstream abandons slow requests
+        // routinely, that would manufacture false server failures.
+        const makeCtx = () => {
+            const emitted: any[][] = []
+            return {
+                app: {emit: (...args: any[]) => { emitted.push(args) }},
+                body: undefined as any,
+                emitted,
+                log: {debug: () => undefined},
+                set: () => undefined,
+                status: 0,
+                url: '/p/test',
+            }
+        }
+
+        const controller = new AbortController()
+        controller.abort()
+        const abortErr = await withEncodeSlot(async () => undefined, controller.signal).catch((e) => e)
+        assert(isEncodeAborted(abortErr), 'precondition: got a tagged abort error')
+
+        const ctx = makeCtx()
+        await errorMiddleware(ctx as any, async () => { throw abortErr })
+        assert.equal(ctx.status, 499, 'client-gone should not surface as 5xx')
+        assert.equal(ctx.emitted.length, 0, 'must not raise an app error event')
+
+        // Control: a genuine failure must still take the normal error path.
+        const failCtx = makeCtx()
+        await errorMiddleware(failCtx as any, async () => { throw new Error('real failure') })
+        assert.equal(failCtx.status, 500, 'genuine errors still report 500')
+        assert.equal(failCtx.emitted.length, 1, 'genuine errors still emit')
     })
 
     it('holds the ceiling when a caller arrives mid hand-off', async function() {

--- a/test/encode-limit.ts
+++ b/test/encode-limit.ts
@@ -1,7 +1,7 @@
 import 'mocha'
 import assert from 'assert'
 
-import {encodeLimitStats, withEncodeSlot} from './../src/encode-limit'
+import {clientGoneSignal, encodeLimitStats, isEncodeAborted, withEncodeSlot} from './../src/encode-limit'
 
 describe('encode concurrency limit', function() {
 
@@ -51,6 +51,67 @@ describe('encode concurrency limit', function() {
         const rv = await withEncodeSlot(async () => 'ok')
         assert.equal(rv, 'ok')
         assert.equal(encodeLimitStats().active, 0)
+    })
+
+    it('drops a queued waiter whose client went away, without spending a slot', async function() {
+        // Fill every slot, then queue two: one whose client disconnects, one that
+        // stays. The abandoned one must never run, and the live one must still
+        // get the slot when it frees.
+        const holders = Array.from({length: limit}, deferred)
+        const held = holders.map((g) => withEncodeSlot(async () => { await g.promise }))
+        await new Promise((resolve) => setImmediate(resolve))
+
+        const controller = new AbortController()
+        let abandonedRan = false
+        const abandoned = withEncodeSlot(async () => { abandonedRan = true }, controller.signal)
+
+        let liveRan = false
+        const live = withEncodeSlot(async () => { liveRan = true })
+        assert.equal(encodeLimitStats().queued, 2, 'both should be queued')
+
+        controller.abort()
+        await assert.rejects(abandoned, (err: any) => isEncodeAborted(err))
+        assert.equal(abandonedRan, false, 'abandoned work must never execute')
+        assert.equal(encodeLimitStats().queued, 1, 'aborted waiter should leave the queue')
+
+        holders.forEach((g) => g.release())
+        await Promise.all([...held, live])
+        assert.equal(liveRan, true, 'the live waiter should still get a slot')
+        assert.equal(encodeLimitStats().active, 0)
+        assert.equal(encodeLimitStats().queued, 0)
+    })
+
+    it('rejects immediately when the signal is already aborted', async function() {
+        const controller = new AbortController()
+        controller.abort()
+        let ran = false
+        await assert.rejects(
+            withEncodeSlot(async () => { ran = true }, controller.signal),
+            (err: any) => isEncodeAborted(err),
+        )
+        assert.equal(ran, false, 'must not run for an already-gone client')
+        assert.equal(encodeLimitStats().active, 0, 'must not consume a slot')
+    })
+
+    it('does not abort when the response completed normally', function() {
+        // 'close' fires on every response, including successful ones — only a
+        // close before the body was written means the client actually left.
+        const handlers: {[k: string]: () => void} = {}
+        const ctx: any = {res: {writableEnded: false, once: (ev: string, cb: () => void) => { handlers[ev] = cb }}}
+        const signal = clientGoneSignal(ctx) as AbortSignal
+
+        ctx.res.writableEnded = true
+        handlers.close()
+        assert.equal(signal.aborted, false, 'a completed response must not look like a disconnect')
+    })
+
+    it('aborts when the connection closes mid-response', function() {
+        const handlers: {[k: string]: () => void} = {}
+        const ctx: any = {res: {writableEnded: false, once: (ev: string, cb: () => void) => { handlers[ev] = cb }}}
+        const signal = clientGoneSignal(ctx) as AbortSignal
+
+        handlers.close()
+        assert.equal(signal.aborted, true, 'closing before the body is written means the client left')
     })
 
     it('holds the ceiling when a caller arrives mid hand-off', async function() {

--- a/test/encode-limit.ts
+++ b/test/encode-limit.ts
@@ -1,0 +1,146 @@
+import 'mocha'
+import assert from 'assert'
+
+import {encodeLimitStats, withEncodeSlot} from './../src/encode-limit'
+
+describe('encode concurrency limit', function() {
+
+    const {limit} = encodeLimitStats()
+
+    const deferred = () => {
+        let release!: () => void
+        const promise = new Promise<void>((resolve) => { release = resolve })
+        return {promise, release}
+    }
+
+    it('resolves to a positive limit', function() {
+        assert(limit >= 1, `limit should be at least 1, got ${ limit }`)
+    })
+
+    it('never runs more than the limit at once', async function() {
+        let running = 0
+        let peak = 0
+        const gates = Array.from({length: limit + 4}, deferred)
+
+        const tasks = gates.map((g) => withEncodeSlot(async () => {
+            running++
+            peak = Math.max(peak, running)
+            await g.promise
+            running--
+        }))
+
+        // Let everything that can start, start; then release one at a time so a
+        // fresh slot is always contended for.
+        await new Promise((resolve) => setImmediate(resolve))
+        for (const g of gates) {
+            g.release()
+            await new Promise((resolve) => setImmediate(resolve))
+        }
+        await Promise.all(tasks)
+
+        assert.equal(peak, limit, `peak concurrency ${ peak } should equal limit ${ limit }`)
+        assert.equal(encodeLimitStats().active, 0, 'all slots should be released')
+        assert.equal(encodeLimitStats().queued, 0, 'queue should drain')
+    })
+
+    it('releases the slot when the work throws', async function() {
+        await assert.rejects(withEncodeSlot(async () => { throw new Error('boom') }), /boom/)
+        assert.equal(encodeLimitStats().active, 0, 'a thrown error must not leak a slot')
+
+        // The slot is reusable afterwards
+        const rv = await withEncodeSlot(async () => 'ok')
+        assert.equal(rv, 'ok')
+        assert.equal(encodeLimitStats().active, 0)
+    })
+
+    it('holds the ceiling when a caller arrives mid hand-off', async function() {
+        // Regression test for a real race. If release() decrements `active` and
+        // lets the queued waiter re-increment when it resumes, there is a window
+        // between those two steps — they are separate microtasks — where an
+        // arriving caller sees a free slot and takes it too. The waiter then
+        // resumes and increments as well, putting us one over the limit.
+        //
+        // The window is only reachable at a specific microtask depth, so sweep
+        // the delay between releasing a holder and the interloper arriving, and
+        // require the ceiling to hold at every depth. With the decrement-then-
+        // reacquire shape this fails at turns=2 (peak limit+1); handing the slot
+        // straight to the waiter holds at every depth.
+        const probe = async (turns: number): Promise<number> => {
+            let running = 0
+            let peak = 0
+            const holders = Array.from({length: limit}, deferred)
+            const held = holders.map((g) => withEncodeSlot(async () => {
+                running++; peak = Math.max(peak, running); await g.promise; running--
+            }))
+            await new Promise((resolve) => setImmediate(resolve))
+
+            const queued = deferred()
+            const waiter = withEncodeSlot(async () => {
+                running++; peak = Math.max(peak, running); await queued.promise; running--
+            })
+
+            holders[0].release()
+            for (let t = 0; t < turns; t++) { await Promise.resolve() }
+
+            // The interloper must HOLD its slot, otherwise it finishes before the
+            // waiter resumes and the overlap is never observable.
+            const gate = deferred()
+            const interloper = withEncodeSlot(async () => {
+                running++; peak = Math.max(peak, running); await gate.promise; running--
+            })
+
+            await new Promise((resolve) => setImmediate(resolve))
+            queued.release(); gate.release()
+            holders.slice(1).forEach((g) => g.release())
+            await Promise.all([...held, waiter, interloper])
+            return peak
+        }
+
+        for (let turns = 0; turns <= 6; turns++) {
+            const peak = await probe(turns)
+            assert(peak <= limit, `peak ${ peak } exceeded limit ${ limit } at turns=${ turns }`)
+            assert.equal(encodeLimitStats().active, 0, `slots leaked at turns=${ turns }`)
+            assert.equal(encodeLimitStats().queued, 0, `queue not drained at turns=${ turns }`)
+        }
+    })
+
+    it('hands a freed slot to a waiter without exceeding the limit', async function() {
+        // Fill every slot, queue one more, then release a holder. If release
+        // decremented instead of handing the slot over, a caller arriving in the
+        // gap could claim it too and put us over the limit.
+        let running = 0
+        let peak = 0
+        const holders = Array.from({length: limit}, deferred)
+
+        const held = holders.map((g) => withEncodeSlot(async () => {
+            running++; peak = Math.max(peak, running)
+            await g.promise
+            running--
+        }))
+        await new Promise((resolve) => setImmediate(resolve))
+        assert.equal(encodeLimitStats().active, limit, 'all slots should be taken')
+
+        const queued = deferred()
+        const waiter = withEncodeSlot(async () => {
+            running++; peak = Math.max(peak, running)
+            await queued.promise
+            running--
+        })
+        assert.equal(encodeLimitStats().queued, 1, 'the extra call should be queued')
+
+        holders[0].release()
+        const interloper = withEncodeSlot(async () => {
+            running++; peak = Math.max(peak, running)
+            running--
+        })
+
+        await new Promise((resolve) => setImmediate(resolve))
+        queued.release()
+        holders.slice(1).forEach((g) => g.release())
+        await Promise.all([...held, waiter, interloper])
+
+        assert.equal(peak, limit, `peak ${ peak } must not exceed limit ${ limit }`)
+        assert.equal(encodeLimitStats().active, 0)
+        assert.equal(encodeLimitStats().queued, 0)
+    })
+})


### PR DESCRIPTION
## Problem

Sharp's async work runs on the **libuv threadpool** — the same pool Node uses for `fs` reads, defaulting to 4 slots per process. An AVIF encode occupies a slot for seconds, and nothing bounded how many ran concurrently.

Two consequences under load:

1. **Cheap work starves.** Serving an already-converted variant is just a file read, but it queues behind multi-second encodes. Measured on a loaded box: a 32KB cached variant took **0.46-8.08s** to serve, while the pure-JS `/healthcheck` answered in **2ms**. The event loop was healthy throughout — the threadpool was full. Since most requests reaching the origin should be cheap store hits, this affects the majority of traffic.
2. **The CPU oversubscribes.** More simultaneous encodes than cores doesn't raise throughput, it just makes each encode slower.

Caching itself was verified working (variants are written and read correctly, no store failures) — the variants were there, just slow to get out.

## Change

A per-worker semaphore around the three `toBuffer()` call sites (`proxy.ts`, `image-resizer.ts`, `fallback.ts`).

- Wrapped region is a **single encode call**, so a slot is never held across other awaits and gated calls cannot nest (which would deadlock at low limits).
- Default limit is `cpus / num_workers`, so the service-wide total lands near the core count rather than a multiple of it. Override with `max_concurrent_encodes` (0/unset = auto).
- Errors release the slot via `finally`.

## Note on the hand-off

`release()` hands a freed slot **directly to a queued waiter** rather than decrementing and letting the waiter re-acquire. The latter is subtly wrong: those are two separate microtasks, and a caller arriving in the gap sees a free slot and takes it too, putting the count one over the limit.

I wrote that bug first, and my initial test did not catch it — the test only failed once the interloper was made to *hold* its slot (a synchronous task finishes before the waiter resumes, so the overlap is unobservable) and the arrival depth was swept. It reproduces at exactly `turns=2`.

## Tests

5 new cases in `test/encode-limit.ts`: limit resolution, ceiling enforcement, slot release on throw, drain, and the hand-off race sweep. `config/test.toml` pins `max_concurrent_encodes = 3` so tests exercise a real ceiling rather than 1.

Verified the race test fails on the buggy shape (`peak 4 exceeded limit 3 at turns=2`) and passes on the fix.

Full suite: **209 passing** (was 204), with the same 4 pre-existing environment failures present on a clean `main`. `tsc --noEmit` clean; no new lint findings.

## Follow-up (not in this PR)

With encodes bounded, raising `UV_THREADPOOL_SIZE` becomes safe and should let cached-variant reads bypass encode queueing entirely. Doing that *without* this cap would be actively harmful — it would permit far more concurrent encodes and thrash worse.