### PR TITLE
Log the blacklist block message where bunyan can see it

### DIFF
--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -19,7 +19,7 @@ export async function serveOrBuildFallbackImage(
     ctx.tag({handler: 'fallback'})
     const fallbackKey = getImageKey(keyPrefix, options as ProxyOptions)
     ctx.set('ETag', etag(fallbackKey))
-    ctx.log.error({ fallbackKey, msg: 'serveOrBuildFallbackImage, falling back to default'})
+    ctx.log.error({ fallbackKey }, 'serveOrBuildFallbackImage, falling back to default')
 
     const image = Sharp(fallbackBuffer)
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -134,13 +134,13 @@ async function convertCachedMatchVariant(
         const image = buildSharpPipeline(cached, false)
         const contentType = applyMatchFallbackFormat(image, mimeType, acceptHeader, metadata.hasAlpha)
         const buffer = await runEncode(() => image.toBuffer(), options, clientGoneSignal(ctx))
-        ctx.log.debug({mimeType, contentType, msg: 'converted cached match variant for client'})
+        ctx.log.debug({ mimeType, contentType }, 'converted cached match variant for client')
         return {buffer, contentType}
     } catch (err) {
         if (isEncodeAborted(err)) {
             throw err
         }
-        ctx.log.error({err, mimeType, msg: 'failed to convert cached match variant'})
+        ctx.log.error({ err, mimeType }, 'failed to convert cached match variant')
         return {buffer: cached, contentType: mimeType}
     }
 }
@@ -218,7 +218,7 @@ export async function proxyHandler(ctx: KoaContext) {
     if (imageBlacklist.includes(urlString) || isEmptyImageUrl(urlString)) {
         ({ url, urlParams } = getDefaultUrlAndParams())
         isDefaultImage = true
-        ctx.log.error({ msg: 'Falling back to default image due to blacklist or 0x0 URL', urlString })
+        ctx.log.error({ urlString }, 'Falling back to default image due to blacklist or 0x0 URL')
     }
 
     // Handle URLs that start with 0x0/ but have additional content (like proxied URLs)
@@ -234,7 +234,7 @@ export async function proxyHandler(ctx: KoaContext) {
                 urlString = url.toString()
                 ctx.log.debug({ originalUrl: urlString, extractedUrl: actualUrl }, 'Extracted URL from 0x0 prefix')
             } catch (err) {
-                ctx.log.error({ err, msg: 'Failed to parse URL after 0x0 prefix', originalUrl: urlString })
+                ctx.log.error({ err, originalUrl: urlString }, 'Failed to parse URL after 0x0 prefix')
             }
         }
     }
