### PR TITLE
Purge every service origin, not only i.ecency.com

### DIFF
--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -210,11 +210,12 @@ async function handleAvatar(ctx: KoaContext) {
         try {
           await storeWrite(origStore, origKey, origData)
           // Purge Cloudflare cache for this user's avatar endpoint since we fetched a new image
+          // One call, not four: purgeCache expands each URL across every service
+          // hostname, so four separate calls would be eight requests to Cloudflare.
           const serviceUrl = new URL(config.get('service_url'))
-          purgeCache(`${serviceUrl.origin}/u/${username}/avatar/`)
-          purgeCache(`${serviceUrl.origin}/u/${username}/avatar/small`)
-          purgeCache(`${serviceUrl.origin}/u/${username}/avatar/medium`)
-          purgeCache(`${serviceUrl.origin}/u/${username}/avatar/large`)
+          purgeCache(['', 'small', 'medium', 'large'].map(
+            (size) => `${serviceUrl.origin}/u/${username}/avatar/${size}`
+          ))
         } catch (err) {
           ctx.log.error({ err, origKey }, 'failed to store original avatar image')
           // Continue serving - storage failure shouldn't block response

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -275,33 +275,83 @@ export function getProxyImageLimits() {
     }
 }
 
+/**
+ * Cloudflare keys cache objects per hostname, so a purge naming only one of the
+ * hostnames that front this service leaves the other one serving the old bytes
+ * until it expires on its own. Every caller builds purge URLs from
+ * `service_url`, so `https://images.ecency.com` was never purged at all.
+ *
+ * `INTERNAL_SERVICE_ORIGINS` is already the set of origins that are "us" (it
+ * backs the double-proxy detection), so reuse it rather than tracking the list
+ * twice and letting the two drift.
+ *
+ * A URL on some other host is passed through untouched: purge inputs are
+ * built from our own origin today, but rewriting an external URL onto ours
+ * would silently purge the wrong object if that ever changes.
+ */
+export function expandPurgeUrls(value: string | string[]): string[] {
+    const input = Array.isArray(value) ? value : [value]
+    const out = new Set<string>()
+    for (const raw of input) {
+        let parsed: URL
+        try {
+            parsed = new URL(raw)
+        } catch (cause) {
+            out.add(raw)
+            continue
+        }
+        if (!INTERNAL_SERVICE_ORIGINS.includes(parsed.origin)) {
+            out.add(raw)
+            continue
+        }
+        for (const origin of INTERNAL_SERVICE_ORIGINS) {
+            out.add(new URL(`${parsed.pathname}${parsed.search}`, origin).toString())
+        }
+    }
+    return [...out]
+}
+
+/** Cloudflare rejects a purge naming more than 30 URLs, which would fail the whole batch. */
+const PURGE_BATCH_SIZE = 30
+
+let purgeUnconfiguredWarned = false
+
 export function purgeCache(value: string | string[]) {
     if (!config.has('cloudflare_token') || !config.has('cloudflare_zone')) {
+        // Warn once rather than per call: a missing config is otherwise
+        // indistinguishable from a successful purge, in the logs and everywhere else.
+        if (!purgeUnconfiguredWarned) {
+            purgeUnconfiguredWarned = true
+            logger.warn('cloudflare_token/cloudflare_zone not configured, CDN purges are being skipped')
+        }
         return
     }
     const CF_KEY = config.get('cloudflare_token') as string
     const CF_ZONE = config.get('cloudflare_zone') as string
-    const files = Array.isArray(value) ? value : [value]
-    if (files.length === 0) {
+    const expanded = expandPurgeUrls(value)
+    if (expanded.length === 0) {
         return
     }
-    fetch(`https://api.cloudflare.com/client/v4/zones/${CF_ZONE}/purge_cache`, {
-        method: 'POST',
-        headers: {
-            'Authorization': `Bearer ${CF_KEY}`,
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ files }),
-    }).then(async (res) => {
-        const body = await res.json().catch(() => null) as any
-        if (!res.ok || (body && !body.success)) {
-            logger.error({ status: res.status, body, files }, 'Cloudflare cache purge failed')
-        } else {
-            logger.info({ files }, 'Cloudflare cache purged')
-        }
-    }).catch((err) => {
-        logger.error({ err, files }, 'Cloudflare cache purge network error')
-    })
+    for (let i = 0; i < expanded.length; i += PURGE_BATCH_SIZE) {
+        const files = expanded.slice(i, i + PURGE_BATCH_SIZE)
+        fetch(`https://api.cloudflare.com/client/v4/zones/${CF_ZONE}/purge_cache`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${CF_KEY}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ files }),
+        }).then(async (res) => {
+            const body = await res.json().catch(() => null) as any
+            if (!res.ok || (body && !body.success)) {
+                logger.error({ status: res.status, body, files }, 'Cloudflare cache purge failed')
+            } else {
+                logger.info({ files }, 'Cloudflare cache purged')
+            }
+        }).catch((err) => {
+            logger.error({ err, files }, 'Cloudflare cache purge network error')
+        })
+    }
 }
 
 export function stripWebpOrPng(value: string): string {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -30,6 +30,7 @@ import {
     OutputFormat,
     storeRemoveByPrefix,
     storeWrite,
+    expandPurgeUrls,
 } from './../src/utils'
 
 import {AVIF_EFFORT, DEFAULT_AVATAR_HASH, DEFAULT_FALLBACK_IMAGE_URL, EMPTY_IMAGE_URL_PATTERNS, INTERNAL_SERVICE_ORIGINS, LEGACY_SERVICE_BASE_URL, SERVICE_BASE_URL, SPECIAL_EMPTY_IMAGE_PATH, applyUrlReplacements, isEmptyImageUrl, startsWithEmptyImagePrefix} from './../src/constants'
@@ -955,5 +956,50 @@ describe('accept header negotiation', function() {
                 initFixture()
             }
         })
