### PR TITLE
Never persist fallback bytes under a user's avatar/cover key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Hive-powered image hosting and proxying service built with TypeScript, Koa, and Sharp. Provides authenticated image uploads via Hive blockchain signatures and image proxying/resizing capabilities with fallback support. Deployed at `images.ecency.com` behind Cloudflare CDN, with `img.ecency.com` as a non-CDN direct origin (manual user opt-in only, not for automatic fallback).
+Hive-powered image hosting and proxying service built with TypeScript, Koa, and Sharp. Provides authenticated image uploads via Hive blockchain signatures and image proxying/resizing capabilities with fallback support. Deployed at `i.ecency.com` behind Cloudflare CDN (this is `service_url` in config and the host all self-referential URLs are built from). `images.ecency.com` remains a CDN-fronted alias for historical URLs, and `img.ecency.com` is a non-CDN direct origin (manual user opt-in only, not for automatic fallback).
 
 ## Development Commands
 
@@ -71,7 +71,7 @@ NODE_ENV=test mocha --require ts-node/register test/[filename].ts --grep 'test p
 - Hive signature verification: `secp256k1_sign(sha256('ImageSigningChallenge'+image_data))`
 - Rate limiting via Redis (700 uploads per week default)
 - Reputation threshold check (min 10 reputation)
-- Max image size: 30MB (configurable)
+- Max image size: 20MB (`max_image_size`, configurable) — applies to both uploads and proxied fetches
 - Multipart parsing with Busboy, single file per request
 - Content hash stored as multihash identifier
 
@@ -97,7 +97,7 @@ NODE_ENV=test mocha --require ts-node/register test/[filename].ts --grep 'test p
 - URLs with query params: /p/ routes (base58) tried first (preserves params), /0x0/ routes tried last (lose params)
 - Serves default fallback image if all mirrors fail
 - Cache-Control: 2 minutes (max-age=120) for fallback images, 1 hour for successful avatars/covers, 1 year immutable for proxy images
-- Default/fallback images are never stored persistently
+- Default/fallback images are never stored persistently, in **any** handler. `proxy.ts` gates on `!isDefaultImage`; `avatar.ts` and `cover.ts` skip both the original and the rendered variant when `isFetchFallback || isResizeFallback`. Storing them would be indistinguishable from a real image on later requests and would be served at the normal 1h freshness instead of the fallback's 120s. The one deliberate exception is a *profile-lookup* fallback (`isProfileFallback`, a transient RPC miss): it derives both keys from the default image's own URL, so it never occupies a user's key and is safe to cache
 - Sentry tracking: `captureImageFailure()` reports all_fallbacks_failed, unsupported_content_type, metadata_extraction_failed, sharp_tobuffer_failed, all_mirrors_exhausted
 
 **Blacklisting** (src/blacklist.ts)
@@ -150,7 +150,8 @@ Key configuration sections:
 - `redis_url` - Redis for rate limiting and shared profile/account cache
 - `upload_limits` - Rate limit config (duration, max, reputation, app credentials)
 - `upload_store`, `proxy_store` - Blob store configurations
-- `max_image_size`, `max_image_width`, `max_image_height` - Size limits
+- `max_image_size`, `max_image_width`, `max_image_height` - Size limits (`max_image_size` defaults to 20MB)
+- `max_cached_original_size` - Largest original the proxy cache keeps a copy of (default 1MB, `0` disables). Does not apply to avatar/cover originals, which are a bounded, frequently re-read set worth ~0.1% of the store
 - `default_avatar`, `default_cover` - Fallback images
 - `sentry_dsn` - Optional Sentry DSN for error tracking
 - `invalidate_token` - Optional token for cache invalidation API
