### PR TITLE
Add retention store tier and temporary origin bridge

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -62,6 +62,10 @@ max_input_pixels = 100000000
 # originals this instance has not received yet (e.g. mid-migration). Tried after
 # the source URL but before the public mirrors, so live origins are unaffected
 # and only the dead-origin tail reaches it. Unset once migration completes.
+#
+# MUST be publicly routable: every candidate is checked by assertPublicUrl, so a
+# private/loopback address (10.x, 172.16-31.x, 192.168.x, 127.x) is skipped with
+# a warning and the bridge silently does nothing.
 # bridge_origin = 'http://198.51.100.10'
 
 # redis db used for ratelimiting uploads

--- a/config/default.toml
+++ b/config/default.toml
@@ -58,6 +58,12 @@ max_image_size = 20000000 # 20mb
 # bitmap and exhaust worker memory (a 16000x16000 image is ~1GB decoded).
 max_input_pixels = 100000000
 
+# Optional temporary bridge to another imagehoster origin that still holds
+# originals this instance has not received yet (e.g. mid-migration). Tried after
+# the source URL but before the public mirrors, so live origins are unaffected
+# and only the dead-origin tail reaches it. Unset once migration completes.
+# bridge_origin = 'http://198.51.100.10'
+
 # redis db used for ratelimiting uploads
 # redis_url = 'redis://localhost'
 redis_url = 'redis://myredis'
@@ -109,3 +115,11 @@ max_image_width = 1280
 max_image_height = 1280
 max_custom_image_width = 2000
 max_custom_image_height = 2000
+
+# Optional durable archive of originals whose upstream no longer exists.
+# Consulted on a local proxy-store miss, BEFORE any network fetch. Like the
+# upload store it is an origin and not a cache, so cache-bypass flags never skip
+# it. Same store types as upload_store/proxy_store. Leave unset to disable.
+# [retention_store]
+# type = 's3'
+# s3_bucket = 'eretention'

