### PR TITLE
Reject malformed proxy keys, keep error and placeholder responses out of the caches, fit the fetch deadline under the edge timeout

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -141,7 +141,7 @@ max_custom_image_height = 2000
 # render slack, so an exhausted mirror walk answers with the placeholder before
 # the edge cuts the request off as a 503. An override is taken as given; keep it
 # under that budget or the placeholder path is dead code again.
-#fetch_deadline_ms = 13000
+#fetch_deadline_ms = 12000
 
 # Threads libvips uses per operation. Sharp already clamps this to 1 on glibc,
 # but only while it does not detect jemalloc, so setting it explicitly makes the

--- a/config/default.toml
+++ b/config/default.toml
@@ -136,9 +136,12 @@ max_custom_image_height = 2000
 # s3_bucket = 'eretention'
 
 # Wall-clock budget for the whole upstream fetch chain of one request, in ms.
-# Must stay well under Varnish's 60s backend first_byte_timeout so an exhausted
-# mirror walk can attempt the placeholder rather than being cut off as a 503.
-#fetch_deadline_ms = 25000
+# The default is derived in src/constants.ts from the 20s first_byte_timeout the
+# Varnish VCL gives the image backend, minus the reserved default-image fetch and
+# render slack, so an exhausted mirror walk answers with the placeholder before
+# the edge cuts the request off as a 503. An override is taken as given; keep it
+# under that budget or the placeholder path is dead code again.
+#fetch_deadline_ms = 13000
 
 # Threads libvips uses per operation. Sharp already clamps this to 1 on glibc,
 # but only while it does not detect jemalloc, so setting it explicitly makes the

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -143,30 +143,6 @@ export function applyUrlReplacements(urlString: string): string {
 }
 
 /**
- * Wall-clock budget for the whole upstream fetch chain of one request.
- *
- * A proxy miss can walk up to eight mirror candidates, and each candidate used to
- * get the full 10s for every phase, so a request against a dead-but-listening
- * origin could spend well over a minute upstream. Varnish gives the backend 60s
- * (the VCL sets no first_byte_timeout, so its default applies) and Cloudflare 100s,
- * so the origin's own budget exceeded the one its caller was willing to wait: the
- * request was cut off as a 503 rather than finishing as a placeholder. That
- * inversion is the likeliest source of the standing 1.0% 503 rate.
- *
- * 25s leaves room for the reserved default-image fetch, a metadata re-walk and a
- * worst-case encode while staying comfortably under 60s.
- *
- * Retune without a rebuild by restarting with
- * NODE_CONFIG='{"fetch_deadline_ms":40000}': config/ is baked into the image, so
- * editing a toml on the box does nothing unless it is mounted.
- */
-export const FETCH_DEADLINE_MS = (() => {
-    if (!config.has('fetch_deadline_ms')) { return 25000 }
-    const v = Number(config.get('fetch_deadline_ms'))
-    return Number.isSafeInteger(v) && v > 0 ? v : 25000
-})()
-
-/**
  * Per-candidate phase timeouts.
  *
  * needle arms these as separate serial phases and re-arms them per redirect leg,
@@ -198,3 +174,42 @@ export const FETCH_DEFAULT_OPEN_MS = 2000
 export const FETCH_DEFAULT_RESPONSE_MS = 3000
 export const FETCH_DEFAULT_READ_MS = 3000
 export const FETCH_DEFAULT_WALL_MS = 5000
+
+/**
+ * First-byte timeout the cache in front of this service grants the image
+ * backend. This is Varnish's `.first_byte_timeout` for the proxy backend in the
+ * deployed VCL, not Varnish's 60s default: a request the origin has not started
+ * answering by then is cut off and the client gets a 503. Every budget below is
+ * derived from it, so that a change here is the one place to retune.
+ */
+export const EDGE_FIRST_BYTE_TIMEOUT_MS = 20000
+
+/**
+ * Wall-clock budget for the whole upstream fetch chain of one request.
+ *
+ * A proxy miss can walk up to eight mirror candidates, and each candidate used to
+ * get the full 10s for every phase, so a request against a dead-but-listening
+ * origin could spend well over a minute upstream. The origin's own budget then
+ * exceeded the one its caller was willing to wait, so the request was cut off as
+ * a 503 rather than finishing as a placeholder.
+ *
+ * The first attempt at this budget assumed the 60s Varnish default and picked
+ * 25s. The deployed VCL sets 20s, so every walk that pressed against the 25s
+ * budget was still a 503 at exactly 20s, and the placeholder path could never
+ * win the race. The default is now derived: the walk must end early enough for
+ * the reserved default-image fetch (its own worst case, FETCH_DEFAULT_WALL_MS)
+ * and the render (FETCH_RENDER_SLACK_MS) to complete inside the edge budget.
+ *
+ * Retune without a rebuild by restarting with
+ * NODE_CONFIG='{"fetch_deadline_ms":11000}': config/ is baked into the image, so
+ * editing a toml on the box does nothing unless it is mounted. An override is
+ * taken as given, but the default is the value that is known to fit.
+ */
+export const FETCH_RENDER_SLACK_MS = 2000
+export const FETCH_DEADLINE_DEFAULT_MS =
+    EDGE_FIRST_BYTE_TIMEOUT_MS - FETCH_DEFAULT_WALL_MS - FETCH_RENDER_SLACK_MS
+export const FETCH_DEADLINE_MS = (() => {
+    if (!config.has('fetch_deadline_ms')) { return FETCH_DEADLINE_DEFAULT_MS }
+    const v = Number(config.get('fetch_deadline_ms'))
+    return Number.isSafeInteger(v) && v > 0 ? v : FETCH_DEADLINE_DEFAULT_MS
+})()

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -200,12 +200,20 @@ export const EDGE_FIRST_BYTE_TIMEOUT_MS = 20000
  * the reserved default-image fetch (its own worst case, FETCH_DEFAULT_WALL_MS)
  * and the render (FETCH_RENDER_SLACK_MS) to complete inside the edge budget.
  *
