### PR TITLE
Size the libuv threadpool and cap encodes so they can never take the slots file reads need

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -207,6 +207,17 @@ ENV NODE_ENV=production
 # RSS until the box swaps. 2 arenas trades negligible alloc concurrency for far
 # lower, stable RSS.
 ENV MALLOC_ARENA_MAX=2
+# Size the libuv threadpool. Sharp encodes, fs reads, dns.lookup and zlib all
+# share it, and libuv's default is 4 threads per process. With encodes bounded
+# by encode-limit.ts (2 per worker on the production shape) the default left 2
+# slots for every cached-variant read and every mirror DNS lookup, and lowering
+# num_workers would have raised the encode share to all 4. 16 keeps the encode
+# cap CPU-driven and leaves the rest of the pool to the cheap work that makes up
+# most requests. Thread stacks are virtual memory; 16 per worker is negligible.
+# encode-limit.ts caps encodes to leave slots free whatever this is set to, and
+# app.ts logs the resulting budget at boot. Note libuv reads this with atoi():
+# a non-numeric value means ONE thread, not the default.
+ENV UV_THREADPOOL_SIZE=16
 
 HEALTHCHECK --interval=20s --timeout=10s --start-period=5s \
   CMD /bin/sh -c 'wget -nv -t1 -O /dev/null "http://localhost:${PORT}/healthcheck" || exit 1'

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import {KoaContext} from './common'
 import {APIError, errorMiddleware} from './error'
 import {logger, loggerMiddleware} from './logger'
 import {routes} from './routes'
+import {encodeBudget} from './encode-limit'
 import {getSharpConcurrency, parseBool} from './utils'
 
 export const app = new Koa()
@@ -115,8 +116,19 @@ async function main() {
         try {
             allocator = fs.readFileSync('/proc/self/maps', 'utf8').includes('jemalloc') ? 'jemalloc' : 'glibc'
         } catch (cause) { allocator = 'unknown' }
-        logger.warn({sharpConcurrency: getSharpConcurrency(), allocator, node: process.versions.node},
-            'image pipeline configured')
+        const budget = encodeBudget()
+        logger.warn({
+            sharpConcurrency: getSharpConcurrency(), allocator, node: process.versions.node,
+            libuvPool: budget.poolSize, encodeLimit: budget.limit, encodeRequested: budget.requested,
+            freePoolSlots: budget.freeSlots,
+        }, 'image pipeline configured')
+        if (budget.cappedByPool) {
+            // The CPU rule wanted more encodes than the pool can carry while still
+            // leaving room for file reads. Raise UV_THREADPOOL_SIZE rather than
+            // lowering num_workers further; see encode-limit.ts.
+            logger.warn({libuvPool: budget.poolSize, encodeRequested: budget.requested, encodeLimit: budget.limit},
+                'encode limit capped by the libuv threadpool size')
+        }
     }
 
     const exit = async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,7 @@ import {KoaContext} from './common'
 import {APIError, errorMiddleware} from './error'
 import {logger, loggerMiddleware} from './logger'
 import {routes} from './routes'
-import {encodeBudget} from './encode-limit'
+import {encodeBudget, RESERVED_POOL_SLOTS} from './encode-limit'
 import {getSharpConcurrency, parseBool} from './utils'
 
 export const app = new Koa()
@@ -122,12 +122,17 @@ async function main() {
             libuvPool: budget.poolSize, encodeLimit: budget.limit, encodeRequested: budget.requested,
             freePoolSlots: budget.freeSlots,
         }, 'image pipeline configured')
-        if (budget.cappedByPool) {
-            // The CPU rule wanted more encodes than the pool can carry while still
-            // leaving room for file reads. Raise UV_THREADPOOL_SIZE rather than
-            // lowering num_workers further; see encode-limit.ts.
-            logger.warn({libuvPool: budget.poolSize, encodeRequested: budget.requested, encodeLimit: budget.limit},
-                'encode limit capped by the libuv threadpool size')
+        if (budget.cappedByPool || budget.freeSlots < RESERVED_POOL_SLOTS) {
+            // Either the CPU rule wanted more encodes than the pool can carry while
+            // still leaving room for file reads, or the pool is so small that even
+            // one encode leaves fewer than the reserved slots free (a one-thread pool
+            // from a mistyped UV_THREADPOOL_SIZE does this without capping anything).
+            // Raise UV_THREADPOOL_SIZE rather than lowering num_workers; see
+            // encode-limit.ts.
+            logger.warn({
+                libuvPool: budget.poolSize, encodeRequested: budget.requested, encodeLimit: budget.limit,
+                freePoolSlots: budget.freeSlots, reservedPoolSlots: RESERVED_POOL_SLOTS, cappedByPool: budget.cappedByPool,
+            }, 'libuv threadpool too small for the encode limit plus the reserved slots')
         }
     }
 