--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -150,15 +150,28 @@ async function handleAvatar(ctx: KoaContext) {
   let isFetchFallback = false
   let isResizeFallback = false
 
-  if (await storeExists(origStore, origKey) && !shouldBypassCache) {
+  const haveLocalOriginal = await storeExists(origStore, origKey) && !shouldBypassCache
+  // Archive of originals whose upstream is gone. An origin, not a cache, so
+  // cache-bypass flags deliberately do not skip it. An object-store outage must
+  // not fail the request, so any error falls through to the normal fetch path.
+  let retentionData: Buffer | undefined
+  if (!haveLocalOriginal && retentionStore) {
+    try {
+      if (await storeExists(retentionStore, origKey)) {
+        retentionData = await readStream(retentionStore.createReadStream(origKey))
+      }
+    } catch (err) {
+      ctx.log.warn({ err, origKey }, 'retention store lookup failed, falling through to fetch')
+    }
+  }
+
+  if (haveLocalOriginal) {
     ctx.tag({ store: 'original' })
     origData = await readStream(origStore.createReadStream(origKey))
     contentType = await mimeMagic(origData)
-  } else if (retentionStore && await storeExists(retentionStore, origKey)) {
-    // Archive of originals whose upstream is gone. An origin, not a cache, so
-    // cache-bypass flags deliberately do not skip it.
+  } else if (retentionData) {
     ctx.tag({ store: 'retention' })
-    origData = await readStream(retentionStore.createReadStream(origKey))
+    origData = retentionData
     contentType = await mimeMagic(origData)
   } else {
     ctx.tag({ store: 'fetch' })

--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -8,7 +8,7 @@ import {fetchImageWithFallbacks} from './fetch-image'
 import {clientGoneSignal} from './encode-limit'
 import {resizeImageWithOptions} from './image-resizer'
 
-import { getProfile, KoaContext, proxyStore, uploadStore } from './common'
+import { getProfile, KoaContext, proxyStore, retentionStore, uploadStore } from './common'
 import { APIError } from './error'
 import {
   getDefaultUrlAndParams,
@@ -153,6 +153,12 @@ async function handleAvatar(ctx: KoaContext) {
   if (await storeExists(origStore, origKey) && !shouldBypassCache) {
     ctx.tag({ store: 'original' })
     origData = await readStream(origStore.createReadStream(origKey))
+    contentType = await mimeMagic(origData)
+  } else if (retentionStore && await storeExists(retentionStore, origKey)) {
+    // Archive of originals whose upstream is gone. An origin, not a cache, so
+    // cache-bypass flags deliberately do not skip it.
+    ctx.tag({ store: 'retention' })
+    origData = await readStream(retentionStore.createReadStream(origKey))
     contentType = await mimeMagic(origData)
   } else {
     ctx.tag({ store: 'fetch' })

--- a/src/common.ts
+++ b/src/common.ts
@@ -348,3 +348,14 @@ function loadStore(key: string): AbstractBlobStore {
 // Primary process only manages workers — no stores needed
 export const uploadStore: AbstractBlobStore = isPrimaryOnly ? undefined! : loadStore('upload_store')
 export const proxyStore: AbstractBlobStore = isPrimaryOnly ? undefined! : loadStore('proxy_store')
+
+/**
+ * Optional durable archive of originals whose upstream no longer exists.
+ *
+ * Like the upload store, this is an ORIGIN and not a cache: it is consulted
+ * whenever the local original is absent, and cache-bypass flags never skip it,
+ * because there is no live origin left to refetch from. Undefined when
+ * `retention_store` is not configured, so every read site must null-check.
+ */
+export const retentionStore: AbstractBlobStore | undefined =
+    (isPrimaryOnly || !config.has('retention_store')) ? undefined : loadStore('retention_store')

--- a/src/common.ts
+++ b/src/common.ts
@@ -359,3 +359,15 @@ export const proxyStore: AbstractBlobStore = isPrimaryOnly ? undefined! : loadSt
  */
 export const retentionStore: AbstractBlobStore | undefined =
     (isPrimaryOnly || !config.has('retention_store')) ? undefined : loadStore('retention_store')
+
+/**
+ * Stores holding irreplaceable originals, which must NEVER be auto-deleted from.
+ *
+ * The corrupt-content and metadata-failure recovery paths purge the serving
+ * store so a bad entry can be refetched. That is safe for a cache, but for these
+ * archives a transient or unsupported-format failure would destroy the only
+ * surviving copy — there is no upstream left to refetch from.
+ */
+export function isArchiveStore(store: AbstractBlobStore): boolean {
+    return store === uploadStore || (retentionStore !== undefined && store === retentionStore)
+}

--- a/src/cover.ts
+++ b/src/cover.ts
@@ -146,15 +146,28 @@ async function handleCover(ctx: KoaContext) {
   let isFetchFallback = false
   let isResizeFallback = false
 
-  if (await storeExists(origStore, origKey) && !shouldBypassCache) {
+  const haveLocalOriginal = await storeExists(origStore, origKey) && !shouldBypassCache
+  // Archive of originals whose upstream is gone. An origin, not a cache, so
+  // cache-bypass flags deliberately do not skip it. An object-store outage must
+  // not fail the request, so any error falls through to the normal fetch path.
+  let retentionData: Buffer | undefined
+  if (!haveLocalOriginal && retentionStore) {
+    try {
+      if (await storeExists(retentionStore, origKey)) {
+        retentionData = await readStream(retentionStore.createReadStream(origKey))
+      }
+    } catch (err) {
+      ctx.log.warn({ err, origKey }, 'retention store lookup failed, falling through to fetch')
+    }
+  }
+
+  if (haveLocalOriginal) {
     ctx.tag({ store: 'original' })
     origData = await readStream(origStore.createReadStream(origKey))
     contentType = await mimeMagic(origData)
-  } else if (retentionStore && await storeExists(retentionStore, origKey)) {
-    // Archive of originals whose upstream is gone. An origin, not a cache, so
-    // cache-bypass flags deliberately do not skip it.
+  } else if (retentionData) {
     ctx.tag({ store: 'retention' })
-    origData = await readStream(retentionStore.createReadStream(origKey))
+    origData = retentionData
     contentType = await mimeMagic(origData)
   } else {
     ctx.tag({ store: 'fetch' })

--- a/src/cover.ts
+++ b/src/cover.ts
@@ -5,7 +5,7 @@ import config from 'config'
 import etag from 'etag'
 import {URL} from 'url'
 
-import { getProfile, KoaContext, proxyStore, uploadStore } from './common'
+import { getProfile, KoaContext, proxyStore, retentionStore, uploadStore } from './common'
 import { APIError } from './error'
 import {fetchImageWithFallbacks} from './fetch-image'
 import {clientGoneSignal} from './encode-limit'
@@ -149,6 +149,12 @@ async function handleCover(ctx: KoaContext) {
   if (await storeExists(origStore, origKey) && !shouldBypassCache) {
     ctx.tag({ store: 'original' })
     origData = await readStream(origStore.createReadStream(origKey))
+    contentType = await mimeMagic(origData)
+  } else if (retentionStore && await storeExists(retentionStore, origKey)) {
+    // Archive of originals whose upstream is gone. An origin, not a cache, so
+    // cache-bypass flags deliberately do not skip it.
+    ctx.tag({ store: 'retention' })
+    origData = await readStream(retentionStore.createReadStream(origKey))
     contentType = await mimeMagic(origData)
   } else {
     ctx.tag({ store: 'fetch' })

--- a/src/fetch-image.ts
+++ b/src/fetch-image.ts
@@ -1,7 +1,19 @@
+import config from 'config'
 import { URL } from 'url'
 import { redisDel, redisGet, redisSet } from './common'
 import { captureImageFailure } from './sentry'
 import { assertPublicUrl, fetchUrl, getUrlHashKey, NeedleResponse } from './utils'
+
+/**
+ * Optional temporary bridge to another imagehoster origin that still holds
+ * originals this instance has not received yet (e.g. mid-migration). Tried after
+ * the source URL but before the public mirrors, so live origins are served
+ * normally and only the dead-origin tail ever reaches the bridge. Unset this
+ * config key once migration completes.
+ */
+const BRIDGE_ORIGIN = (config.has('bridge_origin')
+    ? String(config.get('bridge_origin'))
+    : '').replace(/\/+$/, '')
 
 const buildFallbackUrls = (urlString: string, urlParams: string): string[] => {
     const hasQuery = urlString.indexOf('?') !== -1
@@ -11,6 +23,14 @@ const buildFallbackUrls = (urlString: string, urlParams: string): string[] => {
     const urls: string[] = [
         ...(httpsUrl ? [httpsUrl] : []),
         urlString, // original URL
+        // Bridge host, when configured. 0x0 returns the stored original
+        // unresized so the bridge does no encode work; /p/ is the query-safe
+        // form and is the only usable one when the URL carries query params.
+        ...(BRIDGE_ORIGIN
+            ? (hasQuery
+                ? [BRIDGE_ORIGIN + '/p/' + urlParams]
+                : [BRIDGE_ORIGIN + '/0x0/' + urlString, BRIDGE_ORIGIN + '/p/' + urlParams])
+            : []),
         // /p/ routes use base58 encoding — safely preserves query params
         'https://images.hive.blog/p/' + urlParams,
         'https://steemitimages.com/p/' + urlParams,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,7 +9,7 @@ import Sharp from 'sharp'
 import streamHead from 'stream-head/dist-es6'
 import {URL} from 'url'
 import {imageBlacklist} from './blacklist'
-import {KoaContext, proxyStore, retentionStore, uploadStore} from './common'
+import {isArchiveStore, KoaContext, proxyStore, retentionStore, uploadStore} from './common'
 import { AVIF_EFFORT, EMPTY_IMAGE_URL_PATTERNS, applyUrlReplacements, isEmptyImageUrl, MAX_INPUT_PIXELS } from './constants'
 import {APIError} from './error'
 import {serveOrBuildFallbackImage} from './fallback'
@@ -371,11 +371,18 @@ export async function proxyHandler(ctx: KoaContext) {
         ctx.tag({rescued_original: true})
     }
     // Retention archive: same contract as the upload store above — an origin,
-    // not a cache — for originals migrated off local disk.
-    if (!haveOriginal && retentionStore && await storeExists(retentionStore, origKey)) {
-        servingStore = retentionStore
-        haveOriginal = true
-        ctx.tag({retention_original: true})
+    // not a cache — for originals migrated off local disk. A backend outage here
+    // must not fail the request: fall through to the normal fetch path.
+    if (!haveOriginal && retentionStore) {
+        try {
+            if (await storeExists(retentionStore, origKey)) {
+                servingStore = retentionStore
+                haveOriginal = true
+                ctx.tag({retention_original: true})
+            }
+        } catch (err) {
+            ctx.log.warn({ err, origKey }, 'retention store lookup failed, falling through')
+        }
     }
     if (haveOriginal) {
         origFromCache = true
@@ -388,9 +395,9 @@ export async function proxyHandler(ctx: KoaContext) {
             // truncated responses may have been cached by a previous request
             if (!AcceptedContentTypes.includes(contentType.toLowerCase())) {
                 ctx.log.warn({ contentType, origKey, urlString }, 'stored original has invalid content type')
-                // the upload store holds user uploads and rescued (unrefetchable)
-                // originals — never delete from it here
-                if (servingStore !== uploadStore) {
+                // Archive stores (uploads, retention) hold irreplaceable originals —
+                // never delete from them here
+                if (!isArchiveStore(servingStore)) {
                     try { await storeRemove(servingStore, origKey) } catch (_e) { /* best effort */ }
                 }
                 throw new Error('Invalid stored content type: ' + contentType)
@@ -487,6 +494,9 @@ export async function proxyHandler(ctx: KoaContext) {
     }
 
     let rv: Buffer
+    // Set when Sharp failed and we fall back to serving the original bytes; those
+    // are not a rendered variant and must not be cached as one.
+    let encodeFallback = false
     let isAnimated = contentType === 'image/gif' || contentType === 'image/apng'
     if (contentType.indexOf('video') > -1) {
         rv = origData
@@ -520,9 +530,9 @@ export async function proxyHandler(ctx: KoaContext) {
             ctx.log.error({ url: urlString, key: imageKey }, 'getSharpMetadataWithRetry failed')
             captureImageFailure('metadata_extraction_failed', ctx, { urlString, imageKey, origFromCache, error: String(err) })
             if (origFromCache) {
-                // the upload store holds user uploads and rescued (unrefetchable)
-                // originals — never delete from it here either
-                if (servingStore !== uploadStore) {
+                // Archive stores (uploads, retention) hold irreplaceable originals —
+                // never delete from them here either
+                if (!isArchiveStore(servingStore)) {
                     ctx.log.warn({ origKey }, 'purging corrupt cached original after metadata failure')
                     try { await storeRemove(servingStore, origKey) } catch (_e) { /* best effort */ }
                 }
@@ -636,6 +646,11 @@ export async function proxyHandler(ctx: KoaContext) {
             }
             ctx.log.error({ err, urlString, imageKey }, 'sharp.toBuffer() failed')
             captureImageFailure('sharp_tobuffer_failed', ctx, { urlString, imageKey, origIsUpload, origFromCache, error: String(err) })
+            // Every branch below serves the unprocessed original instead of a
+            // rendered variant. Storing those bytes under imageKey would make
+            // later requests skip resizing and format negotiation entirely, so
+            // the variant write is suppressed.
+            encodeFallback = true
             if (origIsUpload) {
                 // Sharp can't decode this image (e.g. unsupported HEIF/AVIF bitstream)
                 // but browsers likely can — serve the original unresized bytes
@@ -658,7 +673,7 @@ export async function proxyHandler(ctx: KoaContext) {
         }
         } // end non-animated Sharp pipeline
 
-        if (!isDefaultImage && !isLegacy) {
+        if (!isDefaultImage && !isLegacy && !encodeFallback) {
             ctx.log.debug('storing converted %s', imageKey)
             try {
                 await storeWrite(proxyStore, imageKey, rv)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,7 +9,7 @@ import Sharp from 'sharp'
 import streamHead from 'stream-head/dist-es6'
 import {URL} from 'url'
 import {imageBlacklist} from './blacklist'
-import {KoaContext, proxyStore, uploadStore} from './common'
+import {KoaContext, proxyStore, retentionStore, uploadStore} from './common'
 import { AVIF_EFFORT, EMPTY_IMAGE_URL_PATTERNS, applyUrlReplacements, isEmptyImageUrl, MAX_INPUT_PIXELS } from './constants'
 import {APIError} from './error'
 import {serveOrBuildFallbackImage} from './fallback'
@@ -369,6 +369,13 @@ export async function proxyHandler(ctx: KoaContext) {
         servingStore = uploadStore
         haveOriginal = true
         ctx.tag({rescued_original: true})
+    }
+    // Retention archive: same contract as the upload store above — an origin,
+    // not a cache — for originals migrated off local disk.
+    if (!haveOriginal && retentionStore && await storeExists(retentionStore, origKey)) {
+        servingStore = retentionStore
+        haveOriginal = true
+        ctx.tag({retention_original: true})
     }
     if (haveOriginal) {
         origFromCache = true


### PR DESCRIPTION
Supports serving originals that have been migrated off local disk into object storage, and bridges the gap while that migration is still running.

### `retention_store` (optional third store tier)
Consulted on a local proxy-store miss, **before** any network fetch. It follows the same contract as the existing `uploadStore` rescue tier — it is an *origin, not a cache*, so cache-bypass flags (`ignorecache`/`invalidate`) deliberately do not skip it, because there is no live upstream left to refetch from.

Wired into `proxy.ts`, `avatar.ts` and `cover.ts`. `retentionStore` is `undefined` when unconfigured, so all read sites null-check.

```toml
[retention_store]
type = 's3'
s3_bucket = 'eretention'
```

### `bridge_origin` (optional temporary mirror)
Points at another imagehoster origin that still holds originals this instance has not received yet. Inserted into the fallback chain **after the source URL but before the public mirrors**, so live origins are served normally and only the dead-origin tail ever reaches the bridge.

Prefers the `0x0` form, which returns the stored original unresized so the bridge host does no encode work; falls back to the query-safe `/p/` form when the URL has query params.

### Testing
- `tsc --noEmit` clean.
- Suite: **241 passing, 4 failing** — the 4 are the pre-existing test-config failures (test.toml points `service_url` at localhost), identical on `main`.
- Both features default to off, so behaviour is unchanged unless configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for serving archived original avatars, covers, and proxy images when standard sources are unavailable.
  * Added an optional bridge origin for additional image retrieval fallback paths.
* **Configuration**
  * Documented optional settings for enabling the bridge origin and durable original-image retention.
* **Bug Fixes**
  * Improved image availability when upstream originals are missing or previously inaccessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->