### PR TITLE
Lower AVIF encode effort from 3 to 2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ NODE_ENV=test mocha --require ts-node/register test/[filename].ts --grep 'test p
 - Scaling modes: `cover` (center-crop) and `fit` (aspect-preserve)
 - Output formats: `match`, `jpeg`, `png`, `webp`, `avif`
 - Format auto-negotiation: prefers AVIF > WebP > match based on Accept header
-- AVIF encoding: quality 50, effort 3 (balances CPU vs compression — effort 4 is 6x slower for <1% size reduction)
+- AVIF encoding: quality 50, effort 2 (`AVIF_EFFORT` in constants.ts). Measured on five real proxy images: effort 2 is 1.6-2.3x faster than effort 3 at the same size or smaller (92-100% of its bytes). Do not lower further — effort 1 is not reliably faster and effort 0 is ~8% larger; effort 4 is ~6x slower than 3 for <1% size reduction
 - Max dimensions enforced: standard (1280x1280) and custom (2000x2000)
 - Fallback system: attempts multiple mirror URLs if primary source fails
 - Animated GIF/APNG: bypasses Sharp pipeline entirely to preserve animation (Sharp strips frames)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,24 @@ export const INTERNAL_SERVICE_BASE_URLS = Array.from(new Set([
 ]))
 export const INTERNAL_SERVICE_ORIGINS = INTERNAL_SERVICE_BASE_URLS.map((url) => new URL(url).origin)
 
+/**
+ * libaom search effort for AVIF encodes.
+ *
+ * Measured on five real proxy images (same source, quality held at 50, resized
+ * to fit 1280): effort 2 encodes 1.6-2.3x faster than effort 3 and comes out the
+ * same size or smaller (92-100% of effort 3's bytes), so lowering it costs no
+ * bandwidth. Visual comparison at 200% showed no meaningful difference.
+ *
+ * Do not lower it further: effort 1 is not reliably faster than 2 (it was slower
+ * on one image), and effort 0 produces ~8% LARGER files. Effort 4 is ~6x slower
+ * than 3 for under 1% size reduction.
+ *
+ * Encode cost is why this matters: a full 1280 AVIF encode is ~578ms at effort 3
+ * versus ~13ms for a 64px avatar, and encodes are bounded by a per-worker
+ * semaphore (see encode-limit.ts), so cheaper encodes drain that queue faster.
+ */
+export const AVIF_EFFORT = 2
+
 /** Special empty image indicator - used to denote "proxy without resizing" */
 export const SPECIAL_EMPTY_IMAGE_PATH = '0x0'
 

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -2,6 +2,7 @@ import etag from 'etag'
 import Sharp from 'sharp'
 import {KoaContext} from './common'
 import {clientGoneSignal, withEncodeSlot} from './encode-limit'
