### PR TITLE
Bound Sharp memory, flatten animated avatars/covers, reap healthcheck zombies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ FROM node:20-bookworm-slim
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  wget \
+  wget tini \
   # Runtime shared library dependencies for libvips
   libglib2.0-0 libexpat1 \
   libjpeg62-turbo libpng16-16 libwebp7 libwebpdemux2 libwebpmux3 \
@@ -142,8 +142,16 @@ COPY --from=build /app/node_modules node_modules
 EXPOSE 8800
 ENV PORT=8800
 ENV NODE_ENV=production
+# Cap glibc per-thread malloc arenas: libvips spins up many native threads per
+# worker and the default arena-per-thread strategy fragments badly, ballooning
+# RSS until the box swaps. 2 arenas trades negligible alloc concurrency for far
+# lower, stable RSS.
+ENV MALLOC_ARENA_MAX=2
 
 HEALTHCHECK --interval=20s --timeout=10s --start-period=5s \
   CMD /bin/sh -c 'wget -nv -t1 --spider "http://localhost:${PORT}/healthcheck" || exit 1'
 
+# tini as PID 1 reaps zombies. Node as PID 1 does not reap the /bin/sh that the
+# HEALTHCHECK spawns every 20s, so those accumulate as <defunct> processes.
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["node", "lib/app.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ ENV NODE_ENV=production
 ENV MALLOC_ARENA_MAX=2
 
 HEALTHCHECK --interval=20s --timeout=10s --start-period=5s \
-  CMD /bin/sh -c 'wget -nv -t1 --spider "http://localhost:${PORT}/healthcheck" || exit 1'
+  CMD /bin/sh -c 'wget -nv -t1 -O /dev/null "http://localhost:${PORT}/healthcheck" || exit 1'
 
 # tini as PID 1 reaps zombies. Node as PID 1 does not reap the /bin/sh that the
 # HEALTHCHECK spawns every 20s, so those accumulate as <defunct> processes.

--- a/config/default.toml
+++ b/config/default.toml
@@ -50,7 +50,13 @@ log_level = 'error'
 log_output = 'stdout'
 
 # max image size to allow uploading and proxying, in bytes
-max_image_size = 30000000 # 25mb
+max_image_size = 20000000 # 20mb
+
+# Reject decompression bombs: maximum input pixels (width*height) Sharp will
+# decode. 100 MP (~10000x10000) admits all real-world photos and phone cameras
+# while blocking pathological inputs that would otherwise decode to ~1GB+ of raw
+# bitmap and exhaust worker memory (a 16000x16000 image is ~1GB decoded).
+max_input_pixels = 100000000
 
 # redis db used for ratelimiting uploads
 # redis_url = 'redis://localhost'

--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -195,7 +195,8 @@ async function handleAvatar(ctx: KoaContext) {
       ctx.get('user-agent') || '',
       DefaultAvatar,
       ctx.log,
-      clientGoneSignal(ctx)
+      clientGoneSignal(ctx),
+      true // forceStill: avatars never need animation
   )
   contentType = finalType
   isResizeFallback = isFallback

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,9 +36,12 @@ export const AVIF_EFFORT = 2
  * push workers into swap. Configurable via `max_input_pixels`; defaults to
  * 100 MP, which admits all real-world photos while rejecting the pathological.
  */
-export const MAX_INPUT_PIXELS = config.has('max_input_pixels')
-    ? (parseInt(config.get('max_input_pixels') as string, 10) || 100_000_000)
-    : 100_000_000
+export const MAX_INPUT_PIXELS = (() => {
+    if (!config.has('max_input_pixels')) { return 100_000_000 }
+    // TOML parses this as a number; Number() also tolerates a string override.
+    const v = Number(config.get('max_input_pixels'))
+    return Number.isSafeInteger(v) && v > 0 ? v : 100_000_000
+})()
 
 /** Special empty image indicator - used to denote "proxy without resizing" */
 export const SPECIAL_EMPTY_IMAGE_PATH = '0x0'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,17 @@ export const INTERNAL_SERVICE_ORIGINS = INTERNAL_SERVICE_BASE_URLS.map((url) => 
  */
 export const AVIF_EFFORT = 2
 
+/**
+ * Maximum input pixels (width * height) Sharp will decode before throwing.
+ * Guards worker memory against decompression bombs and huge-dimension images: a
+ * 16000x16000 image decodes to ~1GB of raw RGBA, and a handful in flight will
+ * push workers into swap. Configurable via `max_input_pixels`; defaults to
+ * 100 MP, which admits all real-world photos while rejecting the pathological.
+ */
+export const MAX_INPUT_PIXELS = config.has('max_input_pixels')
+    ? (parseInt(config.get('max_input_pixels') as string, 10) || 100_000_000)
+    : 100_000_000
+
 /** Special empty image indicator - used to denote "proxy without resizing" */
 export const SPECIAL_EMPTY_IMAGE_PATH = '0x0'
 

--- a/src/cover.ts
+++ b/src/cover.ts
@@ -188,7 +188,8 @@ async function handleCover(ctx: KoaContext) {
       ctx.get('user-agent') || '',
       DefaultCover,
       ctx.log,
-      clientGoneSignal(ctx)
+      clientGoneSignal(ctx),
+      true // forceStill: covers never need animation
   )
   contentType = finalType
   isResizeFallback = isFallback

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -2,7 +2,7 @@ import etag from 'etag'
 import Sharp from 'sharp'
 import {KoaContext} from './common'
 import {clientGoneSignal, runEncode} from './encode-limit'
-import { AVIF_EFFORT } from './constants'
+import { AVIF_EFFORT, MAX_INPUT_PIXELS } from './constants'
 import {getImageKey, OutputFormat, ProxyOptions, ScalingMode} from './utils'
 
 export async function serveOrBuildFallbackImage(
@@ -21,7 +21,7 @@ export async function serveOrBuildFallbackImage(
     ctx.set('ETag', etag(fallbackKey))
     ctx.log.error({ fallbackKey }, 'serveOrBuildFallbackImage, falling back to default')
 
-    const image = Sharp(fallbackBuffer)
+    const image = Sharp(fallbackBuffer, { limitInputPixels: MAX_INPUT_PIXELS })
 
     switch (options.mode) {
         case ScalingMode.Cover:

--- a/src/image-resizer.ts
+++ b/src/image-resizer.ts
@@ -21,7 +21,12 @@ export async function resizeImageWithOptions(
     // is still there. Leaving it optional let a caller silently omit it and
     // reintroduce unremovable queue waiters. Pass `undefined` deliberately for
     // non-request callers.
-    signal: AbortSignal | undefined
+    signal: AbortSignal | undefined,
+    // Avatars and covers are fixed-size profile images that do not need animation.
+    // When true, an animated source is flattened to its first frame instead of
+    // passed through — far cheaper to decode/store and it keeps large animated
+    // GIFs out of worker memory.
+    forceStill: boolean = false,
 ): Promise<{ buffer: Buffer; contentType: string; isFallback: boolean }> {
     let isAnimated = contentType === 'image/gif' || contentType === 'image/apng'
 
@@ -49,13 +54,17 @@ export async function resizeImageWithOptions(
 
     APIError.assert(meta.width && meta.height, APIError.Code.InvalidImage)
 
-    // Animated images (GIF/APNG): skip Sharp pipeline entirely to preserve animation.
-    // Sharp resize can strip frames even with animated:true, so passthrough is the only safe option.
-    if (isAnimated) {
+    // Animated images (GIF/APNG): preserve animation by passing the original
+    // through untouched — Sharp resize can strip frames even with animated:true.
+    // Callers that set forceStill (avatars/covers) opt out and fall through to
+    // render only the first frame below.
+    if (isAnimated && !forceStill) {
         return { buffer: origData, contentType, isFallback }
     }
 
-    const image = buildSharpPipeline(origData, isAnimated)
+    // First frame only. Reaching here with isAnimated true implies forceStill, so
+    // we never decode every frame — that is the memory-heavy path we are avoiding.
+    const image = buildSharpPipeline(origData, false)
 
     const { maxWidth, maxHeight, maxCustomWidth, maxCustomHeight } = getProxyImageLimits()
     let width = safeParseInt(options.width)
@@ -93,6 +102,11 @@ export async function resizeImageWithOptions(
             } else if (contentType === 'image/heic' || contentType === 'image/heif') {
                 contentType = 'image/jpeg'
                 image.jpeg({ quality: 80, force: true })
+            } else if (forceStill && isAnimated) {
+                // Client negotiated neither WebP nor AVIF: emit a still PNG so we
+                // never ship a (single-frame) GIF from a flattened animation.
+                contentType = 'image/png'
+                image.png({ quality: 80, compressionLevel: 9, force: true })
             }
             break
         case OutputFormat.WEBP:

--- a/src/image-resizer.ts
+++ b/src/image-resizer.ts
@@ -105,8 +105,10 @@ export async function resizeImageWithOptions(
             } else if (forceStill && isAnimated) {
                 // Client negotiated neither WebP nor AVIF: emit a still PNG so we
                 // never ship a (single-frame) GIF from a flattened animation.
+                // quality is a no-op for full-colour PNG (only palette mode), so
+                // only compressionLevel is set.
                 contentType = 'image/png'
-                image.png({ quality: 80, compressionLevel: 9, force: true })
+                image.png({ compressionLevel: 9, force: true })
             }
             break
         case OutputFormat.WEBP:

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,7 +10,7 @@ import streamHead from 'stream-head/dist-es6'
 import {URL} from 'url'
 import {imageBlacklist} from './blacklist'
 import {KoaContext, proxyStore, uploadStore} from './common'
-import { AVIF_EFFORT, EMPTY_IMAGE_URL_PATTERNS, applyUrlReplacements, isEmptyImageUrl } from './constants'
+import { AVIF_EFFORT, EMPTY_IMAGE_URL_PATTERNS, applyUrlReplacements, isEmptyImageUrl, MAX_INPUT_PIXELS } from './constants'
 import {APIError} from './error'
 import {serveOrBuildFallbackImage} from './fallback'
 import {clientGoneSignal, isEncodeAborted, runEncode} from './encode-limit'
@@ -126,7 +126,7 @@ async function convertCachedMatchVariant(
     options: ProxyOptions
 ): Promise<{buffer: Buffer, contentType: string}> {
     try {
-        const metadata = await Sharp(cached).metadata()
+        const metadata = await Sharp(cached, { limitInputPixels: MAX_INPUT_PIXELS }).metadata()
         if (metadata.pages != null && metadata.pages > 1) {
             // Transcoding an animated source here would drop its frames
             return {buffer: cached, contentType: mimeType}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -4,7 +4,7 @@ import {readStream} from './utils'
 import {KoaContext, uploadStore} from './common'
 import {APIError} from './error'
 import {imageBlacklist} from './blacklist'
-import {DEFAULT_AVATAR_HASH, isEmptyImageUrl, SERVICE_BASE_URL} from './constants'
+import {DEFAULT_AVATAR_HASH, isEmptyImageUrl, MAX_INPUT_PIXELS, SERVICE_BASE_URL} from './constants'
 import Sharp from 'sharp'
 
 function detectMimeType(metadata: Sharp.Metadata): string {
@@ -59,7 +59,7 @@ export async function serveHandler(ctx: KoaContext) {
 
     let mimeType = 'application/octet-stream'
     try {
-        const metadata = await Sharp(buffer).metadata()
+        const metadata = await Sharp(buffer, { limitInputPixels: MAX_INPUT_PIXELS }).metadata()
         mimeType = detectMimeType(metadata)
     } catch (err) {
         ctx.log.warn(err, 'Sharp metadata detection failed')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ import Sharp from 'sharp'
 import { URL } from 'url'
 
 import { imageBlacklist } from './blacklist'
-import { DEFAULT_FALLBACK_IMAGE_URL, INTERNAL_SERVICE_ORIGINS, isEmptyImageUrl } from './constants'
+import { DEFAULT_FALLBACK_IMAGE_URL, INTERNAL_SERVICE_ORIGINS, isEmptyImageUrl, MAX_INPUT_PIXELS } from './constants'
 import { APIError } from './error'
 import {fetchImageWithFallbacks} from './fetch-image'
 import { logger } from './logger'
@@ -186,7 +186,7 @@ export async function getSharpMetadataWithRetry(
     fallbackUrl: string,
     logger: any
 ): Promise<{ buffer: Buffer; metadata: Sharp.Metadata; isFallback: boolean }> {
-    const image = Sharp(origData, { failOnError: false })
+    const image = Sharp(origData, { failOnError: false, limitInputPixels: MAX_INPUT_PIXELS })
 
     try {
         const metadata = await image.metadata()
@@ -209,7 +209,7 @@ export async function getSharpMetadataWithRetry(
             throw err // rethrow original metadata error
         }
 
-        const fallbackImage = Sharp(fallback.res.body, { failOnError: false })
+        const fallbackImage = Sharp(fallback.res.body, { failOnError: false, limitInputPixels: MAX_INPUT_PIXELS })
         try {
             const metadata = await fallbackImage.metadata()
             return { buffer: fallback.res.body, metadata, isFallback: fallback.isFallback }
@@ -464,7 +464,7 @@ export function getOrigKeyFromUrl(url: URL, isUpload: boolean): string {
     return 'U' + multihash.toB58String(multihash.encode(urlHash, 'sha1'))
 }
 export function buildSharpPipeline(buffer: Buffer, animated: boolean = false) {
-    return Sharp(buffer, { failOnError: false, animated })
+    return Sharp(buffer, { failOnError: false, animated, limitInputPixels: MAX_INPUT_PIXELS })
 }
 
 function isPrivateIPv4(host: string): boolean {


### PR DESCRIPTION
Hardens the image service against the memory-exhaustion / swap-thrash failure mode where worker RSS grows unbounded under load until the host pages to disk (iowait spike, 503s).

### Changes
- **`limitInputPixels` on every Sharp decode/metadata path** (`max_input_pixels`, default **100 MP**). A `16000x16000` image otherwise decodes to ~1GB of raw bitmap with no cap — the biggest per-request memory spike. 100 MP admits all real-world photos/phone cameras while rejecting pathological inputs; tune lower in config if desired (values below ~50 MP start rejecting legitimate high-res uploads).
- **Flatten animated GIF/APNG to a still first frame for avatars and covers** (new `forceStill` arg). These are fixed-size profile images that don't need animation; currently an animated avatar bypasses the 256px resize and ships/stores the full multi-MB GIF on every cache miss (bandwidth + disk write + a large in-RAM buffer). Post images (`/p/`) are unchanged and keep their animation.
- **`MALLOC_ARENA_MAX=2`** in the runtime image. libvips spins up many native threads per worker; the default glibc arena-per-thread strategy fragments badly and RSS climbs monotonically. Capping arenas keeps worker RSS low and stable.
- **`tini` as PID 1** (`ENTRYPOINT`). Node as PID 1 does not reap the `/bin/sh` the `HEALTHCHECK` spawns every 20s, so they accumulate as `<defunct>` zombies.
- **`max_image_size` 30MB -> 20MB**.

### Testing
- `tsc -p tsconfig.json --noEmit` clean.
- Test suite: **241 passing, 4 failing** — the 4 are pre-existing test-config failures (test.toml points `service_url` at localhost), identical on clean `main`; this branch adds no new failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Animated avatar and cover images are now delivered as still images.
  - Added protection against processing excessively large images.

- **Bug Fixes**
  - Improved container process handling to reduce lingering healthcheck processes.
  - Improved reliability when processing fallback and cached image variants.

- **Configuration**
  - Reduced the maximum image upload size from 30 MB to 20 MB.
  - Added runtime safeguards to limit memory usage during image processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->