### PR TITLE
Convert AVIF sources for clients that cannot decode them

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -18,6 +18,7 @@ import {fetchImageWithFallbacks} from './fetch-image'
 import {captureImageFailure} from './sentry'
 import {
     AcceptedContentTypes,
+    applyMatchFallbackFormat,
     assertPublicUrl,
     buildSharpPipeline,
     fetchUrl,
@@ -26,6 +27,7 @@ import {
     getProxyImageLimits,
     getSharpMetadataWithRetry,
     mimeMagic,
+    needsMatchFallback,
     NeedleResponse,
     OutputFormat,
     isInternalProxyUrl,
@@ -296,11 +298,22 @@ export async function proxyHandler(ctx: KoaContext) {
         })
         const {head, stream} = await streamHead(file, {bytes: 16384})
         const mimeType = await mimeMagic(head)
-        ctx.set('Content-Type', mimeType)
-        ctx.set('Vary', 'Accept')
-        ctx.set('Cache-Control', 'public,max-age=31536000,immutable')
-        ctx.body = stream
-        return
+        // Match variants are one bucket for every client that negotiated neither
+        // AVIF nor WebP, so a stored AVIF/HEIF passthrough can be undecodable for
+        // the client asking now. Re-derive from the original instead of streaming
+        // it; the converted variant then replaces this one for everybody.
+        if (options.format === OutputFormat.Match && needsMatchFallback(mimeType, acceptHeader)) {
+            ctx.tag({match_fallback: true})
+            ctx.log.debug({imageKey, mimeType, msg: 'cached match variant undecodable for client, re-deriving'})
+            ;(stream as any).destroy?.()
+            file.destroy()
+        } else {
+            ctx.set('Content-Type', mimeType)
+            ctx.set('Vary', 'Accept')
+            ctx.set('Cache-Control', 'public,max-age=31536000,immutable')
+            ctx.body = stream
+            return
+        }
     }
 
     // check if we have the original
