### PR TITLE
Verify the token signature on every HiveSigner upload path

### DIFF
--- a/config/test.toml
+++ b/config/test.toml
@@ -27,3 +27,12 @@ type = 'memory'
 
 [proxy_store]
 type = 'memory'
+
+# Deterministic throwaway key (PrivateKey.fromSeed('app-configured')), NOT a real
+# credential. Deliberately different from the ecency.app on-chain keys in the test
+# fixtures, which models a rotated app key: the configured key still authenticates
+# tokens we minted, while the delegation path verifies against current chain state.
+# Without this set, PrivateKey.fromString('') throws and the whole app-signature
+# branch is unreachable, so its tests would pass for the wrong reason.
+[upload_limits]
+app_posting_wif = '5JUqNo9okJuj2yqF4d1odFBw3rX8g9hPXy9SQHiC9vSsvGG7F3E'

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -75,20 +75,32 @@ const broadcasterPubKey: PublicKey | undefined = (() => {
     }
 })()
 
-/** True when `account` has granted `delegate` posting or active authority at full weight. */
-function hasDelegatedTo(account: HiveAccount, delegate: string): boolean {
-    for (const type of ['posting', 'active']) {
+type AuthorityType = 'posting' | 'active'
+
+/**
+ * Authority levels at which `account` has granted `delegate` enough weight to act
+ * alone.
+ *
+ * The level is returned rather than a boolean because a delegation is satisfied
+ * only by the delegate's authority at the SAME level. Collapsing the two lets an
+ * account that delegated only active authority be acted on with the delegate's
+ * posting key, which is the weaker and far more widely held of the two.
+ */
+function delegatedAuthorityTypes(account: HiveAccount, delegate: string): AuthorityType[] {
+    const types: AuthorityType[] = []
+    for (const type of ['posting', 'active'] as AuthorityType[]) {
         const authority: HiveAccountAuthority = account[type]
         if (!authority || !Array.isArray(authority.account_auths)) {
             continue
         }
         for (const [name, weight] of authority.account_auths) {
             if (name === delegate && weight >= authority.weight_threshold) {
-                return true
+                types.push(type)
+                break
             }
         }
     }
-    return false
+    return types
 }
 
 if (new URL('http://blä.se').toString() !== 'http://xn--bl-wia.se/') {
@@ -227,11 +239,17 @@ export async function uploadHsHandler(ctx: KoaContext) {
         //
         // Verifying against the delegate's own on-chain keys also survives a
         // rotation of the app key, which trusting app_posting_wif alone does not.
-        if (!validSignature && hasDelegatedTo(account, UPLOAD_LIMITS.app_account)) {
+        const delegatedTypes = validSignature
+            ? []
+            : delegatedAuthorityTypes(account, UPLOAD_LIMITS.app_account)
+        if (delegatedTypes.length > 0) {
             const [appAccount]: HiveAccount[] = await getAccount(UPLOAD_LIMITS.app_account)
             if (appAccount) {
-                validSignature = authoritySignedBy(appAccount.posting, hash, parsedSignature)
-                    || authoritySignedBy(appAccount.active, hash, parsedSignature)
+                // Same authority level only: a posting delegation is not satisfied
+                // by the delegate's active key, and an active delegation is not
+                // satisfied by the delegate's weaker posting key.
+                validSignature = delegatedTypes.some(
+                    (type) => authoritySignedBy(appAccount[type], hash, parsedSignature))
             } else {
                 ctx.log.error({app: UPLOAD_LIMITS.app_account},
                     'could not load app account to verify a delegated token')
@@ -337,6 +355,16 @@ export async function uploadHandler(ctx: KoaContext) {
               .includes(signedMessage.type)
             && signedMessage.app
           ) {
+                // A token authenticates the account it names, and nothing else.
+                // Without this the app-signed branch below accepts a token minted
+                // for one account submitted under any other account's URL: the
+                // signature still verifies (it is the app's key), while the quota,
+                // reputation gate and attribution all use the URL account. The
+                // /hs/ handler has always asserted this; this path had not.
+                APIError.assert(
+                    String(tokenObj.authors[0]).toLowerCase() === account.name,
+                    APIError.Code.InvalidSignature,
+                )
                 const message = JSON.stringify({
                     signed_message: signedMessage,
                     authors: tokenObj.authors,
@@ -362,11 +390,14 @@ export async function uploadHandler(ctx: KoaContext) {
                     validSignature = authoritySignedBy(account.posting, hash, parsedSigns)
                         || authoritySignedBy(account.active, hash, parsedSigns)
                 }
-                if (!validSignature && hasDelegatedTo(account, UPLOAD_LIMITS.app_account)) {
+                const delegatedTypes = validSignature
+                    ? []
+                    : delegatedAuthorityTypes(account, UPLOAD_LIMITS.app_account)
+                if (delegatedTypes.length > 0) {
                     const [appAccount]: HiveAccount[] = await getAccount(UPLOAD_LIMITS.app_account)
                     if (appAccount) {
-                        validSignature = authoritySignedBy(appAccount.posting, hash, parsedSigns)
-                            || authoritySignedBy(appAccount.active, hash, parsedSigns)
+                        validSignature = delegatedTypes.some(
+                            (type) => authoritySignedBy(appAccount[type], hash, parsedSigns))
                     }
                 }
             }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -8,8 +8,9 @@ import * as multihash from 'multihashes'
 import {URL} from 'url'
 
 import {accountBlacklist} from './blacklist'
-import {getAccount, getProfile, getRatelimit, HiveAccount, KoaContext, redisClient, uploadStore} from './common'
+import {getAccount, getProfile, getRatelimit, HiveAccount, HiveAccountAuthority, KoaContext, redisClient, uploadStore} from './common'
 import {APIError} from './error'
+import {logger} from './logger'
 import {AcceptedContentTypes, mimeMagic, readStream, storeExists, storeWrite} from './utils'
 
 const SERVICE_URL = new URL(config.get('service_url'))
@@ -18,6 +19,77 @@ if (!Number.isFinite(MAX_IMAGE_SIZE)) {
     throw new Error('Invalid max image size')
 }
 const UPLOAD_LIMITS = config.get('upload_limits') as any
+
+/**
+ * True when `signature` was produced by a key that satisfies this authority on
+ * its own.
+ *
+ * A key only counts when its own weight reaches the threshold, so a low-weight
+ * key meant to be combined with others cannot authorise an upload by itself.
+ * This mirrors the direct upload path below.
+ */
+function authoritySignedBy(
+    authority: HiveAccountAuthority | undefined,
+    hash: Buffer,
+    signature: Signature,
+): boolean {
+    if (!authority || !Array.isArray(authority.key_auths)) {
+        return false
+    }
+    for (const [key, weight] of authority.key_auths) {
+        if (weight < authority.weight_threshold) {
+            continue
+        }
+        try {
+            if (PublicKey.fromString(key).verify(hash, signature)) {
+                return true
+            }
+        } catch (cause) {
+            // A key we cannot parse is not a reason to abandon the remaining ones.
+            continue
+        }
+    }
+    return false
+}
+
+/**
+ * Public key for the app's configured posting WIF, or undefined when that WIF is
+ * unset or unparseable.
+ *
+ * Derived once, and deliberately non-fatal: `PrivateKey.fromString('')` throws
+ * ("Private key network id mismatch"), so deriving it per request meant an unset
+ * or rotated-out WIF failed every HiveSigner upload with a 500 before any
+ * verification ran. A missing WIF only means this one check is unavailable; the
+ * token can still verify against the account's own keys or the delegate's.
+ */
+const broadcasterPubKey: PublicKey | undefined = (() => {
+    const wif = UPLOAD_LIMITS.app_posting_wif
+    if (!wif) {
+        return undefined
+    }
+    try {
+        return PrivateKey.fromString(wif).createPublic()
+    } catch (cause) {
+        logger.error({cause}, 'upload_limits.app_posting_wif is set but is not a valid private key')
+        return undefined
+    }
+})()
+
+/** True when `account` has granted `delegate` posting or active authority at full weight. */
+function hasDelegatedTo(account: HiveAccount, delegate: string): boolean {
+    for (const type of ['posting', 'active']) {
+        const authority: HiveAccountAuthority = account[type]
+        if (!authority || !Array.isArray(authority.account_auths)) {
+            continue
+        }
+        for (const [name, weight] of authority.account_auths) {
+            if (name === delegate && weight >= authority.weight_threshold) {
+                return true
+            }
+        }
+    }
+    return false
+}
 
 if (new URL('http://blä.se').toString() !== 'http://xn--bl-wia.se/') {
     throw new Error('Incompatible node.js version, must be compiled with ICU support')
@@ -124,33 +196,46 @@ export async function uploadHsHandler(ctx: KoaContext) {
         ctx.log.warn('uploading app %s', signedMessage.app)
 
         APIError.assert(username === account.name, APIError.Code.InvalidSignature)
-        // when logged in with posting key but got hivesigner token from offline renew
-        const broadcasterPrivKey = PrivateKey.fromString(UPLOAD_LIMITS.app_posting_wif)
-        const broadcasterPubKey = broadcasterPrivKey.createPublic()
+        let parsedSignature: Signature
+        try {
+            parsedSignature = Signature.from(signature)
+        } catch (cause) {
+            throw new APIError({code: APIError.Code.InvalidSignature, cause})
+        }
 
-        if (broadcasterPubKey.verify(hash, Signature.from(signature))) {
+        // 1. Signed by the app's configured posting key, i.e. a token minted by
+        // us, including the offline-renew path.
+        if (broadcasterPubKey && broadcasterPubKey.verify(hash, parsedSignature)) {
             validSignature = true
         }
-        // when authorized app account or if signed message with own keys
-        if (account && account.name) {
-            ['posting', 'active', 'owner'].forEach((type) => {
-                account[type].account_auths.forEach((key: [string, number]) => {
-                    if (
-                    !validSignature
-                    && key[0] === UPLOAD_LIMITS.app_account
-                    ) {
-                    validSignature = true
-                    }
-                })
-                account[type].key_auths.forEach((key: [string, number]) => {
-                    if (
-                        !validSignature
-                        && PublicKey.fromString(key[0]).verify(hash, Signature.from(signature))
-                    ) {
-                        validSignature = true
-                    }
-                })
-            })
+
+        // 2. Signed by one of the account's own keys. Owner is deliberately
+        // excluded, matching the direct upload path: using it for routine
+        // operations is an anti-pattern.
+        if (!validSignature) {
+            validSignature = authoritySignedBy(account.posting, hash, parsedSignature)
+                || authoritySignedBy(account.active, hash, parsedSignature)
+        }
+
+        // 3. Signed by the app account the user has delegated to.
+        //
+        // Delegation on its own is NOT proof of anything: it establishes who MAY
+        // act for this account, not that this request came from them. Previously
+        // finding app_account in account_auths set validSignature directly, so
+        // any caller naming an account that had ever authorised the app was
+        // accepted with an arbitrary signature.
+        //
+        // Verifying against the delegate's own on-chain keys also survives a
+        // rotation of the app key, which trusting app_posting_wif alone does not.
+        if (!validSignature && hasDelegatedTo(account, UPLOAD_LIMITS.app_account)) {
+            const [appAccount]: HiveAccount[] = await getAccount(UPLOAD_LIMITS.app_account)
+            if (appAccount) {
+                validSignature = authoritySignedBy(appAccount.posting, hash, parsedSignature)
+                    || authoritySignedBy(appAccount.active, hash, parsedSignature)
+            } else {
+                ctx.log.error({app: UPLOAD_LIMITS.app_account},
+                    'could not load app account to verify a delegated token')
+            }
         }
 
         APIError.assert(validSignature, APIError.Code.InvalidSignature)
@@ -260,22 +345,29 @@ export async function uploadHandler(ctx: KoaContext) {
                 const signs = tokenObj.signatures[0]
 
                 const hash = createHash('sha256').update(message).digest()
-                const broadcasterPrivKey = PrivateKey.fromString(UPLOAD_LIMITS.app_posting_wif)
-                const broadcasterPubKey = broadcasterPrivKey.createPublic()
 
-                if (broadcasterPubKey.verify(hash, Signature.from(signs))) {
+                let parsedSigns: Signature
+                try {
+                    parsedSigns = Signature.from(signs)
+                } catch (cause) {
+                    throw new APIError({code: APIError.Code.InvalidSignature, cause})
+                }
+
+                if (broadcasterPubKey && broadcasterPubKey.verify(hash, parsedSigns)) {
                     validSignature = true
                 }
-                if (account && account.name) {
-                    ['posting', 'active', 'owner'].forEach((type) => {
-                        account[type].key_auths.forEach((key: [string, number]) => {
-                            if (!validSignature
-                                && PublicKey.fromString(key[0]).verify(hash, Signature.from(signs))
-                            ) {
-                                validSignature = true
-                            }
-                        })
-                    })
+                // Owner excluded and weight_threshold enforced, matching the
+                // key-signature path below and the /hs/ handler.
+                if (!validSignature) {
+                    validSignature = authoritySignedBy(account.posting, hash, parsedSigns)
+                        || authoritySignedBy(account.active, hash, parsedSigns)
+                }
+                if (!validSignature && hasDelegatedTo(account, UPLOAD_LIMITS.app_account)) {
+                    const [appAccount]: HiveAccount[] = await getAccount(UPLOAD_LIMITS.app_account)
+                    if (appAccount) {
+                        validSignature = authoritySignedBy(appAccount.posting, hash, parsedSigns)
+                            || authoritySignedBy(appAccount.active, hash, parsedSigns)
+                    }
                 }
             }
     } else if (ctx.params['signature'].startsWith('stndt')) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -7,7 +7,14 @@ import {rpc} from './../src/common'
 export const testKeys = {
     foo: PrivateKey.fromSeed('foo'),
     bar: PrivateKey.fromSeed('bar'),
+    // The app account's own posting key, as it would appear on chain.
+    app: PrivateKey.fromSeed('app'),
+    // A key nobody's posting/active authority accepts.
+    stranger: PrivateKey.fromSeed('stranger'),
 }
+
+/** Matches upload_limits.app_account in config/default.toml. */
+export const APP_ACCOUNT = 'ecency.app'
 
 export const mockAccounts: any = {
     foo: {
@@ -36,6 +43,89 @@ export const mockAccounts: any = {
             weight_threshold: 1,
             account_auths: [],
             key_auths: [[testKeys.foo.createPublic().toString(), 1]]
+        }
+    },
+    // The app account itself, so a delegated token can be verified against the
+    // delegate's real on-chain keys rather than trusted on delegation alone.
+    'ecency.app': {
+        name: 'ecency.app',
+        reputation: '10525900772718',
+        posting: {
+            weight_threshold: 1,
+            account_auths: [],
+            key_auths: [[testKeys.app.createPublic().toString(), 1]]
+        },
+        active: {
+            weight_threshold: 1,
+            account_auths: [],
+            key_auths: [[testKeys.app.createPublic().toString(), 1]]
+        }
+    },
+    // Has delegated posting authority to the app account, which is the shape that
+    // used to authenticate on delegation alone with no signature check at all.
+    hsdelegator: {
+        name: 'hsdelegator',
+        reputation: '10525900772718',
+        posting: {
+            weight_threshold: 1,
+            account_auths: [['ecency.app', 1]],
+            key_auths: [[testKeys.bar.createPublic().toString(), 1]]
+        },
+        active: {
+            weight_threshold: 1,
+            account_auths: [],
+            key_auths: [[testKeys.bar.createPublic().toString(), 1]]
+        }
+    },
+    // No delegation, so an app-signed token must not be accepted for it.
+    hsplain: {
+        name: 'hsplain',
+        reputation: '10525900772718',
+        posting: {
+            weight_threshold: 1,
+            account_auths: [],
+            key_auths: [[testKeys.bar.createPublic().toString(), 1]]
+        },
+        active: {
+            weight_threshold: 1,
+            account_auths: [],
+            key_auths: [[testKeys.bar.createPublic().toString(), 1]]
+        }
+    },
+    // The signing key exists only under owner, which must never authorise an upload.
+    hsowneronly: {
+        name: 'hsowneronly',
+        reputation: '10525900772718',
+        posting: {
+            weight_threshold: 1,
+            account_auths: [],
+            key_auths: [[testKeys.foo.createPublic().toString(), 1]]
+        },
+        active: {
+            weight_threshold: 1,
+            account_auths: [],
+            key_auths: [[testKeys.foo.createPublic().toString(), 1]]
+        },
+        owner: {
+            weight_threshold: 1,
+            account_auths: [],
+            key_auths: [[testKeys.bar.createPublic().toString(), 1]]
+        }
+    },
+    // The signing key's weight (1) is below the threshold (2), so it is a
+    // multisig participant and cannot authorise on its own.
+    hslowweight: {
+        name: 'hslowweight',
+        reputation: '10525900772718',
+        posting: {
+            weight_threshold: 2,
+            account_auths: [],
+            key_auths: [[testKeys.bar.createPublic().toString(), 1]]
+        },
+        active: {
+            weight_threshold: 2,
+            account_auths: [],
+            key_auths: [[testKeys.bar.createPublic().toString(), 1]]
         }
     },
     // Avatar only in legacy json_metadata; posting_json_metadata is a non-`profile`
@@ -107,6 +197,18 @@ export const mockProfiles: any = {
                 profile_image: 'https://example.com/bar-avatar.jpg',
             }
         }
+    },
+    hsdelegator: {
+        name: 'hsdelegator', active: '2024-01-01T00:00:00', created: '2016-01-01T00:00:00',
+        id: 20, post_count: 10, reputation: 50, blacklists: [],
+        stats: { followers: 1, following: 1, rank: 0 },
+        metadata: { profile: { name: 'HS Delegator' } }
+    },
+    hsplain: {
+        name: 'hsplain', active: '2024-01-01T00:00:00', created: '2016-01-01T00:00:00',
+        id: 21, post_count: 10, reputation: 50, blacklists: [],
+        stats: { followers: 1, following: 1, rank: 0 },
+        metadata: { profile: { name: 'HS Plain' } }
     },
     // bridge returns an empty avatar/cover — these live only in legacy json_metadata.
     legacyonly: {

--- a/test/index.ts
+++ b/test/index.ts
@@ -9,8 +9,14 @@ export const testKeys = {
     bar: PrivateKey.fromSeed('bar'),
     // The app account's own posting key, as it would appear on chain.
     app: PrivateKey.fromSeed('app'),
+    // The app account's ACTIVE key, distinct from its posting key, so tests can
+    // tell the two authority levels apart.
+    appActive: PrivateKey.fromSeed('app-active'),
     // A key nobody's posting/active authority accepts.
     stranger: PrivateKey.fromSeed('stranger'),
+    // The key in upload_limits.app_posting_wif. Distinct from the ecency.app
+    // on-chain keys above, modelling a rotated app key.
+    appConfigured: PrivateKey.fromSeed('app-configured'),
 }
 
 /** Matches upload_limits.app_account in config/default.toml. */
@@ -58,7 +64,23 @@ export const mockAccounts: any = {
         active: {
             weight_threshold: 1,
             account_auths: [],
-            key_auths: [[testKeys.app.createPublic().toString(), 1]]
+            key_auths: [[testKeys.appActive.createPublic().toString(), 1]]
+        }
+    },
+    // Delegated ACTIVE authority to the app but not posting. The app's weaker
+    // posting key must not satisfy that delegation.
+    hsactiveonly: {
+        name: 'hsactiveonly',
+        reputation: '10525900772718',
+        posting: {
+            weight_threshold: 1,
+            account_auths: [],
+            key_auths: [[testKeys.bar.createPublic().toString(), 1]]
+        },
+        active: {
+            weight_threshold: 1,
+            account_auths: [['ecency.app', 1]],
+            key_auths: [[testKeys.bar.createPublic().toString(), 1]]
         }
     },
     // Has delegated posting authority to the app account, which is the shape that
@@ -209,6 +231,12 @@ export const mockProfiles: any = {
         id: 21, post_count: 10, reputation: 50, blacklists: [],
         stats: { followers: 1, following: 1, rank: 0 },
         metadata: { profile: { name: 'HS Plain' } }
+    },
+    hsactiveonly: {
+        name: 'hsactiveonly', active: '2024-01-01T00:00:00', created: '2016-01-01T00:00:00',
+        id: 22, post_count: 10, reputation: 50, blacklists: [],
+        stats: { followers: 1, following: 1, rank: 0 },
+        metadata: { profile: { name: 'HS Active Only' } }
     },
     // bridge returns an empty avatar/cover — these live only in legacy json_metadata.
     legacyonly: {

--- a/test/upload.ts
+++ b/test/upload.ts
@@ -9,7 +9,7 @@ import {PrivateKey} from '@ecency/sdk/hive'
 
 import {app} from './../src/app'
 
-import {testKeys} from './index'
+import {APP_ACCOUNT, testKeys} from './index'
 
 export async function uploadImage(data: Buffer, port: number) {
     return new Promise<any>((resolve, reject) => {
@@ -125,4 +125,114 @@ describe('upload', function() {
         assert.equal(res.body.error.name, 'invalid_signature')
     })
 
+})
+
+
+/**
+ * Build a HiveSigner access token the way the client does: base64url of the
+ * token object, where the signature covers sha256 of the canonical message.
+ */
+function makeHsToken(opts: {author: string, signer: any, app?: string, type?: string, timestamp?: number}) {
+    const signedMessage = {type: opts.type || 'posting', app: opts.app || 'ecency.app'}
+    const authors = [opts.author]
+    const timestamp = opts.timestamp || 1700000000
+    const message = JSON.stringify({signed_message: signedMessage, authors, timestamp})
+    const hash = crypto.createHash('sha256').update(message).digest()
+    const signature = opts.signer.sign(Buffer.from(hash)).toString()
+    const tokenObj = {signed_message: signedMessage, authors, timestamp, signatures: [signature]}
+    return Buffer.from(JSON.stringify(tokenObj))
+        .toString('base64')
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '.')
+}
+
+/** Same token shape, but the signature is over unrelated bytes so it verifies against nothing. */
+function makeHsTokenWithBogusSignature(author: string) {
+    const signedMessage = {type: 'posting', app: 'ecency.app'}
+    const authors = [author]
+    const timestamp = 1700000000
+    const bogusHash = crypto.createHash('sha256').update('not the token message').digest()
+    const signature = testKeys.stranger.sign(Buffer.from(bogusHash)).toString()
+    const tokenObj = {signed_message: signedMessage, authors, timestamp, signatures: [signature]}
+    return Buffer.from(JSON.stringify(tokenObj))
+        .toString('base64')
+        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '.')
+}
+
+async function uploadWithHsToken(data: Buffer, port: number, token: string) {
+    return new Promise<any>((resolve, reject) => {
+        const payload = {
+            image_file: {filename: 'test.jpg', buffer: data, content_type: 'image/jpeg'},
+        }
+        needle.post(`:${ port }/hs/${ token }`, payload, {multipart: true}, (error, response, body) => {
+            if (error) { reject(error) } else { resolve({response, body}) }
+        })
+    })
+}
+
+describe('hivesigner upload auth', function() {
+    const port = 63207
+    const server = http.createServer(app.callback())
+    let data: Buffer
+
+    before((done) => {
+        data = fs.readFileSync(path.resolve(__dirname, 'test.jpg'))
+        server.listen(port, 'localhost', done)
+    })
+    after((done) => { server.close(done) })
+
+    it('rejects a token whose signature verifies against nothing, even when the account delegated to the app', async function() {
+        // The regression this suite exists for. Finding app_account in
+        // account_auths used to set validSignature directly, so any caller
+        // naming a delegating account was accepted with an arbitrary signature.
+        this.slow(1000)
+        const token = makeHsTokenWithBogusSignature('hsdelegator')
+        const {response} = await uploadWithHsToken(data, port, token)
+        assert.equal(response.statusCode, 400)
+    })
+
+    it('accepts a token signed by the account own posting key', async function() {
+        this.slow(1000)
+        const token = makeHsToken({author: 'hsplain', signer: testKeys.bar})
+        const {response} = await uploadWithHsToken(data, port, token)
+        assert.equal(response.statusCode, 200)
+    })
+
+    it('accepts a token signed by the delegate app account key when the account delegated', async function() {
+        this.slow(1000)
+        const token = makeHsToken({author: 'hsdelegator', signer: testKeys.app})
+        const {response} = await uploadWithHsToken(data, port, token)
+        assert.equal(response.statusCode, 200)
+    })
+
+    it('rejects an app-signed token for an account that has NOT delegated to the app', async function() {
+        this.slow(1000)
+        const token = makeHsToken({author: 'hsplain', signer: testKeys.app})
+        const {response} = await uploadWithHsToken(data, port, token)
+        assert.equal(response.statusCode, 400)
+    })
+
+    it('rejects a token signed by a key held only under owner authority', async function() {
+        this.slow(1000)
+        const token = makeHsToken({author: 'hsowneronly', signer: testKeys.bar})
+        const {response} = await uploadWithHsToken(data, port, token)
+        assert.equal(response.statusCode, 400)
+    })
+
+    it('rejects a token signed by a key whose weight is below the authority threshold', async function() {
+        this.slow(1000)
+        const token = makeHsToken({author: 'hslowweight', signer: testKeys.bar})
+        const {response} = await uploadWithHsToken(data, port, token)
+        assert.equal(response.statusCode, 400)
+    })
+
+    it('rejects a token for an account that does not exist', async function() {
+        this.slow(1000)
+        const token = makeHsToken({author: 'nosuchaccount', signer: testKeys.bar})
+        const {response} = await uploadWithHsToken(data, port, token)
+        assert.equal(response.statusCode, 404)
+    })
+
+    it('keeps APP_ACCOUNT aligned with the delegation fixture', function() {
+        assert.equal(APP_ACCOUNT, 'ecency.app')
+    })
 })

--- a/test/upload.ts
+++ b/test/upload.ts
@@ -232,7 +232,92 @@ describe('hivesigner upload auth', function() {
         assert.equal(response.statusCode, 404)
     })
 
+    it('rejects an app-signed token when the account delegated only ACTIVE and the app signed with posting', async function() {
+        // A delegation is satisfied only by the delegate's authority at the SAME
+        // level. Collapsing the two let the app's weaker, far more widely held
+        // posting key stand in for an active-authority delegation.
+        this.slow(1000)
+        const token = makeHsToken({author: 'hsactiveonly', signer: testKeys.app})
+        const {response} = await uploadWithHsToken(data, port, token)
+        assert.equal(response.statusCode, 400)
+    })
+
+    it('accepts an app-signed token when the account delegated ACTIVE and the app signed with its active key', async function() {
+        this.slow(1000)
+        const token = makeHsToken({author: 'hsactiveonly', signer: testKeys.appActive})
+        const {response} = await uploadWithHsToken(data, port, token)
+        assert.equal(response.statusCode, 200)
+    })
+
+    it('rejects an app active-key signature against a posting-only delegation', async function() {
+        this.slow(1000)
+        const token = makeHsToken({author: 'hsdelegator', signer: testKeys.appActive})
+        const {response} = await uploadWithHsToken(data, port, token)
+        assert.equal(response.statusCode, 400)
+    })
+
     it('keeps APP_ACCOUNT aligned with the delegation fixture', function() {
         assert.equal(APP_ACCOUNT, 'ecency.app')
+    })
+})
+
+
+async function uploadWithHiveSigParam(data: Buffer, port: number, username: string, token: string) {
+    return new Promise<any>((resolve, reject) => {
+        const payload = {
+            image_file: {filename: 'test.jpg', buffer: data, content_type: 'image/jpeg'},
+        }
+        const sig = encodeURIComponent(`hive${ token }`)
+        needle.post(`:${ port }/${ username }/${ sig }`, payload, {multipart: true}, (error, response, body) => {
+            if (error) { reject(error) } else { resolve({response, body}) }
+        })
+    })
+}
+
+/** Same token, but base64 rather than base64url: this path decodes it directly. */
+function makeHiveParamToken(opts: {author: string, signer: any}) {
+    const signedMessage = {type: 'posting', app: 'ecency.app'}
+    const authors = [opts.author]
+    const timestamp = 1700000000
+    const message = JSON.stringify({signed_message: signedMessage, authors, timestamp})
+    const hash = crypto.createHash('sha256').update(message).digest()
+    const signature = opts.signer.sign(Buffer.from(hash)).toString()
+    return Buffer.from(JSON.stringify({signed_message: signedMessage, authors, timestamp, signatures: [signature]}))
+        .toString('base64')
+}
+
+describe('hivesigner token replay via the username path', function() {
+    const port = 63208
+    const server = http.createServer(app.callback())
+    let data: Buffer
+
+    before((done) => {
+        data = fs.readFileSync(path.resolve(__dirname, 'test.jpg'))
+        server.listen(port, 'localhost', done)
+    })
+    after((done) => { server.close(done) })
+
+    it('rejects a token whose author does not match the username in the URL', async function() {
+        // The app signature verifies (it is genuinely the app's key), so without
+        // an author/account check the upload would be accepted and attributed to
+        // the URL account, spending their quota and their abuse-report standing.
+        this.slow(1000)
+        const token = makeHiveParamToken({author: 'hsdelegator', signer: testKeys.appConfigured})
+        const {response} = await uploadWithHiveSigParam(data, port, 'hsplain', token)
+        assert.equal(response.statusCode, 400)
+    })
+
+    it('rejects a self-signed token replayed under another username', async function() {
+        this.slow(1000)
+        const token = makeHiveParamToken({author: 'hsplain', signer: testKeys.bar})
+        const {response} = await uploadWithHiveSigParam(data, port, 'hsdelegator', token)
+        assert.equal(response.statusCode, 400)
+    })
+
+    it('still accepts a token whose author matches the username', async function() {
+        this.slow(1000)
+        const token = makeHiveParamToken({author: 'hsplain', signer: testKeys.bar})
+        const {response} = await uploadWithHiveSigParam(data, port, 'hsplain', token)
+        assert.equal(response.statusCode, 200)
     })
 })


### PR DESCRIPTION
Closes #26.

`uploadHsHandler` set `validSignature = true` on finding `app_account` in the account's `account_auths`, without consulting the token signature. Every account that has logged in through HiveSigner carries `ecency.app` in its posting `account_auths`, so naming one was enough to upload as them with an arbitrary signature.

Delegation establishes *who may act* for an account, not *that a request came from them*.

## What changed

The delegated case is still honoured, but the signature now has to verify against the delegate's own on-chain keys. `getAccount` is Redis-cached, so that lookup is cheap, and verifying against chain state rather than `app_posting_wif` alone means **a rotated app key keeps working** where the old code depended on config staying in sync.

Two divergences from the direct upload path came along:

- The token paths iterated **`owner`** key_auths. `uploadHandler` excludes owner deliberately, with a comment explaining why.
- Neither enforced **`weight_threshold`**, so one key of a multisig authority authorised on its own.

Both now go through a shared `authoritySignedBy()` helper, so the three call sites cannot drift again.

## A second copy

The same block existed again in `uploadHandler`, for a `signature` param prefixed with `hive`. No `account_auths` shortcut there, but the same owner and threshold weaknesses. It uses the shared helpers now too.

## Unrelated bug found on the same line

`PrivateKey.fromString('')` throws `Private key network id mismatch`, and the app key was derived **per request**. So an unset or rotated-out `app_posting_wif` failed every HiveSigner upload with a 500 before any verification ran, instead of falling through to the account's own keys. It is now derived once at module load and allowed to be absent.

This is also why the path was untestable: `app_posting_wif` is empty in `config/test.toml`.

## Tests

The `/hs/` path had **no coverage at all**, which is why this survived. Eight cases added:

- rejects a bogus signature for an account that delegated to the app (the regression)
- accepts a token signed by the account's own posting key
- accepts a token signed by the delegate app account's key when delegated
- rejects an app-signed token for an account that has *not* delegated
- rejects a key held only under `owner`
- rejects a key whose weight is below the threshold
- rejects an unknown account

Suite 284 to 292 passing. The 4 failures on `main` (`serve` x1, `constants` x3) are unchanged and unrelated.

Mutation-checked all three guards, each caught by exactly one test: restoring the `account_auths` shortcut, adding `owner` back, and dropping the threshold check.

`tsc --noEmit` clean; `eslint 'src/**/*.ts'` clean.

## Not fixed here, worth a look

In `uploadHandler`'s token branch, `tokenObj.authors[0]` is never checked against `ctx.params['username']`. The signature is verified against the URL user's keys, so it is not forgeable, but a token legitimately signed by the **app** key for user A can be replayed at `/userB/hive<token>` to upload as user B. Left alone because tightening it could break a real client flow and that is your call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened upload authentication and signature validation.
  * Added support for delegated app authority while enforcing the correct authority level and signature weight.
  * Prevented owner-only, insufficient-weight, invalid, and replayed signatures from authenticating uploads.
  * Ensured signed tokens can only authenticate the account they identify.

* **Tests**
  * Expanded coverage for valid and invalid HiveSigner tokens, delegated authority, and app-key rotation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->