### PR TITLE
Bridge: use only the /p/ form

### DIFF
--- a/src/fetch-image.ts
+++ b/src/fetch-image.ts
@@ -23,14 +23,11 @@ const buildFallbackUrls = (urlString: string, urlParams: string): string[] => {
     const urls: string[] = [
         ...(httpsUrl ? [httpsUrl] : []),
         urlString, // original URL
-        // Bridge host, when configured. 0x0 returns the stored original
-        // unresized so the bridge does no encode work; /p/ is the query-safe
-        // form and is the only usable one when the URL carries query params.
-        ...(BRIDGE_ORIGIN
-            ? (hasQuery
-                ? [BRIDGE_ORIGIN + '/p/' + urlParams]
-                : [BRIDGE_ORIGIN + '/0x0/' + urlString, BRIDGE_ORIGIN + '/p/' + urlParams])
-            : []),
+        // Bridge host, when configured. Only the /p/ form is used: it is
+        // base58 so it survives query params, and it is what /0x0/ redirects to
+        // anyway (301 -> /p/...?format=match&mode=fit), so going straight there
+        // saves a round trip and does not change the work the bridge performs.
+        ...(BRIDGE_ORIGIN ? [BRIDGE_ORIGIN + '/p/' + urlParams] : []),
         // /p/ routes use base58 encoding — safely preserves query params
         'https://images.hive.blog/p/' + urlParams,
         'https://steemitimages.com/p/' + urlParams,


### PR DESCRIPTION
Follow-up to #17, from testing against a live bridge host.

`/0x0/<url>` answers **301 → `/p/<base58>?format=match&mode=fit`** on the same host. So the `0x0` variant:
- costs an extra round trip, and
- performs exactly the same resize work on the bridge host

The comment added in #17 claiming it returned the stored original unresized was incorrect. Since `/p/` is base58 it already survives query params, so the `hasQuery` split is unnecessary too.

Verified: `/p/` form returns 200 `image/png` from a live bridge; the 301 target is relative, so there was no self-fetch risk either way.

tsc clean; tests 241 passing / 4 failing (unchanged baseline).