@@ -171,19 +172,20 @@ Multi-stage Dockerfile with vips/heif/aom dependencies for image processing:
 VCL template at `config/varnish-user.vcl`.
 - Caches only /u/* (avatars/covers) and ?blur= URLs
 - Passes proxy images and uploads through (cached by Cloudflare instead)
-- Fallback avatars detected by max-age=120, cached only 2 minutes
-- After deploys: ban avatar cache to prevent stale fallbacks
+- Fallback avatars detected by max-age=120, cached only 2 minutes. This is a header-level contract: the handlers still emit max-age=120 for every fallback render, so the VCL branch is unaffected by the fact that fallbacks are no longer written to the blob store
+- After deploys: ban avatar cache. Note the original reason for this (fallback bytes persisted in the proxy store under a user's key, outliving the 120s response) no longer applies — those are never stored now, so a ban only clears edge-cached responses
 
 ### Cloudflare
 - Page rule: `cache_everything` for the image domain
 - Tiered cache enabled, Polish off, sort query string on, strong ETags on
-- After deploys: purge avatar prefix to clear stale fallbacks
+- After deploys: purge avatar prefix. As with Varnish, this no longer has to undo persisted fallbacks; it only clears edge copies, which expire on their own in 120s for fallback renders
+- A failed avatar/cover fetch no longer triggers the Cloudflare purge that accompanies a successful store write, so a transient upstream outage leaves the previously cached good avatar in place instead of replacing it with the default
 
 Docker Compose configured for 4 replicas with rolling updates and resource limits.
 
 ## Testing
 
-Tests in `test/` directory use Mocha + ts-node (181 tests). Key test files:
+Tests in `test/` directory use Mocha + ts-node (249 passing). Key test files:
 - `test/upload.ts` - Upload signature verification
 - `test/proxy.ts` - Image proxying, resizing, and storage behavior
 - `test/proxy-formats.ts` - Format conversion (AVIF, WebP, JPEG, PNG)

--- a/README.md
+++ b/README.md
@@ -53,9 +53,14 @@ pm2 start ecosystem.config.js
 
 ### Storage Architecture
 
-**Dual Storage System:**
+**Three-tier Storage System:**
 - **Upload Store** - Long-term S3 storage for user uploads (immutable)
 - **Proxy Store** - Ephemeral filesystem/S3 cache for proxied images
+- **Retention Store** (optional) - S3 archive for originals whose upstream origin is dead, so the proxy store can stay freely prunable. Consulted on a proxy-store miss, before the network fetch fallback
+
+The upload and retention stores are **origins, not caches**: cache-bypass flags never skip them and nothing auto-deletes from them. Only the proxy store is safe to LRU-prune.
+
+**What a proxy miss writes:** the rendered variant, plus the untouched original when it is small enough. The original exists only so a later request for a *different* size or format can re-render without a second upstream fetch. Because large originals dominate the cache by volume while being a small share of files, they are skipped above `max_cached_original_size` (default 1MB, `0` disables). Avatar and cover originals are exempt from that cap: they are a bounded, frequently re-read set, and one original feeds up to nine rendered variants.
 
 Images are content-addressed using multihash:
 - Upload keys: `D{base58(sha256(image_data))}`
@@ -82,7 +87,7 @@ POST /hs/:accesstoken          Upload with HiveSigner token
 **Requirements:**
 - Hive account in good standing (minimum reputation: 10)
 - Valid signature or HiveSigner token
-- Image size ≤30MB
+- Image size ≤20MB
 - Account not blacklisted
 - Within rate limit quota (700 uploads/week default)
 
@@ -186,18 +191,24 @@ log_output = 'stdout'
 rpc_node = 'https://api.hive.blog'
 
 # Service URL (used for self-referential URLs)
-service_url = 'https://images.ecency.com'
+service_url = 'https://i.ecency.com'
 
 # Image limits
-max_image_size = 30000000    # 30MB
+max_image_size = 20000000    # 20MB
 max_image_width = 1280
 max_image_height = 1280
 max_custom_image_width = 2000
 max_custom_image_height = 2000
+max_input_pixels = 100000000 # decompression-bomb guard (width*height)
+
+# Largest original the proxy cache keeps a copy of. Rendered variants are always
+# cached; this only bounds the untouched originals kept to avoid a refetch when a
+# different size/format of the same source is requested. 0 disables entirely.
+max_cached_original_size = 1000000  # 1MB
 
 # Default images
-default_avatar = 'https://images.ecency.com/DQm.../avatar.png'
-default_cover = 'https://images.ecency.com/DQm.../cover.png'
+default_avatar = 'https://i.ecency.com/DQm.../avatar.png'
+default_cover = 'https://i.ecency.com/DQm.../cover.png'
 ```
 
 ### S3 Storage
@@ -332,6 +343,8 @@ When primary source fails, tries multiple mirrors in order:
 8. Default fallback image
 
 Each attempt has 10-second timeout. First successful response is returned.
+
+**Fallback results are never persisted.** If every mirror fails and the default image is served, neither the original nor the rendered variant is written to the store, in any handler. A stored fallback would be indistinguishable from a real image on later requests and would be served at the normal 1 hour freshness rather than the fallback's 120 seconds, so a brief upstream outage would look like a permanently broken image until the entry was evicted or manually invalidated. Repeat cost is bounded by the negative cache (10 minutes for a dead URL, 60 seconds for a transient failure), so a broken source is retried at most once per TTL rather than once per request.
 
 ### URL Replacements
 
@@ -510,7 +523,7 @@ make lib
 - **Signature verification** - All uploads require valid Hive account signature
 - **Blacklist system** - Dynamic DMCA compliance with remote updates
 - **Input validation** - All parameters validated before processing
-- **Size limits** - 30MB max upload, 2000x2000 max dimensions
+- **Size limits** - 20MB max upload, 2000x2000 max dimensions
 - **Safe fallbacks** - Malformed URLs return default images, not errors
 - **Content-Type detection** - Server-side validation via file-type
 - **No arbitrary code execution** - All image processing via Sharp (sandboxed)

--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -182,7 +182,10 @@ async function handleAvatar(ctx: KoaContext) {
       origData = res.body
       contentType = await mimeMagic(origData)
 
-      if (res.bytes <= Number.parseInt(config.get('max_image_size'))) {
+      // isFetchFallback means these are the default avatar's bytes, not this
+      // user's image. Persisting them under the user's key would make every
+      // later request serve the default as if it were their real avatar.
+      if (res.bytes <= Number.parseInt(config.get('max_image_size')) && !isFetchFallback) {
         ctx.log.debug('storing original %s', origKey)
         try {
           await storeWrite(origStore, origKey, origData)
@@ -197,7 +200,7 @@ async function handleAvatar(ctx: KoaContext) {
           // Continue serving - storage failure shouldn't block response
         }
       } else {
-        ctx.log.debug('not-storing PayloadTooLarge original %s', origKey)
+        ctx.log.debug('not-storing original %s (bytes=%d, fallback=%s)', origKey, res.bytes, isFetchFallback)
       }
     } catch (cause) {
       ctx.log.error(cause, 'Image fetch failed')
@@ -220,15 +223,27 @@ async function handleAvatar(ctx: KoaContext) {
   contentType = finalType
   isResizeFallback = isFallback
 
-  ctx.log.debug('storing converted %s', imageKey)
-  try {
-    await storeWrite(proxyStore, imageKey, rv)
-  } catch (err) {
-    ctx.log.error({ err, imageKey }, 'failed to store converted avatar image')
-    // Continue serving - storage failure shouldn't block response
+  // Fallback bytes must never be persisted under the requested key. They are the
+  // default avatar standing in for an image we could not fetch or render, and a
+  // stored copy is indistinguishable from a real one on later requests: it would
+  // be served at the normal one-hour freshness until evicted or invalidated.
+  // A profile-lookup fallback is deliberately excluded here — it derives both
+  // keys from the default avatar's own URL, so it never occupies a user's key.
+  const isImageFallback = isFetchFallback || isResizeFallback
+  if (!isImageFallback) {
+    ctx.log.debug('storing converted %s', imageKey)
+    try {
+      await storeWrite(proxyStore, imageKey, rv)
+    } catch (err) {
+      ctx.log.error({ err, imageKey }, 'failed to store converted avatar image')
+      // Continue serving - storage failure shouldn't block response
+    }
+  } else {
+    ctx.log.debug('not-storing fallback variant %s (fetch=%s, resize=%s)',
+        imageKey, isFetchFallback, isResizeFallback)
   }
 
-  const isFinalFallback = isFetchFallback || isResizeFallback || isProfileFallback
+  const isFinalFallback = isImageFallback || isProfileFallback
 
   ctx.set('Content-Type', contentType)
   // Vary on Accept header for proper content negotiation caching

--- a/src/cover.ts
+++ b/src/cover.ts
@@ -178,7 +178,10 @@ async function handleCover(ctx: KoaContext) {
       origData = res.body
       contentType = await mimeMagic(origData)
 
-      if (res.bytes <= Number.parseInt(config.get('max_image_size'))) {
+      // isFetchFallback means these are the default cover's bytes, not this
+      // user's image. Persisting them under the user's key would make every
+      // later request serve the default as if it were their real cover.
+      if (res.bytes <= Number.parseInt(config.get('max_image_size')) && !isFetchFallback) {
         ctx.log.debug('storing original %s', origKey)
         try {
           await storeWrite(origStore, origKey, origData)
@@ -190,7 +193,7 @@ async function handleCover(ctx: KoaContext) {
           // Continue serving - storage failure shouldn't block response
         }
       } else {
-        ctx.log.debug('not-storing PayloadTooLarge original %s', origKey)
+        ctx.log.debug('not-storing original %s (bytes=%d, fallback=%s)', origKey, res.bytes, isFetchFallback)
       }
     } catch (cause) {
       ctx.log.error(cause, 'Image fetch failed')
@@ -213,14 +216,27 @@ async function handleCover(ctx: KoaContext) {
   contentType = finalType
   isResizeFallback = isFallback
 
-  ctx.log.debug('storing converted %s', imageKey)
-  try {
-    await storeWrite(proxyStore, imageKey, rv)
-  } catch (err) {
-    ctx.log.error({ err, imageKey }, 'failed to store converted cover image')
-    // Continue serving - storage failure shouldn't block response
+  // Fallback bytes must never be persisted under the requested key. They are the
+  // default cover standing in for an image we could not fetch or render, and a
+  // stored copy is indistinguishable from a real one on later requests: it would
+  // be served at the normal one-hour freshness until evicted or invalidated.
+  // A profile-lookup fallback is deliberately excluded here — it derives both
+  // keys from the default cover's own URL, so it never occupies a user's key.
+  const isImageFallback = isFetchFallback || isResizeFallback
+  if (!isImageFallback) {
+    ctx.log.debug('storing converted %s', imageKey)
+    try {
+      await storeWrite(proxyStore, imageKey, rv)
+    } catch (err) {
+      ctx.log.error({ err, imageKey }, 'failed to store converted cover image')
+      // Continue serving - storage failure shouldn't block response
+    }
+  } else {
+    ctx.log.debug('not-storing fallback variant %s (fetch=%s, resize=%s)',
+        imageKey, isFetchFallback, isResizeFallback)
   }
-  const isFinalFallback = isFetchFallback || isResizeFallback || isProfileFallback
+
+  const isFinalFallback = isImageFallback || isProfileFallback
 
   ctx.set('Content-Type', contentType)
   // Vary on Accept header for proper content negotiation caching

--- a/test/avatar.ts
+++ b/test/avatar.ts
@@ -5,6 +5,9 @@ import needle from 'needle'
 import sharp from 'sharp'
 
 import {app} from './../src/app'
+import {proxyStore} from './../src/common'
+import {getImageKey, getUrlHashKey, OutputFormat, ScalingMode, storeExists} from './../src/utils'
+import {BROKEN_AVATAR_URL} from './index'
 
 describe('avatar', function() {
     let port: number
@@ -37,6 +40,25 @@ describe('avatar', function() {
         const meta = await sharp(res.body).metadata()
         assert.equal(meta.width, 64)
         assert.equal(meta.height, 64)
+    })
+
+    it('should not persist fallback bytes under the user key', async function() {
+        this.slow(5000)
+        this.timeout(30000)
+        const res = await needle('get', `http://localhost:${port}/u/brokenimages/avatar`)
+        assert.equal(res.statusCode, 200)
+        // 120s freshness is how Varnish and CF identify a fallback render; it must
+        // stay on the fallback response even though nothing is written to the store.
+        assert.equal(res.headers['cache-control'], 'public,max-age=120')
+
+        const origKey = getUrlHashKey(BROKEN_AVATAR_URL)
+        const imageKey = getImageKey(origKey, {
+            width: 256, height: 256, mode: ScalingMode.Cover, format: OutputFormat.Match,
+        } as any)
+        assert((await storeExists(proxyStore, origKey)) === false,
+            'default avatar bytes were stored as the user original')
+        assert((await storeExists(proxyStore, imageKey)) === false,
+            'default avatar bytes were stored as the user variant')
     })
 
     it('should reject short usernames', async function() {

--- a/test/cover.ts
+++ b/test/cover.ts
@@ -5,6 +5,9 @@ import needle from 'needle'
 import sharp from 'sharp'
 
 import {app} from './../src/app'
+import {proxyStore} from './../src/common'
+import {getImageKey, getUrlHashKey, OutputFormat, ScalingMode, storeExists} from './../src/utils'
+import {BROKEN_COVER_URL} from './index'
 
 describe('cover', function() {
     let port: number
@@ -27,6 +30,25 @@ describe('cover', function() {
         const meta = await sharp(res.body).metadata()
         // Cover uses fit mode at 1344x240, so width should be <= 1344
         assert(meta.width && meta.width <= 1344, 'cover width should be <= 1344')
+    })
+
+    it('should not persist fallback bytes under the user key', async function() {
+        this.slow(5000)
+        this.timeout(30000)
+        const res = await needle('get', `http://localhost:${port}/u/brokenimages/cover`)
+        assert.equal(res.statusCode, 200)
+        // 120s freshness is how Varnish and CF identify a fallback render; it must
+        // stay on the fallback response even though nothing is written to the store.
+        assert.equal(res.headers['cache-control'], 'public,max-age=120')
+
+        const origKey = getUrlHashKey(BROKEN_COVER_URL)
+        const imageKey = getImageKey(origKey, {
+            width: 1344, height: 240, mode: ScalingMode.Fit, format: OutputFormat.Match,
+        } as any)
+        assert((await storeExists(proxyStore, origKey)) === false,
+            'default cover bytes were stored as the user original')
+        assert((await storeExists(proxyStore, imageKey)) === false,
+            'default cover bytes were stored as the user variant')
     })
 
     it('should reject short usernames', async function() {

--- a/test/index.ts
+++ b/test/index.ts
@@ -65,13 +65,13 @@ export const mockAccounts: any = {
 }
 
 /**
- * Nothing listens here, so a fetch fails with ECONNREFUSED immediately and the
- * whole mirror chain ends in the default image. Used to exercise the fallback
- * path deterministically without depending on a remote host 404ing.
+ * `.invalid` is reserved by RFC 2606 and guaranteed never to resolve, so these
+ * fetches fail immediately and the whole mirror chain ends in the default image.
+ * Deterministic without depending on a remote host 404ing, and with no port to
+ * collide with a listener that happens to exist on the machine running the tests.
  */