@@ -537,11 +550,9 @@ export async function proxyHandler(ctx: KoaContext) {
 
         switch (options.format) {
             case OutputFormat.Match:
-                // HEIC/HEIF is not renderable by most browsers — convert to JPEG
-                if (contentType === 'image/heic' || contentType === 'image/heif') {
-                    image.jpeg({quality: 80, force: true})
-                    contentType = 'image/jpeg'
-                }
+                // Match hands back the original bytes, which only works if the
+                // client can decode the source format — see applyMatchFallbackFormat
+                contentType = applyMatchFallbackFormat(image, contentType, acceptHeader, metadata.hasAlpha)
                 break
             case OutputFormat.JPEG:
                 image.jpeg({force: true})

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -113,6 +113,38 @@ function parseOptions(query: {[key: string]: any}, acceptHeader: string = ''): P
     return {width, height, mode, format, ignorecache, invalidate, blur}
 }
 
+/**
+ * Transcode an already-sized cached Match variant for a client that cannot
+ * decode its format. Animated sources and encode failures fall back to the
+ * cached bytes: an image that one client cannot render beats a failed request.
+ */
+async function convertCachedMatchVariant(
+    ctx: KoaContext,
+    cached: Buffer,
+    mimeType: string,
+    acceptHeader: string,
+    options: ProxyOptions
+): Promise<{buffer: Buffer, contentType: string}> {
+    try {
+        const metadata = await Sharp(cached).metadata()
+        if (metadata.pages != null && metadata.pages > 1) {
+            // Transcoding an animated source here would drop its frames
+            return {buffer: cached, contentType: mimeType}
+        }
+        const image = buildSharpPipeline(cached, false)
+        const contentType = applyMatchFallbackFormat(image, mimeType, acceptHeader, metadata.hasAlpha)
+        const buffer = await runEncode(() => image.toBuffer(), options, clientGoneSignal(ctx))
+        ctx.log.debug({mimeType, contentType, msg: 'converted cached match variant for client'})
+        return {buffer, contentType}
+    } catch (err) {
+        if (isEncodeAborted(err)) {
+            throw err
+        }
+        ctx.log.error({err, mimeType, msg: 'failed to convert cached match variant'})
+        return {buffer: cached, contentType: mimeType}
+    }
+}
+
 export async function proxyHandler(ctx: KoaContext) {
     ctx.tag({handler: 'proxy'})
 
@@ -300,13 +332,18 @@ export async function proxyHandler(ctx: KoaContext) {
         const mimeType = await mimeMagic(head)
         // Match variants are one bucket for every client that negotiated neither
         // AVIF nor WebP, so a stored AVIF/HEIF passthrough can be undecodable for
-        // the client asking now. Re-derive from the original instead of streaming
-        // it; the converted variant then replaces this one for everybody.
+        // the client asking now. Convert the cached bytes rather than falling
+        // through to the origin: the variant is already sized, and the original
+        // may have been pruned or its remote host may be down.
         if (options.format === OutputFormat.Match && needsMatchFallback(mimeType, acceptHeader)) {
             ctx.tag({match_fallback: true})
-            ctx.log.debug({imageKey, mimeType, msg: 'cached match variant undecodable for client, re-deriving'})
-            ;(stream as any).destroy?.()
-            file.destroy()
+            const cached = await readStream(stream)
+            const served = await convertCachedMatchVariant(ctx, cached, mimeType, acceptHeader, options)
+            ctx.set('Content-Type', served.contentType)
+            ctx.set('Vary', 'Accept')
+            ctx.set('Cache-Control', 'public,max-age=31536000,immutable')
+            ctx.body = served.buffer
+            return
         } else {
             ctx.set('Content-Type', mimeType)
             ctx.set('Vary', 'Accept')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -324,6 +324,9 @@ export function supportsAvif(acceptHeader: string): boolean {
     return acceptHeader.toLowerCase().includes('image/avif')
 }
 
+/** `image/<subtype>`, excluding the `image/*` wildcard */
+const NAMED_IMAGE_TYPE = /image\/[a-z0-9][a-z0-9.+-]*/
+
 /**
  * Whether the client left the door open for any image type.
  *
@@ -335,11 +338,14 @@ export function supportsAvif(acceptHeader: string): boolean {
  * CPU transcoding for it.
  */
 export function acceptsAnyImageType(acceptHeader: string): boolean {
-    const value = acceptHeader.toLowerCase()
-    if (value.includes('image/*')) {
-        return true
-    }
-    return !value.includes('image/')
+    // A named subtype wins over a wildcard: `image/jpeg,image/*;q=0` enumerates,
+    // it does not leave the door open
+    return !NAMED_IMAGE_TYPE.test(acceptHeader.toLowerCase())
+}
+
+/** Whether the client named this exact image type */
+export function acceptsImageType(acceptHeader: string, type: string): boolean {
+    return acceptHeader.toLowerCase().includes(type.toLowerCase())
 }
 
 /**
@@ -362,7 +368,11 @@ export function needsMatchFallback(contentType: string, acceptHeader: string): b
 /**
  * Pick an output format for a source the client cannot render. Returns the
  * content type to serve, and stages the conversion on the pipeline when one is
- * needed. PNG keeps transparency, JPEG is smaller for everything else.
+ * needed.
+ *
+ * PNG keeps transparency, but only for a client that will take PNG — replacing
+ * one undecodable type with another would defeat the point. When alpha has to
+ * go it is flattened onto white, since JPEG would otherwise composite it black.
  */
 export function applyMatchFallbackFormat(
     image: Sharp.Sharp,
@@ -374,11 +384,18 @@ export function applyMatchFallbackFormat(
         return contentType
     }
 
-    if (hasAlpha) {
+    // `*/*` counts: browsers that name a few image types still trail a catch-all
+    const canTakePng = acceptsAnyImageType(acceptHeader) ||
+        acceptsImageType(acceptHeader, 'image/png') ||
+        acceptsImageType(acceptHeader, '*/*')
+    if (hasAlpha && canTakePng) {
         image.png({force: true, compressionLevel: 9})
         return 'image/png'
     }
 
+    if (hasAlpha) {
+        image.flatten({background: '#ffffff'})
+    }
     image.jpeg({quality: 80, force: true})
     return 'image/jpeg'
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -314,14 +314,14 @@ export function stripWebpOrPng(value: string): string {
  * Detect WebP support from Accept header for content negotiation
  */
 export function supportsWebP(acceptHeader: string): boolean {
-    return acceptHeader.toLowerCase().includes('image/webp')
+    return namesImageType(acceptHeader, 'image/webp')
 }
 
 /**
  * Detect AVIF support from Accept header for content negotiation
  */
 export function supportsAvif(acceptHeader: string): boolean {
-    return acceptHeader.toLowerCase().includes('image/avif')
+    return namesImageType(acceptHeader, 'image/avif')
 }
 
 /**
@@ -342,6 +342,18 @@ function parseAccept(acceptHeader: string): Array<{type: string, q: number}> {
             return {type, q: Number.isFinite(q) ? q : 1}
         })
         .filter((entry) => entry.type.length > 0)
+}
+
+/**
+ * Whether the client named this exact type and did not reject it.
+ *
+ * Format negotiation asks this rather than `acceptsImageType`: a trailing
+ * `*\/*;q=0.8` must not be read as AVIF or WebP support, or every browser would
+ * be handed a format it never advertised.
+ */
+export function namesImageType(acceptHeader: string, type: string): boolean {
+    const wanted = type.toLowerCase()
+    return parseAccept(acceptHeader).some((entry) => entry.type === wanted && entry.q > 0)
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -324,6 +324,65 @@ export function supportsAvif(acceptHeader: string): boolean {
     return acceptHeader.toLowerCase().includes('image/avif')
 }
 
+/**
+ * Whether the client left the door open for any image type.
+ *
+ * A client that enumerates image types (`image/webp,image/apng,*\/*;q=0.8` —
+ * every browser image request looks like this) has told us what it decodes, so
+ * a type missing from that list is a type it cannot read. A client that names
+ * no image type at all (empty Accept, `*\/*` from curl and most bots, or an
+ * explicit `image/*`) told us nothing, so assume it copes rather than burning
+ * CPU transcoding for it.
+ */
+export function acceptsAnyImageType(acceptHeader: string): boolean {
+    const value = acceptHeader.toLowerCase()
+    if (value.includes('image/*')) {
+        return true
+    }
+    return !value.includes('image/')
+}
+
+/**
+ * Whether a `OutputFormat.Match` response of this type would be undecodable.
+ *
+ * Match passes the original bytes through, which breaks for sources the
+ * requesting client has no decoder for: HEIC/HEIF is renderable in almost no
+ * browser, and an AVIF original reaching Match means negotiation already
+ * established that this client did not advertise AVIF.
+ */
+export function needsMatchFallback(contentType: string, acceptHeader: string): boolean {
+    const type = contentType.toLowerCase()
+    if (type === 'image/heic' || type === 'image/heif') {
+        return true
+    }
+    // AVIF is only undecodable for a client that enumerated its formats without it
+    return type === 'image/avif' && !acceptsAnyImageType(acceptHeader)
+}
+
+/**
+ * Pick an output format for a source the client cannot render. Returns the
+ * content type to serve, and stages the conversion on the pipeline when one is
+ * needed. PNG keeps transparency, JPEG is smaller for everything else.
+ */
+export function applyMatchFallbackFormat(
+    image: Sharp.Sharp,
+    contentType: string,
+    acceptHeader: string,
+    hasAlpha?: boolean
+): string {
+    if (!needsMatchFallback(contentType, acceptHeader)) {
+        return contentType
+    }
+
+    if (hasAlpha) {
+        image.png({force: true, compressionLevel: 9})
+        return 'image/png'
+    }
+
+    image.jpeg({quality: 80, force: true})
+    return 'image/jpeg'
+}
+
 export function sanitizeIgnoreInvalidateParams(url: URL): URL {
     return new URL(
         url.toString()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -324,8 +324,25 @@ export function supportsAvif(acceptHeader: string): boolean {
     return acceptHeader.toLowerCase().includes('image/avif')
 }
 
-/** `image/<subtype>`, excluding the `image/*` wildcard */
-const NAMED_IMAGE_TYPE = /image\/[a-z0-9][a-z0-9.+-]*/
+/**
+ * Accept entries with their q-values, most specific match first.
+ *
+ * Substring matching is not enough here: `image/png;q=0` contains `image/png`
+ * while meaning the exact opposite, and `image/jpeg,image/*;q=0` contains a
+ * wildcard while still enumerating.
+ */
+function parseAccept(acceptHeader: string): Array<{type: string, q: number}> {
+    return acceptHeader
+        .toLowerCase()
+        .split(',')
+        .map((part) => {
+            const [type, ...params] = part.split(';').map((piece) => piece.trim())
+            const qParam = params.find((param) => param.startsWith('q='))
+            const q = qParam ? Number.parseFloat(qParam.slice(2)) : 1
+            return {type, q: Number.isFinite(q) ? q : 1}
+        })
+        .filter((entry) => entry.type.length > 0)
+}
 
 /**
  * Whether the client left the door open for any image type.
@@ -334,18 +351,35 @@ const NAMED_IMAGE_TYPE = /image\/[a-z0-9][a-z0-9.+-]*/
  * every browser image request looks like this) has told us what it decodes, so
  * a type missing from that list is a type it cannot read. A client that names
  * no image type at all (empty Accept, `*\/*` from curl and most bots, or an
- * explicit `image/*`) told us nothing, so assume it copes rather than burning
+ * `image/*` wildcard) told us nothing, so assume it copes rather than burning
  * CPU transcoding for it.
  */
 export function acceptsAnyImageType(acceptHeader: string): boolean {
-    // A named subtype wins over a wildcard: `image/jpeg,image/*;q=0` enumerates,
-    // it does not leave the door open
-    return !NAMED_IMAGE_TYPE.test(acceptHeader.toLowerCase())
+    // A named subtype enumerates even beside a wildcard, and a q=0 entry names
+    // nothing — it rejects
+    return !parseAccept(acceptHeader).some(
+        (entry) => entry.q > 0 && entry.type.startsWith('image/') && entry.type !== 'image/*'
+    )
 }
 
-/** Whether the client named this exact image type */
+/**
+ * Whether the client will take this type, by the usual most-specific-match
+ * rule: an exact entry decides on its own (including `;q=0`), otherwise the
+ * type wildcard decides, otherwise `*\/*`. An empty Accept accepts anything.
+ */
 export function acceptsImageType(acceptHeader: string, type: string): boolean {
-    return acceptHeader.toLowerCase().includes(type.toLowerCase())
+    const entries = parseAccept(acceptHeader)
+    if (entries.length === 0) {
+        return true
+    }
+
+    const wanted = type.toLowerCase()
+    const wildcard = `${wanted.split('/')[0]}/*`
+    const match = entries.find((entry) => entry.type === wanted) ||
+        entries.find((entry) => entry.type === wildcard) ||
+        entries.find((entry) => entry.type === '*/*')
+
+    return match !== undefined && match.q > 0
 }
 
 /**
@@ -384,11 +418,9 @@ export function applyMatchFallbackFormat(
         return contentType
     }
 
-    // `*/*` counts: browsers that name a few image types still trail a catch-all
-    const canTakePng = acceptsAnyImageType(acceptHeader) ||
-        acceptsImageType(acceptHeader, 'image/png') ||
-        acceptsImageType(acceptHeader, '*/*')
-    if (hasAlpha && canTakePng) {
+    // A trailing `*/*;q=0.8` counts, which is how browsers that name only a few
+    // image types still leave PNG on the table
+    if (hasAlpha && acceptsImageType(acceptHeader, 'image/png')) {
         image.png({force: true, compressionLevel: 9})
         return 'image/png'
     }

--- a/test/proxy-formats.ts
+++ b/test/proxy-formats.ts
@@ -40,6 +40,26 @@ describe('proxy formats', function() {
     after((done) => { server.close(done) })
     after((done) => { imageServer.close(done) })
 
+    // AVIF sources, generated so no binary fixture has to be committed
+    const avifFile = 'generated-test.avif'
+    const avifAlphaFile = 'generated-alpha.avif'
+    before(async function() {
+        this.timeout(30000)
+        await sharp(path.resolve(__dirname, 'test.jpg'))
+            .resize(120)
+            .avif({quality: 50, effort: 0})
+            .toFile(path.resolve(__dirname, avifFile))
+        await sharp({create: {
+            width: 60, height: 60, channels: 4,
+            background: {r: 0, g: 128, b: 255, alpha: 0.5},
+        }}).avif({quality: 50, effort: 0}).toFile(path.resolve(__dirname, avifAlphaFile))
+    })
+    after(() => {
+        for (const file of [avifFile, avifAlphaFile]) {
+            try { fs.unlinkSync(path.resolve(__dirname, file)) } catch (_e) { /* best effort */ }
+        }
+    })
+
     beforeEach(() => { serveFile = 'test.jpg' })
 
     it('should output WebP when requested', async function() {
@@ -88,6 +108,81 @@ describe('proxy formats', function() {
         assert.equal(res.statusCode, 200)
         const meta = await sharp(res.body).metadata()
         assert.equal(meta.format, 'jpeg')
+    })
+
+    it('should convert an AVIF source for a client that did not accept AVIF', async function() {
+        this.slow(2000)
+        this.timeout(10000)
+        serveFile = avifFile
+        const imageUrl = base58Enc(`http://localhost:${imagePort}/avif-no-support.avif`)
+        const res = await needle('get',
+            `http://localhost:${port}/p/${imageUrl}?width=100`,
+            {headers: {accept: 'image/webp,image/apng,image/svg+xml,*/*;q=0.8'}})
+        assert.equal(res.statusCode, 200)
+        // WebP is advertised, so negotiation lands on WebP before Match is reached
+        const meta = await sharp(res.body).metadata()
+        assert.equal(meta.format, 'webp')
+    })
+
+    it('should convert an AVIF source to JPEG for a client accepting neither AVIF nor WebP', async function() {
+        this.slow(2000)
+        this.timeout(10000)
+        serveFile = avifFile
+        const imageUrl = base58Enc(`http://localhost:${imagePort}/avif-old-browser.avif`)
+        const res = await needle('get',
+            `http://localhost:${port}/p/${imageUrl}?width=100`,
+            {headers: {accept: 'image/png,image/jpeg,image/svg+xml,*/*;q=0.8'}})
+        assert.equal(res.statusCode, 200)
+        assert.equal(res.headers['content-type'], 'image/jpeg')
+        const meta = await sharp(res.body).metadata()
+        assert.equal(meta.format, 'jpeg')
+    })
+
+    it('should keep transparency by falling back to PNG', async function() {
+        this.slow(2000)
+        this.timeout(10000)
+        serveFile = avifAlphaFile
+        const imageUrl = base58Enc(`http://localhost:${imagePort}/avif-alpha.avif`)
+        const res = await needle('get',
+            `http://localhost:${port}/p/${imageUrl}?width=30`,
+            {headers: {accept: 'image/png,image/jpeg,*/*;q=0.8'}})
+        assert.equal(res.statusCode, 200)
+        const meta = await sharp(res.body).metadata()
+        assert.equal(meta.format, 'png')
+        assert.equal(meta.hasAlpha, true)
+    })
+
+    it('should pass an AVIF source through to a client that enumerated no image types', async function() {
+        this.slow(2000)
+        this.timeout(10000)
+        serveFile = avifFile
+        const imageUrl = base58Enc(`http://localhost:${imagePort}/avif-bot.avif`)
+        const res = await needle('get',
+            `http://localhost:${port}/p/${imageUrl}?width=100`,
+            {headers: {accept: '*/*'}})
+        assert.equal(res.statusCode, 200)
+        const meta = await sharp(res.body).metadata()
+        assert.equal(meta.format, 'heif')
+    })
+
+    it('should not serve a cached AVIF match variant to a client that cannot decode it', async function() {
+        this.slow(4000)
+        this.timeout(20000)
+        serveFile = avifFile
+        const imageUrl = base58Enc(`http://localhost:${imagePort}/avif-cached-match.avif`)
+        // First request stores the passthrough AVIF under the Match variant key
+        const first = await needle('get',
+            `http://localhost:${port}/p/${imageUrl}?width=100`,
+            {headers: {accept: '*/*'}})
+        assert.equal(first.statusCode, 200)
+        assert.equal((await sharp(first.body).metadata()).format, 'heif')
+
+        // Same key, but this client says it cannot read AVIF
+        const second = await needle('get',
+            `http://localhost:${port}/p/${imageUrl}?width=100`,
+            {headers: {accept: 'image/png,image/jpeg,*/*;q=0.8'}})
+        assert.equal(second.statusCode, 200)
+        assert.equal((await sharp(second.body).metadata()).format, 'jpeg')
     })
 
     it('should handle cover scaling mode', async function() {

--- a/test/proxy-formats.ts
+++ b/test/proxy-formats.ts
@@ -177,12 +177,41 @@ describe('proxy formats', function() {
         assert.equal(first.statusCode, 200)
         assert.equal((await sharp(first.body).metadata()).format, 'heif')
 
-        // Same key, but this client says it cannot read AVIF
+        // The cached variant is converted in place, so the origin is not needed
+        serveFile = 'this-file-does-not-exist.avif'
         const second = await needle('get',
             `http://localhost:${port}/p/${imageUrl}?width=100`,
             {headers: {accept: 'image/png,image/jpeg,*/*;q=0.8'}})
         assert.equal(second.statusCode, 200)
-        assert.equal((await sharp(second.body).metadata()).format, 'jpeg')
+        const meta = await sharp(second.body).metadata()
+        assert.equal(meta.format, 'jpeg')
+        assert.equal(meta.width, 100)
+    })
+
+    it('should treat a named image type as enumeration even next to a wildcard', async function() {
+        this.slow(2000)
+        this.timeout(10000)
+        serveFile = avifFile
+        const imageUrl = base58Enc(`http://localhost:${imagePort}/avif-disabled-wildcard.avif`)
+        const res = await needle('get',
+            `http://localhost:${port}/p/${imageUrl}?width=100`,
+            {headers: {accept: 'image/jpeg,image/*;q=0'}})
+        assert.equal(res.statusCode, 200)
+        assert.equal((await sharp(res.body).metadata()).format, 'jpeg')
+    })
+
+    it('should flatten alpha when the client will not take PNG', async function() {
+        this.slow(2000)
+        this.timeout(10000)
+        serveFile = avifAlphaFile
+        const imageUrl = base58Enc(`http://localhost:${imagePort}/avif-alpha-jpeg-only.avif`)
+        const res = await needle('get',
+            `http://localhost:${port}/p/${imageUrl}?width=30`,
+            {headers: {accept: 'image/jpeg'}})
+        assert.equal(res.statusCode, 200)
+        const meta = await sharp(res.body).metadata()
+        assert.equal(meta.format, 'jpeg')
+        assert.equal(meta.hasAlpha, false)
     })
 
     it('should handle cover scaling mode', async function() {

--- a/test/proxy-formats.ts
+++ b/test/proxy-formats.ts
@@ -200,6 +200,20 @@ describe('proxy formats', function() {
         assert.equal((await sharp(res.body).metadata()).format, 'jpeg')
     })
 
+    it('should flatten alpha when the client rejected PNG', async function() {
+        this.slow(2000)
+        this.timeout(10000)
+        serveFile = avifAlphaFile
+        const imageUrl = base58Enc(`http://localhost:${imagePort}/avif-alpha-png-rejected.avif`)
+        const res = await needle('get',
+            `http://localhost:${port}/p/${imageUrl}?width=30`,
+            {headers: {accept: 'image/jpeg,image/png;q=0,*/*;q=0.8'}})
+        assert.equal(res.statusCode, 200)
+        const rejected = await sharp(res.body).metadata()
+        assert.equal(rejected.format, 'jpeg')
+        assert.equal(rejected.hasAlpha, false)
+    })
+
     it('should flatten alpha when the client will not take PNG', async function() {
         this.slow(2000)
         this.timeout(10000)

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -12,6 +12,9 @@ import {
     safeParseInt,
     supportsWebP,
     supportsAvif,
+    acceptsAnyImageType,
+    acceptsImageType,
+    needsMatchFallback,
     stripWebpOrPng,
     getImageKey,
     getUrlHashKey,
@@ -721,6 +724,62 @@ describe('APIError', function() {
             }, (err: any) => {
                 return err instanceof APIError && err.code === APIError.Code.MissingParam
             })
+        })
+    })
+})
+
+describe('accept header negotiation', function() {
+    describe('acceptsAnyImageType', function() {
+        it('treats a named subtype as enumeration, even beside a wildcard', function() {
+            assert.equal(acceptsAnyImageType('image/webp,image/apng,*/*;q=0.8'), false)
+            assert.equal(acceptsAnyImageType('image/jpeg,image/*;q=0'), false)
+        })
+
+        it('treats a client that names no image type as unknown', function() {
+            assert.equal(acceptsAnyImageType('*/*'), true)
+            assert.equal(acceptsAnyImageType(''), true)
+            assert.equal(acceptsAnyImageType('image/*'), true)
+            assert.equal(acceptsAnyImageType('text/html,application/xhtml+xml'), true)
+        })
+
+        it('ignores types the client rejected outright', function() {
+            assert.equal(acceptsAnyImageType('image/avif;q=0'), true)
+        })
+    })
+
+    describe('acceptsImageType', function() {
+        it('honours an exact entry over any wildcard', function() {
+            assert.equal(acceptsImageType('image/jpeg,image/png;q=0', 'image/png'), false)
+            assert.equal(acceptsImageType('image/png;q=0,*/*;q=0.8', 'image/png'), false)
+            assert.equal(acceptsImageType('image/jpeg,image/png', 'image/png'), true)
+        })
+
+        it('falls back to the type wildcard, then to */*', function() {
+            assert.equal(acceptsImageType('image/*', 'image/png'), true)
+            assert.equal(acceptsImageType('image/webp,*/*;q=0.8', 'image/png'), true)
+            assert.equal(acceptsImageType('image/jpeg', 'image/png'), false)
+        })
+
+        it('accepts anything when the client sent no Accept', function() {
+            assert.equal(acceptsImageType('', 'image/avif'), true)
+        })
+    })
+
+    describe('needsMatchFallback', function() {
+        it('always converts HEIC/HEIF', function() {
+            assert.equal(needsMatchFallback('image/heic', '*/*'), true)
+            assert.equal(needsMatchFallback('image/heif', 'image/webp,*/*;q=0.8'), true)
+        })
+
+        it('converts AVIF only for a client that enumerated without it', function() {
+            assert.equal(needsMatchFallback('image/avif', 'image/png,image/jpeg,*/*;q=0.8'), true)
+            assert.equal(needsMatchFallback('image/avif', '*/*'), false)
+            assert.equal(needsMatchFallback('image/avif', ''), false)
+        })
+
+        it('leaves formats every client can read alone', function() {
+            assert.equal(needsMatchFallback('image/jpeg', 'image/png,*/*;q=0.8'), false)
+            assert.equal(needsMatchFallback('image/webp', 'image/png,*/*;q=0.8'), false)
         })
     })
 })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -765,6 +765,20 @@ describe('accept header negotiation', function() {
         })
     })
 
+    describe('supportsAvif / supportsWebP', function() {
+        it('requires the type to be named, not implied by a wildcard', function() {
+            assert.equal(supportsAvif('image/avif,image/webp,*/*;q=0.8'), true)
+            assert.equal(supportsAvif('image/webp,*/*;q=0.8'), false)
+            assert.equal(supportsWebP('image/webp,*/*;q=0.8'), true)
+            assert.equal(supportsWebP('*/*'), false)
+        })
+
+        it('honours a rejected type so negotiation cannot pick it', function() {
+            assert.equal(supportsAvif('image/avif;q=0,image/webp,*/*;q=0.8'), false)
+            assert.equal(supportsWebP('image/webp;q=0,*/*;q=0.8'), false)
+        })
+    })
+
     describe('needsMatchFallback', function() {
         it('always converts HEIC/HEIF', function() {
             assert.equal(needsMatchFallback('image/heic', '*/*'), true)


### PR DESCRIPTION
## Problem

`format=match` (and no `format` at all) resolves through Accept negotiation: AVIF if the client advertises it, else WebP, else `Match` — which passes the **original bytes** through. An AVIF source therefore reached clients that had just told us they cannot read AVIF, and they got an undecodable image. HEIC/HEIF already had a guard here; AVIF did not.

This matters for any AVIF the proxy touches, whether uploaded to us or linked from another site in a post body.

## Change

- `Match` now transcodes sources the requesting client cannot decode: JPEG, or PNG when the source has alpha so transparency survives. HEIC/HEIF keeps its existing behaviour through the same helper.
- The AVIF guard only fires when the client **enumerated** image types (`image/webp,image/apng,*/*;q=0.8` — what every browser image request looks like) and AVIF was not among them. A client that names no image type at all (`*/*` from bots, curl, unfurlers) still gets the original: it told us nothing about its decoders, and transcoding for it would be spent CPU for no benefit.
- All `Match` responses share one variant cache key regardless of client, so a stored AVIF passthrough is re-derived instead of streamed when the client asking now cannot decode it. The converted variant then replaces it.

## Not covered

- Animated AVIF/WebP still passes through untouched — the animated branch skips the Sharp pipeline on purpose, and transcoding would drop the frames.
- `image-resizer.ts` (avatars/covers) keeps its current `Match` handling; those sources are effectively never AVIF and the endpoints have their own fallback chain.

## Tests

Five cases added to `test/proxy-formats.ts`: enumerated-without-AVIF gets JPEG, WebP-capable clients still negotiate WebP, alpha falls back to PNG, `*/*` still gets the original, and a cached AVIF `Match` variant is not served to a client that cannot decode it. AVIF fixtures are generated at test time rather than committed. Full suite otherwise unchanged (the 4 pre-existing failures on `main` are unrelated and identical before and after).