--- a/src/encode-limit.ts
+++ b/src/encode-limit.ts
@@ -5,18 +5,27 @@ import os from 'os'
  * Bounds how many Sharp encodes run concurrently in this worker.
  *
  * Sharp's async work runs on the libuv threadpool — the SAME pool Node uses for
- * `fs` reads. That pool defaults to 4 slots per process. An AVIF encode occupies
- * a slot for seconds, so with encodes unbounded two things go wrong:
+ * `fs` reads, `dns.lookup` and zlib. libuv sizes that pool from UV_THREADPOOL_SIZE
+ * once per process and defaults to 4. An AVIF encode occupies a slot for seconds,
+ * so with encodes unbounded two things go wrong:
  *
  *   1. Cheap work starves. Serving an already-converted variant is just a file
  *      read, but it queues behind multi-second encodes. Measured on a loaded
  *      box: a 32KB cached variant took 0.46-8.08s to serve while the pure-JS
  *      healthcheck answered in 2ms — the event loop was fine, the pool was full.
+ *      A DNS lookup for a dead mirror holds a slot for the resolver timeout too.
  *   2. The CPU oversubscribes. More simultaneous encodes than cores does not
  *      increase throughput, it just makes every encode slower.
  *
  * Capping concurrency keeps slots free for the cheap reads that make up most
- * requests, and lets each encode finish sooner.
+ * requests, and lets each encode finish sooner. The two purposes have different
+ * inputs: the CPU bound comes from cores per worker, the starvation bound from
+ * the pool size. The limit honours both: it is the CPU figure, capped so that
+ * RESERVED_POOL_SLOTS of the pool can never be taken by encodes. Without the cap,
+ * lowering num_workers raised the per-worker limit until it consumed the whole
+ * default pool, recreating the starvation the file exists to prevent. The image
+ * sets UV_THREADPOOL_SIZE well above the default so the cap does not normally
+ * engage; app.ts logs the resulting budget at boot and warns when it does.
  *
  * NOTE: this limit is per worker process. Service-wide concurrency is
  * `max_concurrent_encodes * num_workers`.
@@ -24,20 +33,81 @@ import os from 'os'
 
 const CONFIG_KEY = 'max_concurrent_encodes'
 