-const BROKEN_IMAGE_PORT = 63219
-export const BROKEN_AVATAR_URL = `http://localhost:${ BROKEN_IMAGE_PORT }/missing-avatar.jpg`
-export const BROKEN_COVER_URL = `http://localhost:${ BROKEN_IMAGE_PORT }/missing-cover.jpg`
+export const BROKEN_AVATAR_URL = 'http://no-such-host.invalid/missing-avatar.jpg'
+export const BROKEN_COVER_URL = 'http://no-such-host.invalid/missing-cover.jpg'
 
 export const mockProfiles: any = {
     foo: {

--- a/test/index.ts
+++ b/test/index.ts
@@ -64,6 +64,15 @@ export const mockAccounts: any = {
     }
 }
 
+/**
+ * Nothing listens here, so a fetch fails with ECONNREFUSED immediately and the
+ * whole mirror chain ends in the default image. Used to exercise the fallback
+ * path deterministically without depending on a remote host 404ing.
+ */
+const BROKEN_IMAGE_PORT = 63219
+export const BROKEN_AVATAR_URL = `http://localhost:${ BROKEN_IMAGE_PORT }/missing-avatar.jpg`
+export const BROKEN_COVER_URL = `http://localhost:${ BROKEN_IMAGE_PORT }/missing-cover.jpg`
+
 export const mockProfiles: any = {
     foo: {
         name: 'foo',
@@ -134,6 +143,24 @@ export const mockProfiles: any = {
         blacklists: [],
         stats: { followers: 5, following: 5, rank: 0 },
         metadata: { profile: { name: '', profile_image: '', cover_image: '' } }
+    },
+    // Avatar and cover both point at an unreachable host, so every fetch ends in
+    // the default image. Used to prove fallback bytes are never persisted under
+    // the user's key.
+    brokenimages: {
+        name: 'brokenimages',
+        active: '2024-01-01T00:00:00',
+        created: '2016-01-01T00:00:00',
+        id: 10,
+        post_count: 1,
+        reputation: 25,
+        blacklists: [],
+        stats: { followers: 0, following: 0, rank: 0 },
+        metadata: { profile: {
+            name: 'Broken',
+            profile_image: BROKEN_AVATAR_URL,
+            cover_image: BROKEN_COVER_URL,
+        } }
     },
     // bridge returns an empty avatar; deliberately has NO mockAccounts entry so
     // condenser_api.get_accounts resolves to [undefined] — simulating a transient


### PR DESCRIPTION
## Bug

When an avatar or cover fetch fell through the entire mirror chain, `fetchImageWithFallbacks` returned the **default image** with `isFallback` set. But the store gate only checked the byte size:

```ts
if (res.bytes <= Number.parseInt(config.get('max_image_size'))) {
  await storeWrite(origStore, origKey, origData)   // default bytes, user's key
```

The rendered variant was then written under the user's `imageKey` as well, and `isFinalFallback` was only computed *after* both writes, where it does nothing but pick a `Cache-Control` value.

Result: a brief upstream outage permanently poisons that user's avatar. The stored entry is indistinguishable from a real one on later requests, so it is served at the normal `max-age=3600` rather than the fallback's `max-age=120`, and it survives until evicted or manually invalidated. This is the underlying reason the deploy runbook carries "ban avatar cache" and "purge avatar prefix to clear stale fallbacks" steps.

`proxy.ts` has always guarded exactly this case with `!isDefaultImage`. `avatar.ts` and `cover.ts` did not.

## Fix

Skip both writes when the fetch or the resize fell back. A **profile-lookup** fallback (`isProfileFallback`, a transient RPC miss) is deliberately still cached: it derives both keys from the default image's own URL, so it never occupies a user's key.

## Caching behaviour is unchanged

This was checked deliberately, since Varnish and Cloudflare both key off the response headers:

- `isFinalFallback` is still `isFetchFallback || isResizeFallback || isProfileFallback`, so every fallback render still emits `public,max-age=120`. The Varnish VCL branch on `Cache-Control ~ "max-age=120"` (config/varnish-user.vcl) and its 120s vs 3600s TTL split behave identically.
- No change to Cloudflare's `/u/*` caching. The edge still holds fallbacks for 120s and real images for 3600s.
- One intentional behavioural improvement: the Cloudflare purge that accompanies a successful avatar store write no longer fires when the fetch fell back. Previously a failed fetch would purge the edge and replace a good cached avatar with the default. Now a transient outage leaves the previously cached good image in place.

The cost of not caching fallbacks is bounded by the existing negative cache in `fetch-image.ts`: `NEGATIVE_TTL_SECONDS = 600` for a dead URL and `60` for a transient failure, in Redis and shared across workers. A broken source is retried at most once per TTL, not once per request, and the edge absorbs the rest at 120s.

## Tests

Two regression tests using a new `brokenimages` profile fixture pointing at an unreachable host, asserting neither the original key nor the variant key lands in the proxy store, and that `max-age=120` is still set.

Verified by mutation: reverting either guard fails both new tests (6 failing against the 4 pre-existing baseline). 249 passing. The 4 failures in `test/utils.ts` and `test/serve.ts` predate this branch and are unrelated.

## Docs

Also corrects stale claims found while documenting this, each checked against code or config: max image size documented as 30MB in four places when `max_image_size` is 20MB, canonical host, the storage tier count (retention has been a third tier since #17), the test count, and the `max_cached_original_size` key from #21.