### PR TITLE
chore(fetch): remove temporary migration bridge_origin

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -58,16 +58,6 @@ max_image_size = 20000000 # 20mb
 # bitmap and exhaust worker memory (a 16000x16000 image is ~1GB decoded).
 max_input_pixels = 100000000
 
-# Optional temporary bridge to another imagehoster origin that still holds
-# originals this instance has not received yet (e.g. mid-migration). Tried after
-# the source URL but before the public mirrors, so live origins are unaffected
-# and only the dead-origin tail reaches it. Unset once migration completes.
-#
-# MUST be publicly routable: every candidate is checked by assertPublicUrl, so a
-# private/loopback address (10.x, 172.16-31.x, 192.168.x, 127.x) is skipped with
-# a warning and the bridge silently does nothing.
-# bridge_origin = 'http://198.51.100.10'
-
 # redis db used for ratelimiting uploads
 # redis_url = 'redis://localhost'
 redis_url = 'redis://myredis'

--- a/src/fetch-image.ts
+++ b/src/fetch-image.ts
@@ -1,19 +1,7 @@
-import config from 'config'
 import { URL } from 'url'
 import { redisDel, redisGet, redisSet } from './common'
 import { captureImageFailure } from './sentry'
 import { assertPublicUrl, fetchUrl, getUrlHashKey, NeedleResponse } from './utils'
-
-/**
- * Optional temporary bridge to another imagehoster origin that still holds
- * originals this instance has not received yet (e.g. mid-migration). Tried after
- * the source URL but before the public mirrors, so live origins are served
- * normally and only the dead-origin tail ever reaches the bridge. Unset this
- * config key once migration completes.
- */
-const BRIDGE_ORIGIN = (config.has('bridge_origin')
-    ? String(config.get('bridge_origin'))
-    : '').replace(/\/+$/, '')
 
 const buildFallbackUrls = (urlString: string, urlParams: string): string[] => {
     const hasQuery = urlString.indexOf('?') !== -1
@@ -23,11 +11,6 @@ const buildFallbackUrls = (urlString: string, urlParams: string): string[] => {
     const urls: string[] = [
         ...(httpsUrl ? [httpsUrl] : []),
         urlString, // original URL
-        // Bridge host, when configured. Only the /p/ form is used: it is
-        // base58 so it survives query params, and it is what /0x0/ redirects to
-        // anyway (301 -> /p/...?format=match&mode=fit), so going straight there
-        // saves a round trip and does not change the work the bridge performs.
-        ...(BRIDGE_ORIGIN ? [BRIDGE_ORIGIN + '/p/' + urlParams] : []),
         // /p/ routes use base58 encoding — safely preserves query params
         'https://images.hive.blog/p/' + urlParams,
         'https://steemitimages.com/p/' + urlParams,


### PR DESCRIPTION
`bridge_origin` was scaffolding for the mid-migration window when some originals still lived only on the previous origin. It sat in the fetch fallback chain after the source URL but before the public mirrors, so only the dead-origin tail ever reached it.

That migration is complete and the config key is unset in production, so this removes:
- the `BRIDGE_ORIGIN` fallback candidate in `buildFallbackUrls`
- its `config.get('bridge_origin')` lookup (the last use of the `config` import in `fetch-image.ts`, so the import goes too)
- the documented example in `config/default.toml`

The `retention_store` tier and the public mirror fallbacks (`images.hive.blog`, `steemitimages.com`, `img.leopedia.io`, `wsrv.nl`) are unchanged.

`tsc --noEmit` passes. Deploys are manual, so merging does not by itself alter any running instance; the origin can stay reachable as a fallback until it is retired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the optional bridge-origin fallback from image retrieval.
  * Image fallback behavior remains available through the existing HTTPS, mirror, proxy, and caching routes.

* **Documentation**
  * Removed obsolete bridge-origin configuration guidance from the default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->