### PR TITLE
Run cheap encodes without queueing behind expensive ones

### DIFF
--- a/src/encode-limit.ts
+++ b/src/encode-limit.ts
@@ -158,6 +158,11 @@ export async function runEncode<T>(
     target: {width?: number, height?: number, blur?: boolean},
     signal: AbortSignal | undefined,
 ): Promise<T> {
+    // Check for a client that already left before either path. withEncodeSlot
+    // does this when it queues, but the bypass calls fn() directly — without this
+    // a cheap encode for a disconnected client would still run Sharp and cache a
+    // result nobody will read, which the gated path already avoids.
+    if (signal && signal.aborted) { throw abortedError() }
     if (!encodeNeedsSlot(target)) { return fn() }
     return withEncodeSlot(fn, signal)
 }

--- a/src/encode-limit.ts
+++ b/src/encode-limit.ts
@@ -123,6 +123,46 @@ export async function withEncodeSlot<T>(fn: () => Promise<T>, signal?: AbortSign
 }
 
 /**
+ * Output area below which an encode runs ungated.
+ *
+ * Encode cost scales steeply with output size. Measured at effort 3: a 64px
+ * avatar is ~13ms and a 128px ~19ms, against ~578ms for a full 1280 proxy image
+ * — roughly 30-45x cheaper. Sending that 13ms of work through a one-slot queue
+ * made it wait behind multi-second full-size encodes, so cold avatars went from
+ * milliseconds to seconds while cached ones stayed fast. The queue exists to
+ * stop expensive encodes starving cheap disk reads; it should not make cheap
+ * encodes starve behind expensive ones instead.
+ *
+ * 256x256 sits between the measured-cheap sizes (64/128, <=20ms) and the ones
+ * worth gating (512 at ~170ms, 1280 at ~578ms).
+ */
+export const ENCODE_GATE_MIN_PIXELS = 256 * 256
+
+/** Whether an encode for this output target is expensive enough to queue. */
+export function encodeNeedsSlot(target: {width?: number, height?: number, blur?: boolean}): boolean {
+    // Blur placeholders are ~20px LQIP thumbnails regardless of the requested size.
+    if (target.blur) { return false }
+    const {width, height} = target
+    // An unspecified target means "no resize" — it could be the full original, so gate it.
+    if (!width || !height) { return true }
+    return width * height >= ENCODE_GATE_MIN_PIXELS
+}
+
+/**
+ * Runs an encode, queueing it only when it is expensive enough to be worth
+ * gating. Prefer this over calling withEncodeSlot directly at request paths so
+ * the cheap/expensive decision stays in one place.
+ */
+export async function runEncode<T>(
+    fn: () => Promise<T>,
+    target: {width?: number, height?: number, blur?: boolean},
+    signal: AbortSignal | undefined,
+): Promise<T> {
+    if (!encodeNeedsSlot(target)) { return fn() }
+    return withEncodeSlot(fn, signal)
+}
+
+/**
  * AbortSignal that fires if the connection closes before the response was fully
  * written — i.e. the client, or the cache in front of us, gave up waiting.
  */

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -1,7 +1,7 @@
 import etag from 'etag'
 import Sharp from 'sharp'
 import {KoaContext} from './common'
-import {clientGoneSignal, withEncodeSlot} from './encode-limit'
+import {clientGoneSignal, runEncode} from './encode-limit'
 import { AVIF_EFFORT } from './constants'
 import {getImageKey, OutputFormat, ProxyOptions, ScalingMode} from './utils'
 
@@ -59,7 +59,7 @@ export async function serveOrBuildFallbackImage(
             contentType = 'image/jpeg'
     }
 
-    const rv = await withEncodeSlot(() => image.toBuffer(), clientGoneSignal(ctx))
+    const rv = await runEncode(() => image.toBuffer(), options, clientGoneSignal(ctx))
 
     ctx.set('Content-Type', contentType)
     ctx.set('Vary', 'Accept')

--- a/src/image-resizer.ts
+++ b/src/image-resizer.ts
@@ -1,6 +1,6 @@
 // utils/image-resizer.ts
 import Sharp from 'sharp'