+    })
+})
+
+describe('expandPurgeUrls', function() {
+    // Cloudflare keys cache objects per hostname, so a purge that names only one
+    // of the origins fronting this service leaves the other serving stale bytes.
+    // In the test config INTERNAL_SERVICE_ORIGINS is the service_url origin plus
+    // the legacy images.ecency.com origin.
+    const [primary, legacy] = INTERNAL_SERVICE_ORIGINS
+
+    it('fans a service URL out across every service origin', function() {
+        const out = expandPurgeUrls(`${primary}/p/sometoken`)
+        assert.equal(out.length, INTERNAL_SERVICE_ORIGINS.length)
+        assert.ok(out.includes(`${primary}/p/sometoken`))
+        assert.ok(out.includes(`${legacy}/p/sometoken`))
+    })
+
+    it('fans out a URL given on the legacy origin too, not just the primary', function() {
+        const out = expandPurgeUrls(`${legacy}/u/alice/avatar/small`)
+        assert.ok(out.includes(`${primary}/u/alice/avatar/small`))
+        assert.ok(out.includes(`${legacy}/u/alice/avatar/small`))
+    })
+
+    it('preserves the query string on every origin', function() {
+        const out = expandPurgeUrls(`${primary}/p/tok?format=match&mode=fit`)
+        assert.ok(out.includes(`${primary}/p/tok?format=match&mode=fit`))
+        assert.ok(out.includes(`${legacy}/p/tok?format=match&mode=fit`))
+    })
+
+    it('accepts an array and deduplicates the result', function() {
+        const out = expandPurgeUrls([`${primary}/p/tok`, `${legacy}/p/tok`, `${primary}/p/tok`])
+        assert.equal(out.length, INTERNAL_SERVICE_ORIGINS.length)
+    })
+
+    it('never rewrites a URL belonging to some other host onto ours', function() {
+        const foreign = 'https://images.hive.blog/p/sometoken'
+        assert.deepEqual(expandPurgeUrls(foreign), [foreign])
+    })
+
+    it('passes a non-URL string through untouched rather than throwing', function() {
+        assert.deepEqual(expandPurgeUrls('not a url'), ['not a url'])
+    })
+
+    it('returns an empty list for empty input', function() {
+        assert.deepEqual(expandPurgeUrls([]), [])
     })
 })


### PR DESCRIPTION
Closes #27.

Cloudflare keys cache objects per hostname, so purging `https://i.ecency.com/p/<key>` leaves the `images.ecency.com` copy of the same image in place. Every purge URL was built from `service_url`, so that second hostname was never purged at all.

The two hostnames are genuinely separate caches. Over 24h to 2026-08-31:

| host | requests | hit | miss |
|---|---|---|---|
| i.ecency.com | 3,929,424 | 27.9% | 52.8% |
| images.ecency.com | 3,029,677 | 13.8% | 65.9% |

## Approach

The issue suggested a new `purge_hosts` config key. Not needed: `INTERNAL_SERVICE_ORIGINS` (`src/constants.ts:12`) is already the set of origins that are us, and already backs the double-proxy detection. Reusing it keeps the two from drifting.

`expandPurgeUrls()` fans each URL across those origins. `purgeCache()` calls it, so the five call sites are unchanged.

A URL on some other host passes through untouched. Inputs are built from our own origin today, but rewriting an external URL onto ours would purge the wrong object if that ever changes.

## Also in here

- `purgeCache` returned silently when `cloudflare_token`/`cloudflare_zone` are absent, with no log line, so a missing config looked exactly like a successful purge. Now warns once.
- Batched at 30 URLs per request, which is Cloudflare's limit; a larger purge is rejected outright.
- `avatar.ts` made four separate calls where `purgeCache` already accepts an array. With the fan-out that would have been eight requests per avatar refresh.

## Tests

7 new cases in `test/utils.ts`. Suite goes 277 to 284 passing. The 4 pre-existing failures on `main` (`serve > should reject non-GET methods` and three `constants > internal service URL helpers` cases) are unchanged and unrelated.

Mutation-checked both new guards: removing the fan-out fails 3 tests, removing the foreign-host guard fails 1.

`tsc --noEmit` clean. eslint reports only the pre-existing unused-`path` warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar cache purging to avoid duplicate requests.
  * Cache purge requests now support multiple internal service addresses while preserving external and invalid URLs.
  * Large purge operations are processed in manageable batches with clearer success and error reporting.
  * Added a warning when Cloudflare cache purging is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->