@@ -317,12 +317,12 @@ export async function proxyHandler(ctx: KoaContext) {
         ctx.log.debug('streaming %s from store', imageKey)
         const file = proxyStore.createReadStream(imageKey)
         file.on('error', async (err) => {
-            ctx.log.error({err, msg: 'unable to read', imageKey})
+            ctx.log.error({ err, imageKey }, 'unable to read')
             try {
                 await storeRemove(proxyStore, imageKey)
                 ctx.log.debug({ image: imageKey }, 'removed resized imageKey file')
             } catch (err) {
-                ctx.log.error({err, msg: 'unable to remove onerror', imageKey})
+                ctx.log.error({ err, imageKey }, 'unable to remove onerror')
             }
             file.destroy()
             ctx.res.writeHead(500, 'Internal Error')
@@ -380,7 +380,7 @@ export async function proxyHandler(ctx: KoaContext) {
             // Validate stored data is actually an image — stale error pages or
             // truncated responses may have been cached by a previous request
             if (!AcceptedContentTypes.includes(contentType.toLowerCase())) {
-                ctx.log.warn({contentType, origKey, urlString, msg: 'stored original has invalid content type'})
+                ctx.log.warn({ contentType, origKey, urlString }, 'stored original has invalid content type')
                 // the upload store holds user uploads and rescued (unrefetchable)
                 // originals — never delete from it here
                 if (servingStore !== uploadStore) {
@@ -390,7 +390,7 @@ export async function proxyHandler(ctx: KoaContext) {
             }
         } catch (err) {
             ctx.tag({url: urlString})
-            ctx.log.error({err, urlString, msg: 'storeExist read / mimeMagic failed'})
+            ctx.log.error({ err, urlString }, 'storeExist read / mimeMagic failed')
             const result = await fetchImageWithFallbacks(
                 urlString,
                 urlParams,
@@ -432,7 +432,7 @@ export async function proxyHandler(ctx: KoaContext) {
             res = result.res
             isDefaultImage = result.isFallback
         } catch (err) {
-            ctx.log.error({ err, urlString, msg: 'fetchImageWithFallbacks failed'})
+            ctx.log.error({ err, urlString }, 'fetchImageWithFallbacks failed')
             captureImageFailure('all_fallbacks_failed', ctx, { urlString, error: String(err) })
             throw new APIError({ code: APIError.Code.InvalidImage, info: { fallback: 'true' } })
         }
@@ -442,7 +442,7 @@ export async function proxyHandler(ctx: KoaContext) {
         contentType = contentType.toLowerCase()
 
         if (!AcceptedContentTypes.includes(contentType)) {
-            ctx.log.error({ url: urlString, type: contentType, msg: 'Unsupported content type, defaulted'})
+            ctx.log.error({ url: urlString, type: contentType }, 'Unsupported content type, defaulted')
             captureImageFailure('unsupported_content_type', ctx, { urlString, contentType })
             const fallbackRes = await fetchUrl(DefaultAvatar, {
                 parse_response: false,
@@ -510,13 +510,13 @@ export async function proxyHandler(ctx: KoaContext) {
                 isDefaultImage = true
             }
         } catch (err) {
-            ctx.log.error({ url: urlString, key: imageKey, msg: 'getSharpMetadataWithRetry failed'})
+            ctx.log.error({ url: urlString, key: imageKey }, 'getSharpMetadataWithRetry failed')
             captureImageFailure('metadata_extraction_failed', ctx, { urlString, imageKey, origFromCache, error: String(err) })
             if (origFromCache) {
                 // the upload store holds user uploads and rescued (unrefetchable)
                 // originals — never delete from it here either
                 if (servingStore !== uploadStore) {
-                    ctx.log.warn({origKey, msg: 'purging corrupt cached original after metadata failure'})
+                    ctx.log.warn({ origKey }, 'purging corrupt cached original after metadata failure')
                     try { await storeRemove(servingStore, origKey) } catch (_e) { /* best effort */ }
                 }
                 const fallbackRes = await fetchUrl(DefaultAvatar, {
@@ -624,27 +624,27 @@ export async function proxyHandler(ctx: KoaContext) {
                 // The client gave up while we were queued. Nothing failed, and
                 // there is no socket left to serve the fallback bytes to, so do
                 // not walk the recovery path or report it as a Sharp failure.
-                ctx.log.debug({ urlString, imageKey, msg: 'encode abandoned, client gone' })
+                ctx.log.debug({ urlString, imageKey }, 'encode abandoned, client gone')
                 throw err
             }
-            ctx.log.error({ err, urlString, imageKey, msg: 'sharp.toBuffer() failed' })
+            ctx.log.error({ err, urlString, imageKey }, 'sharp.toBuffer() failed')
             captureImageFailure('sharp_tobuffer_failed', ctx, { urlString, imageKey, origIsUpload, origFromCache, error: String(err) })
             if (origIsUpload) {
                 // Sharp can't decode this image (e.g. unsupported HEIF/AVIF bitstream)
                 // but browsers likely can — serve the original unresized bytes
-                ctx.log.warn({origKey, msg: 'serving original upload bytes after toBuffer failure'})
+                ctx.log.warn({ origKey }, 'serving original upload bytes after toBuffer failure')
                 rv = origData
                 contentType = await mimeMagic(origData)
             } else if (origFromCache) {
                 // Sharp can't process this image (e.g. truncated JPEG) but browsers
                 // are lenient and will render it fine — serve the original bytes
-                ctx.log.warn({origKey, msg: 'serving original bytes after toBuffer failure on cached image'})
+                ctx.log.warn({ origKey }, 'serving original bytes after toBuffer failure on cached image')
                 try { await storeRemove(proxyStore, imageKey) } catch (_e) { /* best effort */ }
                 rv = origData
                 contentType = await mimeMagic(origData)
             } else {
                 // Sharp can't process but browsers are lenient — serve original bytes
-                ctx.log.warn({origKey, msg: 'serving original bytes after toBuffer failure on fetched image'})
+                ctx.log.warn({ origKey }, 'serving original bytes after toBuffer failure on fetched image')
                 rv = origData
                 contentType = await mimeMagic(origData)
             }
@@ -667,7 +667,7 @@ export async function proxyHandler(ctx: KoaContext) {
     // Vary on Accept header for proper content negotiation caching
     ctx.set('Vary', 'Accept')
     if (isDefaultImage) {
-        ctx.log.error({ msg: 'Responding with default image', finalUrl: urlString })
+        ctx.log.error({ finalUrl: urlString }, 'Responding with default image')
         ctx.set('Cache-Control', 'public,max-age=600') // 10 minutes
     } else {
         ctx.set('Cache-Control', 'public,max-age=31536000,immutable') // 1 year

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -192,7 +192,7 @@ export async function getSharpMetadataWithRetry(
         const metadata = await image.metadata()
         return { buffer: origData, metadata, isFallback: false }
     } catch (err) {
-        logger.error({err, urlString, msg: 'Sharp metadata() failed, attempting fallback image fetch'})
+        logger.error({ err, urlString }, 'Sharp metadata() failed, attempting fallback image fetch')
 
         // Try alternate source once
         let fallback
@@ -203,10 +203,9 @@ export async function getSharpMetadataWithRetry(
         } catch (fetchErr) {
             logger.error({
                 err: fetchErr,
-                msg: 'metadata fallback fetch also failed',
                 urlString,
                 fallbackUrl
-            })
+            }, 'metadata fallback fetch also failed')
             throw err // rethrow original metadata error
         }
 
@@ -217,10 +216,9 @@ export async function getSharpMetadataWithRetry(
         } catch (err2) {
             logger.error({
                 err: err2,
-                msg: 'metadata() failed even after fallback fetch',
                 urlString,
                 fallbackUrl
-            })
+            }, 'metadata() failed even after fallback fetch')
             throw err2
         }
     }

--- a/test/logging.ts
+++ b/test/logging.ts
@@ -1,0 +1,33 @@
+import 'mocha'
+import assert from 'assert'
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * Bunyan takes the message as its second argument. A `msg` key inside the
+ * fields object is overwritten by the (empty) message, so the text never
+ * reaches the log record — the line is emitted as `"msg":""` and becomes
+ * invisible to log search and to anything alerting on it.
+ */
+const MSG_IN_FIELDS = /\.(?:error|warn|info|debug|fatal|trace)\(\s*\{[^{}]*\bmsg\s*:/
+
+describe('logging', function() {
+    it('never passes msg inside the logger fields object', function() {
+        // mocha runs from the repo root; __dirname is unavailable when ts-node
+        // treats the file as an ES module
+        const srcDir = path.resolve(process.cwd(), 'src')
+        const offenders: string[] = []
+
+        for (const file of fs.readdirSync(srcDir).filter((f) => f.endsWith('.ts'))) {
+            const contents = fs.readFileSync(path.join(srcDir, file), 'utf8')
+            // Match across line breaks: these calls are often wrapped over several lines
+            const collapsed = contents.replace(/\r?\n\s*/g, ' ')
+            if (MSG_IN_FIELDS.test(collapsed)) {
+                offenders.push(file)
+            }
+        }
+
+        assert.deepEqual(offenders, [],
+            `pass the message as the second argument instead: ${offenders.join(', ')}`)
+    })
+})

--- a/test/logging.ts
+++ b/test/logging.ts
@@ -9,7 +9,53 @@ import * as path from 'path'
  * reaches the log record — the line is emitted as `"msg":""` and becomes
  * invisible to log search and to anything alerting on it.
  */
-const MSG_IN_FIELDS = /\.(?:error|warn|info|debug|fatal|trace)\(\s*\{[^{}]*\bmsg\s*:/
+const LOG_CALL = /\.(?:error|warn|info|debug|fatal|trace)\(\s*\{/g
+
+/**
+ * Walk the object literal that starts at `start` (the index of its `{`) and
+ * report whether it has a top-level `msg` key. Nested objects are skipped by
+ * depth rather than by a character class, so `{ info: { a: 1 }, msg: 'x' }` is
+ * still caught, and `msg` inside a string or a nested object is not.
+ */
+function hasTopLevelMsgKey(source: string, start: number): boolean {
+    let depth = 0
+    let quote: string | null = null
+
+    for (let i = start; i < source.length; i++) {
+        const char = source[i]
+
+        if (quote) {
+            if (char === '\\') { i++ } else if (char === quote) { quote = null }
+            continue
+        }
+
+        if (char === '"' || char === "'" || char === '`') { quote = char; continue }
+        if (char === '/' && source[i + 1] === '/') { i = source.indexOf('\n', i); if (i === -1) { return false } ; continue }
+        if (char === '/' && source[i + 1] === '*') { i = source.indexOf('*/', i); if (i === -1) { return false } ; i++; continue }
+        if (char === '{' || char === '(' || char === '[') { depth++; continue }
+        if (char === '}' || char === ')' || char === ']') {
+            depth--
+            if (depth === 0) { return false } // end of the fields object
+            continue
+        }
+
+        if (depth === 1 && /msg/.test(source.slice(i, i + 3)) && /^\s*:/.test(source.slice(i + 3))) {
+            // only a standalone key, not a suffix like `errMsg:`
+            const before = source[i - 1] || ''
+            if (!/[A-Za-z0-9_$]/.test(before)) { return true }
+        }
+    }
+
+    return false
+}
+
+function collectSourceFiles(dir: string): string[] {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const full = path.join(dir, entry.name)
+        if (entry.isDirectory()) { return collectSourceFiles(full) }
+        return entry.isFile() && full.endsWith('.ts') ? [full] : []
+    })
+}
 
 describe('logging', function() {
     it('never passes msg inside the logger fields object', function() {
@@ -18,12 +64,16 @@ describe('logging', function() {
         const srcDir = path.resolve(process.cwd(), 'src')
         const offenders: string[] = []
 
-        for (const file of fs.readdirSync(srcDir).filter((f) => f.endsWith('.ts'))) {
-            const contents = fs.readFileSync(path.join(srcDir, file), 'utf8')
-            // Match across line breaks: these calls are often wrapped over several lines
-            const collapsed = contents.replace(/\r?\n\s*/g, ' ')
-            if (MSG_IN_FIELDS.test(collapsed)) {
-                offenders.push(file)
+        for (const file of collectSourceFiles(srcDir)) {
+            const contents = fs.readFileSync(file, 'utf8')
+            LOG_CALL.lastIndex = 0
+            let match = LOG_CALL.exec(contents)
+            while (match !== null) {
+                if (hasTopLevelMsgKey(contents, match.index + match[0].length - 1)) {
+                    offenders.push(path.relative(srcDir, file))
+                    break
+                }
+                match = LOG_CALL.exec(contents)
             }
         }
 

--- a/test/logging.ts
+++ b/test/logging.ts
@@ -49,10 +49,17 @@ function hasTopLevelMsgKey(source: string, start: number): boolean {
             continue
         }
 
-        if (depth === 1 && /msg/.test(source.slice(i, i + 3)) && /^\s*:/.test(source.slice(i + 3))) {
-            // only a standalone key, not a suffix like `errMsg:`
+        if (depth === 1 && source.slice(i, i + 3) === 'msg') {
+            // only a standalone identifier, not a suffix like `errMsg`
             const before = source[i - 1] || ''
-            if (!/[A-Za-z0-9_$]/.test(before)) { return true }
+            const after = source.slice(i + 3)
+            // `msg: x` sets the key; so does the shorthand `{ err, msg }`, but
+            // only in key position — in `{ detail: msg }` it is just a value
+            const isKeyPosition = /[{,]\s*$/.test(source.slice(start, i))
+            if (!/[A-Za-z0-9_$]/.test(before) &&
+                (/^\s*:/.test(after) || (isKeyPosition && /^\s*[,}]/.test(after)))) {
+                return true
+            }
         }
     }
 

--- a/test/logging.ts
+++ b/test/logging.ts
@@ -20,16 +20,26 @@ const LOG_CALL = /\.(?:error|warn|info|debug|fatal|trace)\(\s*\{/g
 function hasTopLevelMsgKey(source: string, start: number): boolean {
     let depth = 0
     let quote: string | null = null
+    let quoteStart = 0
 
     for (let i = start; i < source.length; i++) {
         const char = source[i]
 
         if (quote) {
-            if (char === '\\') { i++ } else if (char === quote) { quote = null }
+            if (char === '\\') {
+                i++
+            } else if (char === quote) {
+                // a quoted key counts as much as a bare one: { 'msg': 'x' }
+                if (depth === 1 && source.slice(quoteStart + 1, i) === 'msg' &&
+                    /^\s*:/.test(source.slice(i + 1))) {
+                    return true
+                }
+                quote = null
+            }
             continue
         }
 
-        if (char === '"' || char === "'" || char === '`') { quote = char; continue }
+        if (char === '"' || char === "'" || char === '`') { quote = char; quoteStart = i; continue }
         if (char === '/' && source[i + 1] === '/') { i = source.indexOf('\n', i); if (i === -1) { return false } ; continue }
         if (char === '/' && source[i + 1] === '*') { i = source.indexOf('*/', i); if (i === -1) { return false } ; i++; continue }
         if (char === '{' || char === '(' || char === '[') { depth++; continue }


### PR DESCRIPTION
## What

`ctx.log.error({ msg: 'Falling back to default image due to blacklist or 0x0 URL', urlString })` never logs that text. Bunyan takes the message as its **second** argument, so a `msg` key inside the fields object is overwritten by the (empty) message and the record comes out as `"level":50,"msg":""`.

Consequence: a DMCA block leaves no searchable trace. Chasing "is the blacklist even working?" on the box, every grep for the message came back empty while the block was in fact firing correctly - the only visible evidence was an unexplained empty-message error line. Anything alerting or dashboarding on that text has been blind too.

The same shape had spread to 22 call sites across `proxy.ts`, `fallback.ts` and `utils.ts` - two of which I added myself last week by copying the surrounding style. All are moved to `log(fields, message)`.

## Not changed

The static `blacklist-*.json` files still are not copied into the runtime image, which logs `blacklist file not found` on startup. That is correct as-is: the lists are fetched from the configured remote endpoints (verified loading 2480 images / 364 accounts per worker), and the static files are only a fallback. Shipping them in the image would mask a remote-fetch outage rather than help.

## Tests

Adds `test/logging.ts`, which scans `src` for the pattern - verified it fails when the old form is reintroduced and passes otherwise. Full suite: 241 passing, with the same 4 pre-existing failures as `main`.