-import { withEncodeSlot } from './encode-limit'
+import { runEncode } from './encode-limit'
 import { AVIF_EFFORT } from './constants'
 import { APIError } from './error'
 import {
@@ -113,6 +113,6 @@ export async function resizeImageWithOptions(
             break
     }
 
-    const buffer = await withEncodeSlot(() => image.toBuffer(), signal)
+    const buffer = await runEncode(() => image.toBuffer(), options, signal)
     return { buffer, contentType, isFallback }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -13,7 +13,7 @@ import {KoaContext, proxyStore, uploadStore} from './common'
 import { AVIF_EFFORT, EMPTY_IMAGE_URL_PATTERNS, applyUrlReplacements, isEmptyImageUrl } from './constants'
 import {APIError} from './error'
 import {serveOrBuildFallbackImage} from './fallback'
-import {clientGoneSignal, isEncodeAborted, withEncodeSlot} from './encode-limit'
+import {clientGoneSignal, isEncodeAborted, runEncode} from './encode-limit'
 import {fetchImageWithFallbacks} from './fetch-image'
 import {captureImageFailure} from './sentry'
 import {
@@ -570,7 +570,7 @@ export async function proxyHandler(ctx: KoaContext) {
         }
 
         try {
-            rv = await withEncodeSlot(() => image.toBuffer(), clientGoneSignal(ctx))
+            rv = await runEncode(() => image.toBuffer(), options, clientGoneSignal(ctx))
         } catch (err) {
             if (isEncodeAborted(err)) {
                 // The client gave up while we were queued. Nothing failed, and

--- a/test/encode-limit.ts
+++ b/test/encode-limit.ts
@@ -1,7 +1,9 @@
 import 'mocha'
 import assert from 'assert'
 
-import {clientGoneSignal, encodeLimitStats, isEncodeAborted, withEncodeSlot} from './../src/encode-limit'
+import {
+    clientGoneSignal, encodeLimitStats, encodeNeedsSlot, isEncodeAborted, runEncode, withEncodeSlot,
+} from './../src/encode-limit'
 import {errorMiddleware} from './../src/error'
 
 describe('encode concurrency limit', function() {
@@ -148,6 +150,62 @@ describe('encode concurrency limit', function() {
         await errorMiddleware(failCtx as any, async () => { throw new Error('real failure') })
         assert.equal(failCtx.status, 500, 'genuine errors still report 500')
         assert.equal(failCtx.emitted.length, 1, 'genuine errors still emit')
+    })
+
+    describe('cheap-encode bypass', function() {
+        it('gates expensive targets and lets cheap ones through', function() {
+            // Measured encode cost at effort 3: 64px ~13ms, 128px ~19ms,
+            // 512px ~170ms, 1280px ~578ms.
+            assert.equal(encodeNeedsSlot({width: 64, height: 64}), false, '64px avatar is cheap')
+            assert.equal(encodeNeedsSlot({width: 128, height: 128}), false, '128px avatar is cheap')
+            assert.equal(encodeNeedsSlot({width: 512, height: 512}), true, '512px is worth gating')
+            assert.equal(encodeNeedsSlot({width: 1280, height: 1280}), true, 'full size is worth gating')
+        })
+
+        it('gates an unspecified target, which may be the full original', function() {
+            assert.equal(encodeNeedsSlot({}), true)
+            assert.equal(encodeNeedsSlot({width: 1280}), true, 'half-specified is still unknown area')
+        })
+
+        it('never gates a blur placeholder regardless of requested size', function() {
+            assert.equal(encodeNeedsSlot({width: 1280, height: 1280, blur: true}), false)
+        })
+
+        it('runs a cheap encode without taking a slot, even when all slots are busy', async function() {
+            const holders = Array.from({length: limit}, deferred)
+            const held = holders.map((g) => withEncodeSlot(async () => { await g.promise }))
+            await new Promise((resolve) => setImmediate(resolve))
+            assert.equal(encodeLimitStats().active, limit, 'all slots taken')
+
+            // This is the regression: before the bypass, a 13ms avatar encode
+            // queued here behind multi-second full-size work.
+            let ran = false
+            const rv = await runEncode(async () => { ran = true; return 'avatar' }, {width: 64, height: 64}, undefined)
+            assert.equal(rv, 'avatar')
+            assert.equal(ran, true, 'cheap encode must not wait for a slot')
+            assert.equal(encodeLimitStats().queued, 0, 'and must not enter the queue')
+
+            holders.forEach((g) => g.release())
+            await Promise.all(held)
+            assert.equal(encodeLimitStats().active, 0)
+        })
+
+        it('still queues an expensive encode when slots are busy', async function() {
+            const holders = Array.from({length: limit}, deferred)
+            const held = holders.map((g) => withEncodeSlot(async () => { await g.promise }))
+            await new Promise((resolve) => setImmediate(resolve))
+
+            let ran = false
+            const pending = runEncode(async () => { ran = true }, {width: 1280, height: 1280}, undefined)
+            await new Promise((resolve) => setImmediate(resolve))
+            assert.equal(ran, false, 'expensive encode must wait its turn')
+            assert.equal(encodeLimitStats().queued, 1)
+
+            holders.forEach((g) => g.release())
+            await Promise.all([...held, pending])
+            assert.equal(ran, true)
+            assert.equal(encodeLimitStats().active, 0)
+        })
     })
 
     it('holds the ceiling when a caller arrives mid hand-off', async function() {

--- a/test/encode-limit.ts
+++ b/test/encode-limit.ts
@@ -190,6 +190,21 @@ describe('encode concurrency limit', function() {
             assert.equal(encodeLimitStats().active, 0)
         })
 
+        it('rejects a cheap encode when the client already left, without running Sharp', async function() {
+            // The bypass path skips the queue, so it must do the abort check the
+            // queued path does — otherwise a disconnected client's cheap encode
+            // still runs and caches a result nobody reads.
+            const controller = new AbortController()
+            controller.abort()
+            let ran = false
+            await assert.rejects(
+                runEncode(async () => { ran = true }, {width: 64, height: 64}, controller.signal),
+                (err) => isEncodeAborted(err),
+            )
+            assert.equal(ran, false, 'cheap encode must not run for a gone client')
+            assert.equal(encodeLimitStats().active, 0)
+        })
+
         it('still queues an expensive encode when slots are busy', async function() {
             const holders = Array.from({length: limit}, deferred)
             const held = holders.map((g) => withEncodeSlot(async () => { await g.promise }))


### PR DESCRIPTION
## Problem

The per-worker encode semaphore (#11) was added to stop expensive full-size AVIF encodes from starving cheap disk reads. But avatars and covers pass through the same gate, and their encodes are cheap. Measured at effort 3:

| target | encode time |
|---|---|
| 64px avatar | ~13 ms |
| 128px avatar | ~19 ms |
| 512px | ~170 ms |
| 1280px proxy | ~578 ms |

A 64px avatar is ~30-45x cheaper than a full-size proxy encode, but the single-slot queue made it wait behind those multi-second encodes. Observed on the box after #11 deployed: avatar backend **mean 0.42s, worst 13.49s**, while cached avatars still served in 6-86ms. The gate was inverting its own purpose — it exists to keep cheap work from being starved, and it was starving cheap work.

## Fix

Gate on **output area**, not on route. `runEncode()` takes a slot only when the target is `>= 256x256`; below that it runs immediately.

- **256x256** sits between the measured-cheap sizes (64/128, <=20ms) and the ones worth gating (512 at ~170ms, 1280 at ~578ms).
- **Blur placeholders** are ~20px LQIP thumbnails regardless of requested size, so they always bypass.
- **An unspecified target** may be the full original, so it gates (conservative default).

Keying on encode cost rather than the avatar/cover route means any small resize benefits, and there's no route-based assumption that can drift as handlers change. All three encode sites (`proxy.ts`, `image-resizer.ts`, `fallback.ts`) now call `runEncode` with their existing `options` object.

## Why not just raise the limit

Raising the global limit would undo the cache-read protection #11 added — the day's most durable win (cached-variant serving went 1.428s to ~7ms and held across every measurement). The point isn't more concurrency, it's not making cheap work queue at all.

## Tests

5 new cases: the size threshold (64/128 bypass, 512/1280 gate), unspecified-target and blur handling, a cheap encode running while all slots are busy, and an expensive one still queueing. Verified the bypass test fails if the gate is removed.

Full suite: **220 passing** (was 215), same 4 pre-existing environment failures on a clean `main`. `tsc --noEmit` clean, no new lint findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Small image encodes and blur placeholders now process immediately, reducing unnecessary queuing.
  * Larger or unspecified-size image encodes continue to respect concurrency limits.

* **Reliability**
  * Encoding remains responsive to cancellation when clients disconnect.

* **Tests**
  * Added coverage for immediate processing, queueing behavior, blur placeholders, and unknown image dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->