-function resolveLimit(): number {
-    if (config.has(CONFIG_KEY)) {
-        const configured = Number.parseInt(config.get(CONFIG_KEY) as string, 10)
-        if (Number.isFinite(configured) && configured > 0) { return configured }
-    }
-    // Default: divide the machine across the workers that will compete for it,
-    // so the service-wide total lands near the core count rather than a multiple
-    // of it. Workers are what app.ts will actually fork (0 = autodetect).
-    let numWorkers = Number.parseInt(config.get('num_workers') as string, 10)
-    if (!Number.isFinite(numWorkers) || numWorkers <= 0) { numWorkers = os.cpus().length }
-    return Math.max(1, Math.floor(os.cpus().length / numWorkers))
+/** libuv's compiled-in default and ceiling for the threadpool. */
+export const LIBUV_DEFAULT_THREADPOOL_SIZE = 4
+export const LIBUV_MAX_THREADPOOL_SIZE = 1024
+/** Pool slots encodes may never take, kept for file reads, DNS and zlib. */
+export const RESERVED_POOL_SLOTS = 2
+
+/**
+ * The libuv threadpool size this process runs with, derived the way libuv does
+ * it (src/threadpool.c): `atoi()` of UV_THREADPOOL_SIZE when set, so a value
+ * that is not a number reads as 0 and becomes ONE thread, and a negative value
+ * wraps to the 1024 ceiling. Modelling those edges here is what lets the boot
+ * log say what the process actually got rather than what was intended.
+ */
+export function libuvThreadpoolSize(env: NodeJS.ProcessEnv = process.env): number {
+    const raw = env.UV_THREADPOOL_SIZE
+    if (raw === undefined) { return LIBUV_DEFAULT_THREADPOOL_SIZE }
+    const parsed = Number.parseInt(raw, 10)
+    const asAtoi = Number.isFinite(parsed) ? parsed : 0
+    if (asAtoi < 0) { return LIBUV_MAX_THREADPOOL_SIZE }
+    if (asAtoi === 0) { return 1 }
+    return Math.min(asAtoi, LIBUV_MAX_THREADPOOL_SIZE)
 }
 
-const LIMIT = resolveLimit()
+export interface EncodeBudget {
+    /** libuv threadpool slots in this process */
+    poolSize: number
+    /** what the CPU rule (or explicit config) asked for */
+    requested: number
+    /** the limit actually enforced */
+    limit: number
+    /** pool slots encodes can never occupy */
+    freeSlots: number
+    /** true when the pool, not the CPU rule, decided the limit */
+    cappedByPool: boolean
+}
+
+export function resolveEncodeBudget(input: {
+    cpus?: number
+    numWorkers?: number
+    configured?: number
+    poolSize?: number
+} = {}): EncodeBudget {
+    const cpus = input.cpus !== undefined ? input.cpus : os.cpus().length
+    const poolSize = input.poolSize !== undefined ? input.poolSize : libuvThreadpoolSize()
+
+    let requested: number | undefined
+    const configured = input.configured !== undefined
+        ? input.configured
+        : (config.has(CONFIG_KEY) ? Number.parseInt(config.get(CONFIG_KEY) as string, 10) : undefined)
+    if (configured !== undefined && Number.isFinite(configured) && configured > 0) {
+        requested = configured
+    } else {
+        // Default: divide the machine across the workers that will compete for it,
+        // so the service-wide total lands near the core count rather than a multiple
+        // of it. Workers are what app.ts will actually fork (0 = autodetect).
+        let numWorkers = input.numWorkers !== undefined
+            ? input.numWorkers
+            : Number.parseInt(config.get('num_workers') as string, 10)
+        if (!Number.isFinite(numWorkers) || numWorkers <= 0) { numWorkers = cpus }
+        requested = Math.max(1, Math.floor(cpus / numWorkers))
+    }
+
+    const poolCap = Math.max(1, poolSize - RESERVED_POOL_SLOTS)
+    const limit = Math.min(requested, poolCap)
+    return {
+        poolSize,
+        requested,
+        limit,
+        freeSlots: poolSize - limit,
+        cappedByPool: limit < requested,
+    }
+}
+
+const BUDGET = resolveEncodeBudget()
+const LIMIT = BUDGET.limit
 
 export const ENCODE_ABORTED = 'EncodeAborted'
 
@@ -184,4 +254,9 @@ export function clientGoneSignal(ctx: any): AbortSignal | undefined {
 /** Exposed for tests and diagnostics. */
 export function encodeLimitStats() {
     return { limit: LIMIT, active, queued: waiting.length }
+}
+
+/** The budget this worker booted with, for the startup log. */
+export function encodeBudget(): EncodeBudget {
+    return BUDGET
 }

--- a/src/encode-limit.ts
+++ b/src/encode-limit.ts
@@ -56,6 +56,14 @@ export function libuvThreadpoolSize(env: NodeJS.ProcessEnv = process.env): numbe
     return Math.min(asAtoi, LIBUV_MAX_THREADPOOL_SIZE)
 }
 
+/**
+ * The pool arithmetic for one worker. `freeSlots` is what GATED encodes can never
+ * occupy. Encodes below ENCODE_GATE_MIN_PIXELS and blur placeholders bypass the
+ * gate by design (they take 10-20ms and would otherwise queue behind full-size
+ * encodes, see runEncode), so a burst of them can briefly borrow from the free
+ * slots; that is bounded by their duration, not by this accounting, and is one
+ * of the reasons the image sizes the pool well above the default.
+ */
 export interface EncodeBudget {
     /** libuv threadpool slots in this process */
     poolSize: number
@@ -63,7 +71,7 @@ export interface EncodeBudget {
     requested: number
     /** the limit actually enforced */
     limit: number
-    /** pool slots encodes can never occupy */
+    /** pool slots gated encodes can never occupy */
     freeSlots: number
     /** true when the pool, not the CPU rule, decided the limit */
     cappedByPool: boolean

--- a/test/encode-limit.ts
+++ b/test/encode-limit.ts
@@ -2,7 +2,9 @@ import 'mocha'
 import assert from 'assert'
 
 import {
-    clientGoneSignal, encodeLimitStats, encodeNeedsSlot, isEncodeAborted, runEncode, withEncodeSlot,
+    clientGoneSignal, encodeBudget, encodeLimitStats, encodeNeedsSlot, isEncodeAborted,
+    LIBUV_DEFAULT_THREADPOOL_SIZE, LIBUV_MAX_THREADPOOL_SIZE, libuvThreadpoolSize, RESERVED_POOL_SLOTS,
+    resolveEncodeBudget, runEncode, withEncodeSlot,
 } from './../src/encode-limit'
 import {errorMiddleware} from './../src/error'
 
@@ -18,6 +20,65 @@ describe('encode concurrency limit', function() {
 
     it('resolves to a positive limit', function() {
         assert(limit >= 1, `limit should be at least 1, got ${ limit }`)
+    })
+
+    describe('libuv threadpool size', function() {
+        it('is 4 when UV_THREADPOOL_SIZE is unset', function() {
+            assert.equal(libuvThreadpoolSize({}), LIBUV_DEFAULT_THREADPOOL_SIZE)
+        })
+
+        it('reads a numeric UV_THREADPOOL_SIZE', function() {
+            assert.equal(libuvThreadpoolSize({UV_THREADPOOL_SIZE: '16'}), 16)
+            assert.equal(libuvThreadpoolSize({UV_THREADPOOL_SIZE: '16abc'}), 16, 'atoi stops at the first non-digit')
+        })
+
+        it('models the libuv edges: garbage is ONE thread, negative wraps to the ceiling', function() {
+            assert.equal(libuvThreadpoolSize({UV_THREADPOOL_SIZE: 'sixteen'}), 1)
+            assert.equal(libuvThreadpoolSize({UV_THREADPOOL_SIZE: '0'}), 1)
+            assert.equal(libuvThreadpoolSize({UV_THREADPOOL_SIZE: '-3'}), LIBUV_MAX_THREADPOOL_SIZE)
+            assert.equal(libuvThreadpoolSize({UV_THREADPOOL_SIZE: '99999'}), LIBUV_MAX_THREADPOOL_SIZE)
+        })
+    })
+
+    describe('encode budget', function() {
+        it('follows the CPU rule when the pool has room', function() {
+            // configured: 0 is the config's own 'auto', so the CPU rule decides
+            const b = resolveEncodeBudget({cpus: 12, numWorkers: 6, configured: 0, poolSize: 16})
+            assert.equal(b.requested, 2)
+            assert.equal(b.limit, 2)
+            assert.equal(b.freeSlots, 14)
+            assert.equal(b.cappedByPool, false)
+        })
+
+        it('never lets encodes take the reserved pool slots', function() {
+            // the documented trap: fewer workers raise the per-worker limit until it
+            // would consume the whole default pool of 4
+            const b = resolveEncodeBudget({cpus: 12, numWorkers: 3, configured: 0, poolSize: 4})
+            assert.equal(b.requested, 4)
+            assert.equal(b.limit, 4 - RESERVED_POOL_SLOTS)
+            assert.equal(b.freeSlots, RESERVED_POOL_SLOTS)
+            assert.equal(b.cappedByPool, true)
+        })
+
+        it('caps an explicit max_concurrent_encodes the same way', function() {
+            const b = resolveEncodeBudget({cpus: 12, numWorkers: 6, configured: 10, poolSize: 4})
+            assert.equal(b.requested, 10)
+            assert.equal(b.limit, 2)
+            assert.equal(b.cappedByPool, true)
+        })
+
+        it('still allows one encode on a one-thread pool', function() {
+            const b = resolveEncodeBudget({cpus: 12, numWorkers: 6, configured: 0, poolSize: 1})
+            assert.equal(b.limit, 1)
+            assert.equal(b.freeSlots, 0)
+        })
+
+        it('is what the running gate enforces', function() {
+            const b = encodeBudget()
+            assert.equal(b.limit, encodeLimitStats().limit)
+            assert(b.freeSlots >= 0)
+            assert.equal(b.poolSize, libuvThreadpoolSize())
+        })
     })
 
     it('never runs more than the limit at once', async function() {


### PR DESCRIPTION
Closes #35.

Sharp encodes, `fs` reads, `dns.lookup` and zlib share one libuv threadpool per process. It defaults to 4 threads and was never set anywhere in this repo. The encode gate (`encode-limit.ts`) bounds encodes by cores per worker, which on the production shape leaves 2 of the 4 slots for every cached-variant read and every mirror DNS lookup, and its own docstring records what happens when those run out. Lowering `num_workers` would have raised the per-worker encode share to all 4.

- `ENV UV_THREADPOOL_SIZE=16` in the image, next to `MALLOC_ARENA_MAX`. Applies to every forked worker. Thread stacks are virtual, so the memory cost is negligible.
- The gate now derives its limit from both inputs: the CPU rule (or an explicit `max_concurrent_encodes`), capped so that `RESERVED_POOL_SLOTS` (2) are always left for the cheap work, whatever the pool size is. With the pool at 16 the cap does not engage; on a default pool it reproduces today's limit exactly, so behaviour without the env var is unchanged.
- The worker boot log states pool size, requested and enforced encode limit and free slots, and warns when the pool rather than the CPU rule decided the limit.
- libuv reads the variable with `atoi()`: a non-numeric value means one thread, a negative one wraps to 1024. `libuvThreadpoolSize()` reproduces those edges so the boot log reports what the process actually got.

Tests cover the env parsing edges, the cap engaging on the documented num_workers trap, an explicit config being capped the same way, and that the running gate enforces the computed budget. Each was checked to fail with its guard removed.

To verify after deploy, inside the container:

```
node -e 'console.log(process.env.UV_THREADPOOL_SIZE)'
```

and the `image pipeline configured` line in the worker logs should show `libuvPool: 16, encodeLimit: 2, freePoolSlots: 14` on the production worker count.