+ * The render slack is a heuristic, not an enforced limit: metadata, the encode
+ * gate's queue wait and the encode itself are not deadline-aware, so a saturated
+ * worker can still push the first byte past the edge cutoff. It is sized for the
+ * measured shape (a placeholder encode is tens of milliseconds, queue waits are
+ * usually well under a second at the production limit) with headroom, and it
+ * costs nothing in mirror depth: the first slow candidate's 12s wall consumes a
+ * 12s and a 13s budget identically, so the second candidate never ran either way.
+ *
  * Retune without a rebuild by restarting with
  * NODE_CONFIG='{"fetch_deadline_ms":11000}': config/ is baked into the image, so
  * editing a toml on the box does nothing unless it is mounted. An override is
  * taken as given, but the default is the value that is known to fit.
  */
-export const FETCH_RENDER_SLACK_MS = 2000
+export const FETCH_RENDER_SLACK_MS = 3000
 export const FETCH_DEADLINE_DEFAULT_MS =
     EDGE_FIRST_BYTE_TIMEOUT_MS - FETCH_DEFAULT_WALL_MS - FETCH_RENDER_SLACK_MS
 export const FETCH_DEADLINE_MS = (() => {

--- a/src/error.ts
+++ b/src/error.ts
@@ -126,7 +126,17 @@ export async function errorMiddleware(ctx: KoaContext, next: () => Promise<any>)
         }
         const error = err instanceof APIError ? err : new APIError({cause: err})
         ctx.status = error.statusCode
-        ctx.set('Cache-Control', 'no-cache')
+        // An error body must not be cached anywhere and must not be revalidatable.
+        // Handlers set the image's ETag before they do any work, so a failure that
+        // happens after that point would otherwise leave here wearing the ETag of
+        // the image it failed to produce. With `no-cache` the edge kept such a body
+        // and revalidated it conditionally; the origin then rendered the real image
+        // under the same ETag, the cache in between turned that into a 304, and the
+        // edge kept serving the stale error as a hit. no-store forbids storing it
+        // at all, and without validators there is nothing to revalidate against.
+        ctx.set('Cache-Control', 'no-store, no-cache')
+        ctx.remove('ETag')
+        ctx.remove('Last-Modified')
         ctx['api_error'] = error
         ctx.body = {error}
         ctx.app.emit('error', error, ctx)

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -63,6 +63,6 @@ export async function serveOrBuildFallbackImage(
 
     ctx.set('Content-Type', contentType)
     ctx.set('Vary', 'Accept')
-    ctx.set('Cache-Control', 'public,max-age=600')
+    ctx.set('Cache-Control', 'public,max-age=120') // fallback contract: 2 minutes
     ctx.body = rv
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -85,6 +85,21 @@ export function shouldCacheOriginal(
     if (cap <= 0) { return false }
     return bytes <= MAX_IMAGE_SIZE && bytes <= cap
 }
+
+/**
+ * ETag for a placeholder served in place of `imageKey`.
+ *
+ * The real variant's ETag is derived from the key alone, so a placeholder that
+ * shared it would be validated by the real image and vice versa: a cache holding
+ * the placeholder asks "still the same?", the origin answers with the recovered
+ * image under the same ETag, the cache in front of us collapses that into a 304,
+ * and the placeholder outlives its 120s contract by as long as anyone keeps
+ * asking. Deterministic, so a placeholder still revalidates as a placeholder.
+ */
+export function fallbackEtag(imageKey: string): string {
+    return etag(imageKey + '|fallback')
+}
+
 const SERVICE_URL = new URL(config.get('service_url'))
 
 // Public proxy hosts that old post bodies wrapped around img.esteem.ws URLs
@@ -179,9 +194,11 @@ async function convertCachedMatchVariant(
 export async function proxyHandler(ctx: KoaContext) {
     ctx.tag({handler: 'proxy'})
     // One budget for every upstream fetch this request makes, including the
-    // metadata re-walk. Keeps the origin's own worst case comfortably under the
-    // 60s Varnish allows the backend, so an exhausted chain gets the chance to
-    // answer with a placeholder instead of being cut off as a 503.
+    // metadata re-walk. It is sized so that the walk, the reserved default-image
+    // fetch and the render all fit inside the first-byte timeout the cache in
+    // front of this service gives the backend (see FETCH_DEADLINE_MS), so an
+    // exhausted chain gets the chance to answer with a placeholder instead of
+    // being cut off as a 503.
     const fetchDeadlineAt = Date.now() + FETCH_DEADLINE_MS
 
     APIError.assert(ctx.method === 'GET', APIError.Code.InvalidMethod)
@@ -400,6 +417,7 @@ export async function proxyHandler(ctx: KoaContext) {
         const variantCacheControl = isDefaultImage
             ? 'public,max-age=120' // fallback contract: 2 minutes
             : 'public,max-age=31536000,immutable'
+        if (isDefaultImage) { ctx.set('ETag', fallbackEtag(imageKey)) }
         if (options.format === OutputFormat.Match && needsMatchFallback(mimeType, acceptHeader)) {
             ctx.tag({match_fallback: true})
             const cached = await readStream(stream)
@@ -770,6 +788,7 @@ export async function proxyHandler(ctx: KoaContext) {
     if (isDefaultImage) {
         ctx.log.error({ finalUrl: urlString }, 'Responding with default image')
         ctx.set('Cache-Control', 'public,max-age=120') // fallback contract: 2 minutes
+        ctx.set('ETag', fallbackEtag(imageKey))
     } else {
         ctx.set('Cache-Control', 'public,max-age=31536000,immutable') // 1 year
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ import Sharp from 'sharp'
 import { URL } from 'url'
 
 import { domainBlacklist, imageBlacklist } from './blacklist'
-import { DEFAULT_FALLBACK_IMAGE_URL, INTERNAL_SERVICE_ORIGINS, isEmptyImageUrl, MAX_INPUT_PIXELS } from './constants'
+import { INTERNAL_SERVICE_ORIGINS, isEmptyImageUrl, MAX_INPUT_PIXELS } from './constants'
 import { APIError } from './error'
 import {fetchImageWithFallbacks} from './fetch-image'
 import { logger } from './logger'
@@ -269,14 +269,29 @@ export function safeParseInt(value: any): number | undefined {
     return isNaN(basicNumber) ? undefined : basicNumber
 }
 
+/**
+ * Decodes a /p/<key> path segment back into the source URL.
+ *
+ * A key that does not decode, or decodes to something that is not a URL, is a
+ * client error and is rejected as one. It used to be substituted with the 1x1
+ * placeholder upload instead, without being marked as a fallback, so the request
+ * went on through the normal pipeline: the pixel was rendered, stored under the
+ * placeholder's own key and served with the immutable 1y header, and a transient
+ * failure on that path was cached at the edge under the image's ETag. A malformed
+ * key can never become valid, so there is nothing to stand in for.
+ * Raw URLs are deliberately not accepted here either.
+ */
 export function parseProxiedUrl(value: string): URL {
+    let decoded: string
     try {
-        const decoded = base58Dec(value).replace(/\/+$/, '')
+        decoded = base58Dec(value).replace(/\/+$/, '')
+    } catch (cause) {
+        throw new APIError({cause, code: APIError.Code.InvalidProxyUrl, info: {reason: 'key is not base58'}})
+    }
+    try {
         return new URL(decoded)
     } catch (cause) {
-        // Fail fast on decode errors - do not accept raw URLs as this is a security risk
-        // Return default fallback image instead
-        return new URL(DEFAULT_FALLBACK_IMAGE_URL)
+        throw new APIError({cause, code: APIError.Code.InvalidProxyUrl, info: {reason: 'key does not decode to a URL'}})
     }
 }
 

--- a/test/encode-limit.ts
+++ b/test/encode-limit.ts
@@ -129,6 +129,7 @@ describe('encode concurrency limit', function() {
                 body: undefined as any,
                 emitted,
                 log: {debug: () => undefined},
+                remove: () => undefined,
                 set: () => undefined,
                 status: 0,
                 url: '/p/test',

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -8,9 +8,11 @@ import * as multihash from 'multihashes'
 import * as path from 'path'
 import * as fs from 'fs'
 import sharp from 'sharp'
+import Koa from 'koa'
 
 import {app} from './../src/app'
-import {fetchImageWithFallbacks} from './../src/fetch-image'
+import {APIError, errorMiddleware} from './../src/error'
+import {clearDeadUrl, fetchImageWithFallbacks, markDeadUrl} from './../src/fetch-image'
 import {initBlacklistService} from './../src/blacklist-service'
 import {proxyStore, uploadStore} from './../src/common'
 import {DEFAULT_FALLBACK_IMAGE_URL, MAX_CACHED_ORIGINAL_SIZE, SERVICE_BASE_URL} from './../src/constants'
@@ -61,6 +63,118 @@ describe('proxy', function() {
         assert.equal(meta.height, 67)
         assert.equal(meta.format, 'jpeg')
         assert.equal(meta.space, 'srgb')
+    })
+
+    describe('error and placeholder responses stay out of the caches', function() {
+        // The 1x1 placeholder upload and the default avatar are fetched from the
+        // configured hosts when the substituted paths run; nothing below depends on
+        // that fetch succeeding except the placeholder tests, which say so.
+
+        it('answers a malformed proxy key with a 400 and nothing a cache could keep', async function() {
+            this.slow(1000)
+            for (const bad of ['not-valid-base58!!!', base58Enc('not a url'),
+                '3W72119s5BjW3w55E9m2dpuZgVrNq2aY9kcSn9SY4wgjN3KWKyHprjyV9f7rjvBoQnFKrVP9XPjYGE3jRJcJqyq']) {
+                const res = await needle('get', `http://localhost:${ port }/p/${ bad }?format=match&height=500&mode=fit&width=600`)
+                assert.equal(res.statusCode, 400, `${ bad }: status`)
+                assert.equal(res.body.error.name, 'invalid_proxy_url', `${ bad }: body ${ JSON.stringify(res.body) }`)
+                assert.equal(res.headers['etag'], undefined, `${ bad }: error response must carry no ETag`)
+                assert.equal(res.headers['last-modified'], undefined, `${ bad }: error response must carry no Last-Modified`)
+                assert.equal(res.headers['cache-control'], 'no-store, no-cache', `${ bad }: cache-control`)
+            }
+        })
+
+        it('answers an error with no-store even on a path that had already set headers', async function() {
+            this.slow(1000)
+            serveImage = true
+            const source = `http://localhost:${ port+1 }/test.jpg`
+            const res = await needle('get', `http://localhost:${ port }/p/${ base58Enc(source) }?width=100&mode=fit&invalidate=1`)
+            assert.equal(res.statusCode, 403)
+            assert.equal(res.headers['etag'], undefined)
+            assert.equal(res.headers['cache-control'], 'no-store, no-cache')
+        })
+
+        it('strips validators the handler set before it failed', async function() {
+            // The handlers set ETag(imageKey) before doing any work, so an error
+            // raised later would otherwise go out wearing the image's validator and
+            // a cache could revalidate the error body against the real image
+            const failing = new Koa()
+            failing.on('error', () => undefined) // the thrown APIError is the point of the test
+            failing.use(errorMiddleware as any)
+            failing.use(async (ctx) => {
+                ctx.set('ETag', '"the-image-etag"')
+                ctx.set('Last-Modified', new Date().toUTCString())
+                ctx.set('Cache-Control', 'public,max-age=31536000,immutable')
+                throw new APIError({code: APIError.Code.InvalidImage})
+            })
+            const failingServer = http.createServer(failing.callback())
+            await new Promise<void>((resolve) => failingServer.listen(0, 'localhost', () => resolve()))
+            try {
+                const failingPort = (failingServer.address() as any).port
+                const res = await needle('get', `http://localhost:${ failingPort }/anything`)
+                assert.equal(res.statusCode, 400)
+                assert.equal(res.headers['etag'], undefined, 'ETag set before the failure must not survive it')
+                assert.equal(res.headers['last-modified'], undefined, 'Last-Modified set before the failure must not survive it')
+                assert.equal(res.headers['cache-control'], 'no-store, no-cache')
+            } finally {
+                await new Promise<void>((resolve) => failingServer.close(() => resolve()))
+            }
+        })
+
+        it('gives a placeholder for a dead source its own ETag and the 120s contract', async function() {
+            this.slow(5000)
+            this.timeout(15000)
+            const source = `http://localhost:${ port+1 }/etag-placeholder-${ Date.now() }.jpg`
+            const url = `http://localhost:${ port }/p/${ base58Enc(source) }?width=100&mode=fit`
+            // A negatively cached URL skips the mirror walk and goes straight to the
+            // default image, which is the fetch-fallback path with the source's key
+            await markDeadUrl(source)
+            try {
+                const placeholder = await needle('get', url)
+                assert.equal(placeholder.statusCode, 200)
+                assert.equal(placeholder.headers['cache-control'], 'public,max-age=120')
+                assert(placeholder.headers['etag'], 'placeholder carries an ETag so a placeholder still revalidates as one')
+                const again = await needle('get', url)
+                assert.equal(again.headers['etag'], placeholder.headers['etag'], 'placeholder ETag is deterministic')
+
+                // Now the source is alive: the real image must not share the placeholder's ETag,
+                // or a cache holding the placeholder would be told it is still current
+                await clearDeadUrl(source)
+                serveImage = true
+                const real = await needle('get', url)
+                assert.equal(real.statusCode, 200)
+                assert.equal(real.headers['cache-control'], 'public,max-age=31536000,immutable')
+                assert.equal((await sharp(real.body).metadata()).width, 100)
+                assert.notEqual(real.headers['etag'], placeholder.headers['etag'],
+                    'real image and its placeholder must never validate each other')
+            } finally {
+                await clearDeadUrl(source)
+            }
+        })
+
+        it('serves the built placeholder for an unsupported source type under the 120s contract', async function() {
+            this.slow(5000)
+            this.timeout(15000)
+            // A binary body needle keeps as a Buffer (a text body comes back as a
+            // string and the fetch chain rejects it before this path is reached),
+            // with magic bytes that match no image type
+            const textServer = http.createServer((_req, res) => {
+                res.writeHead(200, {'content-type': 'application/octet-stream'})
+                res.end(Buffer.from([0x00, 0x01, 0x02, 0x03, 0x7f, 0x45, 0x4c, 0x46, 0xde, 0xad, 0xbe, 0xef]))
+            })
+            await new Promise<void>((resolve) => textServer.listen(0, 'localhost', () => resolve()))
+            const textPort = (textServer.address() as any).port
+            try {
+                const res = await needle('get',
+                    `http://localhost:${ port }/p/${ base58Enc(`http://localhost:${ textPort }/notes.txt`) }?width=100&mode=fit`)
+                assert.equal(res.statusCode, 200)
+                // the builder always renders the default as JPEG for format=match,
+                // which is how this path is told apart from the fetch-fallback one
+                assert.equal(res.headers['content-type'], 'image/jpeg')
+                assert.equal(res.headers['cache-control'], 'public,max-age=120')
+            } finally {
+                await new Promise<void>((resolve) => textServer.close(() => resolve()))
+            }
+        })
     })
 
     it('should proxy stored image when source is gone', async function() {

--- a/test/serve.ts
+++ b/test/serve.ts
@@ -84,6 +84,8 @@ describe('serve', function() {
             method: 'POST',
             params: { hash: 'DQmSomeHash', filename: 'test.jpg' },
             tag() {},
+            set() {},
+            remove() {},
             app: { emit() {} },
         }
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -518,9 +518,12 @@ describe('constants', function() {
             assert.equal(EDGE_FIRST_BYTE_TIMEOUT_MS, 20000)
             assert(FETCH_DEADLINE_DEFAULT_MS + FETCH_DEFAULT_WALL_MS + FETCH_RENDER_SLACK_MS <= EDGE_FIRST_BYTE_TIMEOUT_MS,
                 `deadline ${ FETCH_DEADLINE_DEFAULT_MS } + default fetch ${ FETCH_DEFAULT_WALL_MS } + render ${ FETCH_RENDER_SLACK_MS } exceeds ${ EDGE_FIRST_BYTE_TIMEOUT_MS }`)
-            // and it still leaves room for a full slow candidate plus at least the
-            // minimum needed to start another, or the chain degenerates to one try
-            assert(FETCH_DEADLINE_DEFAULT_MS >= FETCH_CANDIDATE_WALL_MS + FETCH_MIN_REMAINING_MS - 1000)
+            // and it still lets one slow candidate run to its own wall, so a
+            // slow-but-alive origin is not cut off by the budget before its
+            // per-candidate timeout has had its say
+            assert(FETCH_DEADLINE_DEFAULT_MS >= FETCH_CANDIDATE_WALL_MS,
+                `deadline ${ FETCH_DEADLINE_DEFAULT_MS } is shorter than one candidate wall ${ FETCH_CANDIDATE_WALL_MS }`)
+            assert(FETCH_MIN_REMAINING_MS > 0)
             // the test config sets no override, so the live value is the default
             assert.equal(FETCH_DEADLINE_MS, FETCH_DEADLINE_DEFAULT_MS)
         })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -34,7 +34,7 @@ import {
     expandPurgeUrls,
 } from './../src/utils'
 
-import {AVIF_EFFORT, DEFAULT_AVATAR_HASH, DEFAULT_FALLBACK_IMAGE_URL, EMPTY_IMAGE_URL_PATTERNS, INTERNAL_SERVICE_ORIGINS, LEGACY_SERVICE_BASE_URL, SERVICE_BASE_URL, SPECIAL_EMPTY_IMAGE_PATH, applyUrlReplacements, isEmptyImageUrl, startsWithEmptyImagePrefix} from './../src/constants'
+import {AVIF_EFFORT, DEFAULT_AVATAR_HASH, DEFAULT_FALLBACK_IMAGE_URL, EDGE_FIRST_BYTE_TIMEOUT_MS, EMPTY_IMAGE_URL_PATTERNS, FETCH_CANDIDATE_WALL_MS, FETCH_DEADLINE_DEFAULT_MS, FETCH_DEADLINE_MS, FETCH_DEFAULT_WALL_MS, FETCH_MIN_REMAINING_MS, FETCH_RENDER_SLACK_MS, INTERNAL_SERVICE_ORIGINS, LEGACY_SERVICE_BASE_URL, SERVICE_BASE_URL, SPECIAL_EMPTY_IMAGE_PATH, applyUrlReplacements, isEmptyImageUrl, startsWithEmptyImagePrefix} from './../src/constants'
 
 import { APIError } from './../src/error'
 
@@ -299,15 +299,29 @@ describe('utils', function() {
             assert.equal(result.toString(), 'https://example.com/image.jpg')
         })
 
-        it('should return fallback for invalid base58', function() {
-            const result = parseProxiedUrl('not-valid-base58!!!')
-            assert.equal(result.toString(), DEFAULT_FALLBACK_IMAGE_URL)
+        const rejectsAsInvalidProxyUrl = (err: any) =>
+            err instanceof APIError && err.code === APIError.Code.InvalidProxyUrl
+
+        it('rejects a key that is not base58 as a client error', function() {
+            // Used to substitute the 1x1 placeholder upload silently, which then
+            // travelled the normal pipeline as a real image (stored, immutable)
+            assert.throws(() => parseProxiedUrl('not-valid-base58!!!'), rejectsAsInvalidProxyUrl)
         })
 
-        it('should return fallback for non-URL after decoding', function() {
-            const encoded = base58Enc('not a url')
-            const result = parseProxiedUrl(encoded)
-            assert.equal(result.toString(), DEFAULT_FALLBACK_IMAGE_URL)
+        it('rejects a key that decodes to something other than a URL', function() {
+            assert.throws(() => parseProxiedUrl(base58Enc('not a url')), rejectsAsInvalidProxyUrl)
+            // valid base58 whose bytes are binary noise, the shape seen in production
+            assert.throws(() => parseProxiedUrl(
+                '3W72119s5BjW3w55E9m2dpuZgVrNq2aY9kcSn9SY4wgjN3KWKyHprjyV9f7rjvBoQnFKrVP9XPjYGE3jRJcJqyq'),
+                rejectsAsInvalidProxyUrl)
+        })
+
+        it('never resolves an undecodable key to the placeholder upload', function() {
+            for (const bad of ['not-valid-base58!!!', base58Enc('not a url')]) {
+                let resolved: URL | undefined
+                try { resolved = parseProxiedUrl(bad) } catch (_e) { /* expected */ }
+                assert.equal(resolved, undefined, `${ bad } resolved to ${ resolved }`)
+            }
         })
     })
 
@@ -494,6 +508,21 @@ describe('constants', function() {
         it('should have valid DEFAULT_FALLBACK_IMAGE_URL', function() {
             assert(DEFAULT_FALLBACK_IMAGE_URL.startsWith(SERVICE_BASE_URL))
             assert(DEFAULT_FALLBACK_IMAGE_URL.includes('1x1_000000.png'))
+        })
+
+        it('fits the fetch deadline, the default-image fetch and the render inside the edge budget', function() {
+            // Varnish's .first_byte_timeout for the image backend. A walk that has
+            // not answered by then is a 503 at the edge regardless of what the
+            // origin does next, so the placeholder path only exists if the whole
+            // worst case ends before it. Change the VCL and this value together.
+            assert.equal(EDGE_FIRST_BYTE_TIMEOUT_MS, 20000)
+            assert(FETCH_DEADLINE_DEFAULT_MS + FETCH_DEFAULT_WALL_MS + FETCH_RENDER_SLACK_MS <= EDGE_FIRST_BYTE_TIMEOUT_MS,
+                `deadline ${ FETCH_DEADLINE_DEFAULT_MS } + default fetch ${ FETCH_DEFAULT_WALL_MS } + render ${ FETCH_RENDER_SLACK_MS } exceeds ${ EDGE_FIRST_BYTE_TIMEOUT_MS }`)
+            // and it still leaves room for a full slow candidate plus at least the
+            // minimum needed to start another, or the chain degenerates to one try
+            assert(FETCH_DEADLINE_DEFAULT_MS >= FETCH_CANDIDATE_WALL_MS + FETCH_MIN_REMAINING_MS - 1000)
+            // the test config sets no override, so the live value is the default
+            assert.equal(FETCH_DEADLINE_MS, FETCH_DEADLINE_DEFAULT_MS)
         })
 
         it('should have valid DEFAULT_AVATAR_HASH', function() {


### PR DESCRIPTION
Closes #33. Answers to the five questions in the issue, from the code and the live request data, then the changes.

**1. Which path emits the placeholder with the immutable header.** `parseProxiedUrl` caught any base58 or URL parse failure and returned the 1x1 placeholder upload URL without marking the request as a fallback. The handler then treated it as a proxy of an internal upload: rendered it, stored the variant under the placeholder's own key, and served it with `public,max-age=31536000,immutable` and `ETag(imageKey)`. The four top failing URLs are all keys that do not decode, which is why they share one body and one ETag.

**2. Was a poisoned key stored.** Not under a user's key. The variants live under the 1x1 upload's key, which is a legitimate render of that upload. Nothing to purge in the store.

**3 and 4. The 500 storm.** All but a handful of the daily 500s were edge cache HITs with origin status 0, content type JSON, one URL, from mobile clients. Six origin 500s in 24h became ~20k client 500s because the error response carried `Cache-Control: no-cache` plus the image's ETag, which the handler sets before it does any work. With origin cache control on, the edge caches a `no-cache` response and always revalidates it. It revalidated with If-None-Match, the origin rendered the real image under the same ETag, Varnish collapsed that 200 into a 304 (62 origin 304s in the same window), and the edge kept the stale error body as a hit. Nothing was retrying without backoff; the cache was faithfully re-serving one error.

**5. The 503s at 19 to 20 seconds.** Every 503 in the Varnish log is at exactly 20.00 s. The VCL sets `first_byte_timeout = 20s` for the image backend; #31 assumed the 60 s default and set the fetch deadline to 25 s, so the placeholder path could never win the race.

Changes:

- A malformed `/p/` key is a 400 (`invalid_proxy_url`). It can never become valid, so nothing stands in for it.
- Error responses are `Cache-Control: no-store, no-cache` with ETag and Last-Modified removed, so no cache keeps them and nothing can revalidate them.
- Placeholders served in place of a source carry their own deterministic ETag (`fallbackEtag`), so a cache holding one is never told it is current by the real image. The built-placeholder path now uses the 120 s fallback contract instead of 600 s.
- `FETCH_DEADLINE_MS` default is derived: `EDGE_FIRST_BYTE_TIMEOUT_MS (20 s) - FETCH_DEFAULT_WALL_MS (5 s) - FETCH_RENDER_SLACK_MS (2 s) = 13 s`. A test pins the sum. A `fetch_deadline_ms` override is still honoured as given.

Tests added for each: the parser rejects the production key shape; a middleware-level test proves validators set before a failure are stripped; a dead-source placeholder gets a different ETag from the recovered image and the 120 s header; the built placeholder path is exercised with a binary non-image body (a text body never reaches it, needle hands text back as a string and the chain rejects it); and the budget invariant. Each new test was checked to fail with its fix reverted. Two fake contexts in existing tests gained the `remove` method the middleware now calls; the serve one was already failing on main for lack of `set`.

Not in scope here, left for #34: the `ctx.fresh` 304 short-circuit in `proxy.ts` never fires (Koa's status is 404 at that point), and avatar/cover fallbacks still share the key-derived ETag with the real image.

Rollout notes: no config change needed, the host config does not override `fetch_deadline_ms`. The cached 500s at the edge heal on their next revalidation, which now gets a 400 with no validators. Existing immutable 1x1 edge copies for malformed keys stay until they expire or are purged by exact URL; they are blank pixels for keys that were always malformed, so purging is optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid proxy URLs now return a clear error instead of silently serving a placeholder image.
  * Error responses are no longer cached or revalidated.
  * Fetch deadlines now fit within the edge timeout budget, improving request reliability.

* **Behavior Changes**
  * Placeholder images use shorter caching periods and distinct cache validators.
  * Added coverage confirming correct caching, error handling, and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->