+import { AVIF_EFFORT } from './constants'
 import {getImageKey, OutputFormat, ProxyOptions, ScalingMode} from './utils'
 
 export async function serveOrBuildFallbackImage(
@@ -49,7 +50,7 @@ export async function serveOrBuildFallbackImage(
             contentType = 'image/webp'
             break
         case OutputFormat.AVIF:
-            image.avif({ force: true, quality: 50, effort: 3 })
+            image.avif({ force: true, quality: 50, effort: AVIF_EFFORT })
             contentType = 'image/avif'
             break
         case OutputFormat.Match:

--- a/src/image-resizer.ts
+++ b/src/image-resizer.ts
@@ -1,6 +1,7 @@
 // utils/image-resizer.ts
 import Sharp from 'sharp'
 import { withEncodeSlot } from './encode-limit'
+import { AVIF_EFFORT } from './constants'
 import { APIError } from './error'
 import {
     buildSharpPipeline, getProxyImageLimits, mimeMagic,
@@ -108,7 +109,7 @@ export async function resizeImageWithOptions(
             break
         case OutputFormat.AVIF:
             contentType = 'image/avif'
-            image.avif({ quality: 50, effort: 3, force: true })
+            image.avif({ quality: 50, effort: AVIF_EFFORT, force: true })
             break
     }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,7 +10,7 @@ import streamHead from 'stream-head/dist-es6'
 import {URL} from 'url'
 import {imageBlacklist} from './blacklist'
 import {KoaContext, proxyStore, uploadStore} from './common'
-import {applyUrlReplacements, isEmptyImageUrl, EMPTY_IMAGE_URL_PATTERNS} from './constants'
+import { AVIF_EFFORT, EMPTY_IMAGE_URL_PATTERNS, applyUrlReplacements, isEmptyImageUrl } from './constants'
 import {APIError} from './error'
 import {serveOrBuildFallbackImage} from './fallback'
 import {clientGoneSignal, isEncodeAborted, withEncodeSlot} from './encode-limit'
@@ -557,7 +557,7 @@ export async function proxyHandler(ctx: KoaContext) {
                 break
             case OutputFormat.AVIF:
                 contentType = 'image/avif'
-                image.avif({quality: 50, effort: 3, force: true})
+                image.avif({quality: 50, effort: AVIF_EFFORT, force: true})
                 break
             default:
                 break

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -29,18 +29,7 @@ import {
     storeWrite,
 } from './../src/utils'
 
-import {
-    isEmptyImageUrl,
-    startsWithEmptyImagePrefix,
-    applyUrlReplacements,
-    SERVICE_BASE_URL,
-    SPECIAL_EMPTY_IMAGE_PATH,
-    DEFAULT_FALLBACK_IMAGE_URL,
-    DEFAULT_AVATAR_HASH,
-    EMPTY_IMAGE_URL_PATTERNS,
-    INTERNAL_SERVICE_ORIGINS,
-    LEGACY_SERVICE_BASE_URL,
-} from './../src/constants'
+import {AVIF_EFFORT, DEFAULT_AVATAR_HASH, DEFAULT_FALLBACK_IMAGE_URL, EMPTY_IMAGE_URL_PATTERNS, INTERNAL_SERVICE_ORIGINS, LEGACY_SERVICE_BASE_URL, SERVICE_BASE_URL, SPECIAL_EMPTY_IMAGE_PATH, applyUrlReplacements, isEmptyImageUrl, startsWithEmptyImagePrefix} from './../src/constants'
 
 import { APIError } from './../src/error'
 
@@ -484,6 +473,15 @@ describe('constants', function() {
 
         it('should have correct SPECIAL_EMPTY_IMAGE_PATH', function() {
             assert.equal(SPECIAL_EMPTY_IMAGE_PATH, '0x0')
+        })
+
+        it('should keep AVIF_EFFORT in the measured-safe range', function() {
+            // 2 is the measured sweet spot: 1.6-2.3x faster than 3 at the same
+            // size or smaller. Guard the range rather than the exact value so
+            // retuning stays possible, but a drift to 0 (~8% larger files) or
+            // back to 4 (~6x slower for <1% gain) fails here.
+            assert.equal(typeof AVIF_EFFORT, 'number')
+            assert(AVIF_EFFORT >= 1 && AVIF_EFFORT <= 3, `AVIF_EFFORT ${ AVIF_EFFORT } outside measured-safe 1-3`)
         })
 
         it('should have valid DEFAULT_FALLBACK_IMAGE_URL', function() {


### PR DESCRIPTION
## Why

Measured on five real proxy images (same source, `quality: 50` held constant, resized to fit 1280):

| image | effort 3 | effort 2 | speedup | effort 2 size vs 3 |
|---|---|---|---|---|
| 1280x905 | 672 ms | 399 ms | 1.7x | 92% |
| 1280x640 | 393 ms | 213 ms | 1.8x | 94% |
| 1024x576 | 285 ms | 177 ms | 1.6x | 92% |
| 900x506 | 341 ms | 208 ms | 1.6x | 100% |
| 704x384 | 179 ms | 77 ms | 2.3x | 92% |

**1.6-2.3x faster at the same size or smaller.** No bandwidth cost, which is unusual for an encoder speed/size tradeoff and is what makes this worth taking rather than a judgement call.

Byte size is only a proxy for quality, so both encodes were also compared visually at 200% zoom (wipe and flip, same retinal position) on two images — including one where the two sizes are near-identical, so any visible difference would be pure loss with no saving to justify it. No meaningful difference.

## Why 2 and not lower

- **effort 1** is not reliably faster than 2 — it was *slower* on one of the five images (251 ms vs 208 ms) at equal size.
- **effort 0** is fastest but produces **~8% larger** files, so it loses on the axis we actually care about.
- **effort 4** was already documented as ~6x slower than 3 for <1% size reduction.

Effort 2 is the floor worth taking, not a step on the way down.

## Why encode cost matters here

A full 1280 AVIF encode is ~578 ms at effort 3, against ~13 ms for a 64px avatar. Encodes now run behind a per-worker semaphore (`encode-limit.ts`), so making the expensive ones cheaper drains that queue faster for everything waiting behind them.

## Change

The three call sites (`proxy.ts`, `image-resizer.ts`, `fallback.ts`) now share a documented `AVIF_EFFORT` constant instead of each repeating a bare literal. A test guards the measured-safe range (1-3) rather than the exact value, so retuning stays possible but a drift to 0 or back to 4 fails instead of silently regressing. `CLAUDE.md` rationale updated to match.

Full suite: **215 passing** (was 214), with the same 4 pre-existing environment failures present on a clean `main`. `tsc --noEmit` clean, no new lint findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved AVIF image encoding efficiency, balancing processing speed, file size, and visual quality.
  * Applied consistent AVIF optimization across image resizing, fallback generation, and proxy conversion workflows.

* **Documentation**
  * Updated AVIF encoding guidance with performance and compression tradeoff details.

* **Tests**
  * Added validation to help ensure AVIF encoding remains within the supported optimization range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->