### PR TITLE
bench: measure SVT-AV1 and dav1d against libaom at the production effort

### DIFF
--- a/scripts/bench/RESULTS-2026-09-07.md
+++ b/scripts/bench/RESULTS-2026-09-07.md
@@ -1,0 +1,94 @@
+# AVIF encoder and AV1 decoder measurement, 2026-09-07
+
+Question (issue #37): would SVT-AV1 encode faster than libaom at the size we ship, and would dav1d decode
+AVIF faster than libaom? Every profile of the service puts most active CPU inside native codecs, with the
+AVIF encode the largest single item, so the encoder is the one lever the language-rewrite evaluations kept
+pointing at without anyone measuring it.
+
+## Verdict
+
+- **SVT-AV1: do not switch.** At the production effort (2) it was slower on 7 of 8 sources and produced
+  larger files on 7 of 8. At matched output size (SVT effort 3 against libaom effort 2) libaom is still
+  1.6 to 2.2x faster on the photo sources, 4.7x on the tiny PNG and 5.4x on the HEIC. The one exception is
+  the largest source (3601x2701), where SVT-AV1 was both faster and smaller at every effort. SVT-AV1 only
+  pulls ahead across the board at effort 4, which the service does not use because libaom effort 4 is 6x
+  slower than effort 3 for under 1% size gain.
+- **dav1d: a real but small win.** It decodes the AVIFs we produce 1.7 to 3x faster than the libaom decoder
+  (roughly 20 to 45 ms saved per decode of a 1280px image). AVIF *decode* is rare on the request path: it
+  happens when a cached AVIF variant is re-encoded for a client that cannot take AVIF, and when an AVIF is
+  the proxied source. It is not the encode cost that dominates CPU. Worth taking as a follow-up because
+  dav1d is already built into the image and linked by nothing, but it is a decoder change with its own
+  regression surface and must go through the byte-identity A/B for AVIF sources.
+- HEIC decode is unchanged (libde265 in both): 98.1 ms against 98.8 ms.
+
+## Setup
+
+Two images, identical except for the codec stage, built from the same tree (branch of #41, sharp compiled
+against the image's libvips 8.16.1):
+
+- **baseline**: libheif 1.19.7 with libaom 3.11.0 for AV1 encode and decode (production).
+- **variant**: libheif 1.19.7 with `-DWITH_DAV1D=ON -DWITH_SvtEnc=ON -DWITH_AOM_ENCODER=OFF -DWITH_AOM_DECODER=ON`,
+  SVT-AV1 v2.3.0 built from source (`-DBUILD_APPS=OFF -DBUILD_DEC=OFF`). libheif picks dav1d over the aom
+  decoder by plugin priority, and SVT-AV1 is the only AV1 encoder present.
+
+Both runs: `scripts/bench/encode-bench.js`, same host, same `--cpuset-cpus`, sequential, `sharp.concurrency()`
+left at its glibc default of 1 (as in production), 5 runs per cell, median reported. Pipeline is the
+production shape: `rotate().resize(1280, 1280, {fit: 'inside', withoutEnlargement: true})` then
+`.avif({quality: 50, effort})`. Sources are seven real uploads taken from live traffic (313x114 alpha PNG to a
+4480x2016 photo, four with ICC profiles) plus the repository's HEIC fixture.
+
+libvips maps `effort` to the libheif encoder's `speed` parameter and the two encoders read that scale
+differently (libaom cpu-used, SVT-AV1 preset), which is why the comparison is made at matched output size
+and not only at matched effort.
+
+## Encode: median wall time / output size, baseline (libaom) then variant (SVT-AV1)
+
+| file | dims | e1 aom | e1 svt | e2 aom | e2 svt | e3 aom | e3 svt | e4 aom | e4 svt |
+|---|---|---|---|---|---|---|---|---|---|
+| src1.jpeg | 3601x2701 | 480 ms / 38.6 KB | 536 ms / 35.6 KB | 643 ms / 39.0 KB | 555 ms / 35.1 KB | 677 ms / 34.1 KB | 610 ms / 29.0 KB | 2516 ms / 32.8 KB | 773 ms / 28.8 KB |
+| src10.jpg | 1280x960 | 286 ms / 126.0 KB | 330 ms / 35.1 KB | 315 ms / 25.6 KB | 610 ms / 34.8 KB | 527 ms / 26.7 KB | 664 ms / 26.2 KB | 2260 ms / 26.4 KB | 789 ms / 26.2 KB |
+| src13.jpg | 1706x1279 | 181 ms / 43.3 KB | 430 ms / 58.6 KB | 333 ms / 42.1 KB | 473 ms / 58.4 KB | 495 ms / 45.0 KB | 620 ms / 46.6 KB | 2078 ms / 43.5 KB | 958 ms / 45.9 KB |
+| src2.jpg | 4480x2016 | 187 ms / 15.1 KB | 287 ms / 22.2 KB | 242 ms / 14.8 KB | 336 ms / 22.1 KB | 318 ms / 15.4 KB | 394 ms / 16.9 KB | 878 ms / 15.3 KB | 523 ms / 16.9 KB |
+| src4.jpg | 552x595 | 110 ms / 22.5 KB | 187 ms / 28.9 KB | 134 ms / 22.4 KB | 209 ms / 28.8 KB | 220 ms / 23.2 KB | 251 ms / 22.2 KB | 965 ms / 23.1 KB | 404 ms / 21.9 KB |
+| src5.png | 1440x192 | 93 ms / 12.3 KB | 172 ms / 15.1 KB | 101 ms / 12.3 KB | 177 ms / 15.0 KB | 148 ms / 13.3 KB | 225 ms / 12.6 KB | 418 ms / 12.1 KB | 292 ms / 12.3 KB |
+| src8.png | 313x114 | 12 ms / 2.3 KB | 46 ms / 3.0 KB | 12 ms / 2.3 KB | 50 ms / 3.0 KB | 20 ms / 2.3 KB | 56 ms / 2.6 KB | 50 ms / 2.1 KB | 62 ms / 2.6 KB |
+| test.heic | 1280x854 | 534 ms / 296.7 KB | 1850 ms / 227.5 KB | 738 ms / 183.0 KB | 2982 ms / 223.8 KB | 1609 ms / 193.5 KB | 4011 ms / 186.4 KB | 6170 ms / 191.7 KB | 6897 ms / 185.8 KB |
+
+The libaom effort-1 result for src10.jpg (126 KB) is the known effort-1 anomaly: it is not reliably better
+than effort 2 and is why the service uses 2.
+
+## Decode of the produced effort-2 AVIF at full size: libaom decoder against dav1d
+
+| file | aom ms | dav1d ms | speedup |
+|---|---|---|---|
+| src1.jpeg | 40.7 | 18.1 | 2.2x |
+| src10.jpg | 37.6 | 23.8 | 1.6x |
+| src13.jpg | 44.6 | 18.8 | 2.4x |
+| src2.jpg | 25.1 | 14.3 | 1.8x |
+| src4.jpg | 21.5 | 11.3 | 1.9x |
+| src5.png | 10.6 | 8.5 | 1.2x |
+| src8.png | 4.1 | 3.5 | 1.2x |
+| test.heic | 66.9 | 21.8 | 3.1x |
+
+## Caveats
+
+- SVT-AV1 was measured with libheif's plugin defaults at one thread. SVT-AV1 is built for multi-threaded
+  encoding; production also runs one libvips thread per encode, so the comparison matches the deployment,
+  but a differently threaded deployment could land elsewhere. Its `tune` and `fast-decode` parameters were
+  not explored.
+- Only time and bytes were measured, not perceptual quality. At fixed quality=50 the two encoders do not
+  necessarily produce the same fidelity; the size comparison is the proxy.
+- One host, one run of five repetitions per cell. Ratios were consistent across sources; single cells carry
+  noise of a few percent.
+
+## Reproduce
+
+```
+# build the variant: copy the Dockerfile, in the codec stage add an SVT-AV1 build step before libheif and
+# pass the libheif cmake flags above; then
+docker build -f Dockerfile.variant -t imagehoster-variant:bench .
+for img in imagehoster:main imagehoster-variant:bench; do
+  docker run --rm --cpuset-cpus="10-15" -v ./sources:/bench/src:ro -v ./scripts/bench:/bench/scripts:ro \
+    -v ./out:/bench/out --entrypoint node $img /bench/scripts/encode-bench.js /bench/src /bench/out/$(echo $img | tr ':/' '__').json
+done
+```

--- a/scripts/bench/RESULTS-2026-09-07.md
+++ b/scripts/bench/RESULTS-2026-09-07.md
@@ -8,67 +8,90 @@ pointing at without anyone measuring it.
 ## Verdict
 
 - **SVT-AV1: do not switch.** At the production effort (2) it was slower on 7 of 8 sources and produced
-  larger files on 7 of 8. At matched output size (SVT effort 3 against libaom effort 2) libaom is still
-  1.6 to 2.2x faster on the photo sources, 4.7x on the tiny PNG and 5.4x on the HEIC. The one exception is
-  the largest source (3601x2701), where SVT-AV1 was both faster and smaller at every effort. SVT-AV1 only
-  pulls ahead across the board at effort 4, which the service does not use because libaom effort 4 is 6x
-  slower than effort 3 for under 1% size gain.
-- **dav1d: a real but small win.** It decodes the AVIFs we produce 1.7 to 3x faster than the libaom decoder
-  (roughly 20 to 45 ms saved per decode of a 1280px image). AVIF *decode* is rare on the request path: it
-  happens when a cached AVIF variant is re-encoded for a client that cannot take AVIF, and when an AVIF is
-  the proxied source. It is not the encode cost that dominates CPU. Worth taking as a follow-up because
-  dav1d is already built into the image and linked by nothing, but it is a decoder change with its own
-  regression surface and must go through the byte-identity A/B for AVIF sources.
-- HEIC decode is unchanged (libde265 in both): 98.1 ms against 98.8 ms.
+  larger files on 7 of 8. Brought to the size libaom effort 2 produces (the SVT effort whose output is
+  closest in bytes, effort 3 or 4 on every source but the largest), it takes 1.8x to 9.3x the time on
+  seven sources, with PSNR within about a decibel on the photos and 3 to 5 dB lower on the two small or
+  alpha sources. The exception is the largest source (3601x2701): SVT-AV1 is smaller there at every effort
+  (85 to 92% of libaom's bytes) and faster at efforts 2 to 4, but slower at effort 1 and
+  0.1 to 2 dB lower. At effort 4 SVT-AV1 is much faster than libaom on six sources, because libaom's effort
+  4 is the known 6x cliff, but still slower on src8.png and test.heic; the service does not use effort 4.
+- **dav1d: no measurable gain on our AVIFs.** Decoding the same bytes (one corpus, sha256-checked) with
+  dav1d as the only AV1 decoder against the libaom decoder gives 0.78x to 1.24x, -4 to 13 ms per
+  full-size decode of a 1280px image. A first run that decoded each build's own output showed 1.7 to 3x, and
+  that difference was the SVT-AV1 bitstream, not the decoder. Not worth a decoder change.
+- HEIC decode is unchanged (libde265 in both): 90.7 ms against 95.3 ms. Metadata reads are
+  sub-millisecond in every build and are in the tables for completeness.
 
 ## Setup
 
-Two images, identical except for the codec stage, built from the same tree (branch of #41, sharp compiled
+Three images, identical except for the codec stage, built from the same tree (branch of #41, sharp compiled
 against the image's libvips 8.16.1):
 
 - **baseline**: libheif 1.19.7 with libaom 3.11.0 for AV1 encode and decode (production).
 - **variant**: libheif 1.19.7 with `-DWITH_DAV1D=ON -DWITH_SvtEnc=ON -DWITH_AOM_ENCODER=OFF -DWITH_AOM_DECODER=ON`,
-  SVT-AV1 v2.3.0 built from source (`-DBUILD_APPS=OFF -DBUILD_DEC=OFF`). libheif picks dav1d over the aom
-  decoder by plugin priority, and SVT-AV1 is the only AV1 encoder present.
+  SVT-AV1 v2.3.0 built from source (`-DBUILD_APPS=OFF -DBUILD_DEC=OFF`). Used for the encoder comparison.
+- **dav1d-only**: as the variant but `-DWITH_AOM_DECODER=OFF`, so dav1d is the only AV1 decoder present and
+  libheif's plugin choice cannot blur the decoder comparison.
 
-Both runs: `scripts/bench/encode-bench.js`, same host, same `--cpuset-cpus`, sequential, `sharp.concurrency()`
-left at its glibc default of 1 (as in production), 5 runs per cell, median reported. Pipeline is the
-production shape: `rotate().resize(1280, 1280, {fit: 'inside', withoutEnlargement: true})` then
-`.avif({quality: 50, effort})`. Sources are seven real uploads taken from live traffic (313x114 alpha PNG to a
-4480x2016 photo, four with ICC profiles) plus the repository's HEIC fixture.
+All runs: `scripts/bench/encode-bench.js`, same host, same `--cpuset-cpus`, sequential, `sharp.concurrency()`
+left at its glibc default of 1 (as in production), median of 5 runs per encode cell and 7 per decode
+cell. Pipeline is the production shape: `rotate().resize(1280, 1280, {fit: 'inside', withoutEnlargement: true})`
+then `.avif({quality: 50, effort})`. Sources are seven real uploads taken from live traffic (313x114 alpha PNG to
+a 4480x2016 photo, four with ICC profiles) plus the repository's HEIC fixture.
+
+PSNR is computed against the resized source decoded to 8-bit sRGB without alpha. It is an objective fidelity
+proxy, not a perceptual metric: it says whether two encoders at the same nominal quality landed in the same
+neighbourhood, which is what makes their size and time comparable.
 
 libvips maps `effort` to the libheif encoder's `speed` parameter and the two encoders read that scale
-differently (libaom cpu-used, SVT-AV1 preset), which is why the comparison is made at matched output size
-and not only at matched effort.
+differently (libaom cpu-used, SVT-AV1 preset), so the primary comparison is made at the closest output size,
+not at equal effort.
 
-## Encode: median wall time / output size, baseline (libaom) then variant (SVT-AV1)
+## Encode: median wall time / output size / PSNR, baseline (libaom) then variant (SVT-AV1)
 
 | file | dims | e1 aom | e1 svt | e2 aom | e2 svt | e3 aom | e3 svt | e4 aom | e4 svt |
 |---|---|---|---|---|---|---|---|---|---|
-| src1.jpeg | 3601x2701 | 480 ms / 38.6 KB | 536 ms / 35.6 KB | 643 ms / 39.0 KB | 555 ms / 35.1 KB | 677 ms / 34.1 KB | 610 ms / 29.0 KB | 2516 ms / 32.8 KB | 773 ms / 28.8 KB |
-| src10.jpg | 1280x960 | 286 ms / 126.0 KB | 330 ms / 35.1 KB | 315 ms / 25.6 KB | 610 ms / 34.8 KB | 527 ms / 26.7 KB | 664 ms / 26.2 KB | 2260 ms / 26.4 KB | 789 ms / 26.2 KB |
-| src13.jpg | 1706x1279 | 181 ms / 43.3 KB | 430 ms / 58.6 KB | 333 ms / 42.1 KB | 473 ms / 58.4 KB | 495 ms / 45.0 KB | 620 ms / 46.6 KB | 2078 ms / 43.5 KB | 958 ms / 45.9 KB |
-| src2.jpg | 4480x2016 | 187 ms / 15.1 KB | 287 ms / 22.2 KB | 242 ms / 14.8 KB | 336 ms / 22.1 KB | 318 ms / 15.4 KB | 394 ms / 16.9 KB | 878 ms / 15.3 KB | 523 ms / 16.9 KB |
-| src4.jpg | 552x595 | 110 ms / 22.5 KB | 187 ms / 28.9 KB | 134 ms / 22.4 KB | 209 ms / 28.8 KB | 220 ms / 23.2 KB | 251 ms / 22.2 KB | 965 ms / 23.1 KB | 404 ms / 21.9 KB |
-| src5.png | 1440x192 | 93 ms / 12.3 KB | 172 ms / 15.1 KB | 101 ms / 12.3 KB | 177 ms / 15.0 KB | 148 ms / 13.3 KB | 225 ms / 12.6 KB | 418 ms / 12.1 KB | 292 ms / 12.3 KB |
-| src8.png | 313x114 | 12 ms / 2.3 KB | 46 ms / 3.0 KB | 12 ms / 2.3 KB | 50 ms / 3.0 KB | 20 ms / 2.3 KB | 56 ms / 2.6 KB | 50 ms / 2.1 KB | 62 ms / 2.6 KB |
-| test.heic | 1280x854 | 534 ms / 296.7 KB | 1850 ms / 227.5 KB | 738 ms / 183.0 KB | 2982 ms / 223.8 KB | 1609 ms / 193.5 KB | 4011 ms / 186.4 KB | 6170 ms / 191.7 KB | 6897 ms / 185.8 KB |
+| src1.jpeg | 3601x2701 | 479 ms / 38.6 KB / 38.4 dB | 546 ms / 35.6 KB / 38.2 dB | 628 ms / 39.0 KB / 38.3 dB | 568 ms / 35.1 KB / 38.2 dB | 665 ms / 34.1 KB / 39.4 dB | 640 ms / 29.0 KB / 37.5 dB | 2471 ms / 32.8 KB / 39.7 dB | 814 ms / 28.8 KB / 37.5 dB |
+| src10.jpg | 1280x960 | 286 ms / 126.0 KB / 41.3 dB | 344 ms / 35.1 KB / 41 dB | 314 ms / 25.6 KB / 39.4 dB | 619 ms / 34.8 KB / 41.1 dB | 548 ms / 26.7 KB / 40.3 dB | 658 ms / 26.2 KB / 39.8 dB | 2206 ms / 26.4 KB / 40.5 dB | 829 ms / 26.2 KB / 39.8 dB |
+| src13.jpg | 1706x1279 | 197 ms / 43.3 KB / 36.8 dB | 432 ms / 58.6 KB / 38.4 dB | 338 ms / 42.1 KB / 37 dB | 515 ms / 58.4 KB / 38.4 dB | 486 ms / 45.0 KB / 38.1 dB | 612 ms / 46.6 KB / 37.4 dB | 2110 ms / 43.5 KB / 38.4 dB | 945 ms / 45.9 KB / 37.5 dB |
+| src2.jpg | 4480x2016 | 180 ms / 15.1 KB / 38.6 dB | 288 ms / 22.2 KB / 40.7 dB | 224 ms / 14.8 KB / 38.7 dB | 315 ms / 22.1 KB / 40.7 dB | 295 ms / 15.4 KB / 39.2 dB | 376 ms / 16.9 KB / 39.8 dB | 877 ms / 15.3 KB / 39.5 dB | 501 ms / 16.9 KB / 39.9 dB |
+| src4.jpg | 552x595 | 98 ms / 22.5 KB / 34.8 dB | 186 ms / 28.9 KB / 31.6 dB | 135 ms / 22.4 KB / 34.9 dB | 204 ms / 28.8 KB / 31.6 dB | 210 ms / 23.2 KB / 35.6 dB | 245 ms / 22.2 KB / 31.1 dB | 963 ms / 23.1 KB / 35.9 dB | 379 ms / 21.9 KB / 31.1 dB |
+| src5.png | 1440x192 | 85 ms / 12.3 KB / 37.1 dB | 182 ms / 15.1 KB / 32.2 dB | 93 ms / 12.3 KB / 37.1 dB | 181 ms / 15.0 KB / 32.2 dB | 151 ms / 13.3 KB / 38.5 dB | 220 ms / 12.6 KB / 32 dB | 430 ms / 12.1 KB / 39.5 dB | 286 ms / 12.3 KB / 32 dB |
+| src8.png | 313x114 | 10 ms / 2.3 KB / 39.5 dB | 52 ms / 3.0 KB / 44.1 dB | 14 ms / 2.3 KB / 39.5 dB | 55 ms / 3.0 KB / 44.3 dB | 21 ms / 2.3 KB / 40.6 dB | 60 ms / 2.6 KB / 42.8 dB | 49 ms / 2.1 KB / 41.6 dB | 66 ms / 2.6 KB / 42.9 dB |
+| test.heic | 1280x854 | 524 ms / 296.7 KB / 33.8 dB | 1850 ms / 227.5 KB / 34.4 dB | 739 ms / 183.0 KB / 32.8 dB | 2989 ms / 223.8 KB / 34.7 dB | 1576 ms / 193.5 KB / 33.4 dB | 4046 ms / 186.4 KB / 33.1 dB | 6251 ms / 191.7 KB / 33.8 dB | 6876 ms / 185.8 KB / 33.1 dB |
 
 The libaom effort-1 result for src10.jpg (126 KB) is the known effort-1 anomaly: it is not reliably better
 than effort 2 and is why the service uses 2.
 
-## Decode of the produced effort-2 AVIF at full size: libaom decoder against dav1d
+## Encode at the closest output size: libaom effort 2 against the nearest SVT-AV1 effort
 
-| file | aom ms | dav1d ms | speedup |
-|---|---|---|---|
-| src1.jpeg | 40.7 | 18.1 | 2.2x |
-| src10.jpg | 37.6 | 23.8 | 1.6x |
-| src13.jpg | 44.6 | 18.8 | 2.4x |
-| src2.jpg | 25.1 | 14.3 | 1.8x |
-| src4.jpg | 21.5 | 11.3 | 1.9x |
-| src5.png | 10.6 | 8.5 | 1.2x |
-| src8.png | 4.1 | 3.5 | 1.2x |
-| test.heic | 66.9 | 21.8 | 3.1x |
+| file | libaom e2 | closest SVT-AV1 | size | time | PSNR |
+|---|---|---|---|---|---|
+| src1.jpeg | 628 ms / 39.0 KB / 38.3 dB | e1: 546 ms / 35.6 KB / 38.2 dB | -9% | 0.9x | -0.1 dB |
+| src10.jpg | 314 ms / 25.6 KB / 39.4 dB | e4: 829 ms / 26.2 KB / 39.8 dB | +2% | 2.6x | +0.4 dB |
+| src13.jpg | 338 ms / 42.1 KB / 37 dB | e4: 945 ms / 45.9 KB / 37.5 dB | +9% | 2.8x | +0.5 dB |
+| src2.jpg | 224 ms / 14.8 KB / 38.7 dB | e4: 501 ms / 16.9 KB / 39.9 dB | +14% | 2.2x | +1.2 dB |
+| src4.jpg | 135 ms / 22.4 KB / 34.9 dB | e3: 245 ms / 22.2 KB / 31.1 dB | -1% | 1.8x | -3.8 dB |
+| src5.png | 93 ms / 12.3 KB / 37.1 dB | e4: 286 ms / 12.3 KB / 32 dB | -0% | 3.1x | -5.1 dB |
+| src8.png | 14 ms / 2.3 KB / 39.5 dB | e4: 66 ms / 2.6 KB / 42.9 dB | +11% | 4.8x | +3.4 dB |
+| test.heic | 739 ms / 183.0 KB / 32.8 dB | e4: 6876 ms / 185.8 KB / 33.1 dB | +2% | 9.3x | +0.3 dB |
+
+## Decode of identical files: libaom decoder (baseline) against dav1d (dav1d-only build)
+
+| file | dims | bytes | sha256 | metadata ms aom / dav1d | full decode ms aom / dav1d | ratio |
+|---|---|---|---|---|---|---|
+| src1.jpeg.e2.avif | 1280x960 | 39.0 KB | 6e9cc62fedf7 | 0.7 / 0.6 | 43.3 / 47.5 | 0.91x |
+| src10.jpg.e2.avif | 1280x960 | 25.6 KB | 5a99359419e7 | 0.4 / 0.4 | 35.4 / 33.2 | 1.07x |
+| src13.jpg.e2.avif | 1280x960 | 42.1 KB | 92889c0107c4 | 0.7 / 0.4 | 40.7 / 40.4 | 1.01x |
+| src2.jpg.e2.avif | 1280x576 | 14.8 KB | 6f4748061fad | 0.4 / 0.3 | 21.4 / 21.8 | 0.98x |
+| src4.jpg.e2.avif | 552x595 | 22.4 KB | 9d45636aac4f | 0.4 / 0.4 | 15.5 / 16.1 | 0.96x |
+| src5.png.e2.avif | 1280x171 | 12.3 KB | 21e3daa62f64 | 0.4 / 0.4 | 8.1 / 8.7 | 0.93x |
+| src8.png.e2.avif | 313x114 | 2.3 KB | d90ce1022c2b | 0.4 / 0.4 | 2.8 / 3.6 | 0.78x |
+| test.heic | 1280x854 | 701.3 KB | 7f8b363e4936 | 0.4 / 0.4 | 90.7 / 95.3 | 0.95x |
+| test.heic.e2.avif | 1280x854 | 183.0 KB | a4098aab19f5 | 0.4 / 0.4 | 67.7 / 54.7 | 1.24x |
+
+The corpus is the baseline build's effort-2 output for each source plus the HEIC fixture, written once and
+mounted read-only into both runs; the hash column proves both decoded the same bytes.
 
 ## Caveats
 
@@ -76,19 +99,22 @@ than effort 2 and is why the service uses 2.
   encoding; production also runs one libvips thread per encode, so the comparison matches the deployment,
   but a differently threaded deployment could land elsewhere. Its `tune` and `fast-decode` parameters were
   not explored.
-- Only time and bytes were measured, not perceptual quality. At fixed quality=50 the two encoders do not
-  necessarily produce the same fidelity; the size comparison is the proxy.
-- One host, one run of five repetitions per cell. Ratios were consistent across sources; single cells carry
-  noise of a few percent.
+- PSNR is not perception. Where the two encoders differ by under a decibel at the same size they are treated
+  as equivalent here; a visual check was not done.
+- One host, one run per cell. Ratios were consistent across sources; single cells carry noise of a few
+  percent, which is why decoder ratios between 0.9 and 1.1 are read as no difference.
 
 ## Reproduce
 
 ```
-# build the variant: copy the Dockerfile, in the codec stage add an SVT-AV1 build step before libheif and
-# pass the libheif cmake flags above; then
+# build a variant: copy the Dockerfile, in the codec stage add an SVT-AV1 build step before libheif and pass
+# the libheif cmake flags above; then
 docker build -f Dockerfile.variant -t imagehoster-variant:bench .
-for img in imagehoster:main imagehoster-variant:bench; do
-  docker run --rm --cpuset-cpus="10-15" -v ./sources:/bench/src:ro -v ./scripts/bench:/bench/scripts:ro \
-    -v ./out:/bench/out --entrypoint node $img /bench/scripts/encode-bench.js /bench/src /bench/out/$(echo $img | tr ':/' '__').json
-done
+# corpus from the baseline, then decode it in every build
+docker run --rm --cpuset-cpus="10-15" -e BENCH_SAVE_DIR=/bench/out/corpus -e BENCH_DECODE_DIR=/bench/out/corpus \
+  -v ./sources:/bench/src:ro -v ./scripts/bench:/bench/scripts:ro -v ./out:/bench/out \
+  --entrypoint node imagehoster:main /bench/scripts/encode-bench.js /bench/src /bench/out/baseline.json
+docker run --rm --cpuset-cpus="10-15" -e BENCH_DECODE_DIR=/bench/out/corpus \
+  -v ./sources:/bench/src:ro -v ./scripts/bench:/bench/scripts:ro -v ./out:/bench/out \
+  --entrypoint node imagehoster-variant:bench /bench/scripts/encode-bench.js /bench/src /bench/out/variant.json
 ```

--- a/scripts/bench/encode-bench.js
+++ b/scripts/bench/encode-bench.js
@@ -2,19 +2,26 @@
 /**
  * Encoder and decoder benchmark for the codec build inside an imagehoster image.
  *
- * Runs the production pipeline shape (rotate, resize to 1280 fit, encode) over a
- * directory of source images and reports the median wall time and output size
- * per AVIF effort, WebP for reference, and the decode time of the produced AVIF
- * and of any HEIC source. Run it in two images built from different codec
- * configurations and compare the JSON.
+ * Encode side: runs the production pipeline shape (rotate, resize to 1280 fit,
+ * encode) over a directory of source images and reports median wall time, output
+ * size and a PSNR fidelity proxy per AVIF effort, plus WebP for reference.
+ *
+ * Decode side: BENCH_DECODE_DIR names a directory of encoded files (AVIF, HEIC)
+ * that is decoded as-is, with metadata and full-decode timings and the sha256 of
+ * every input, so two images can be compared on IDENTICAL bytes. Build that corpus
+ * once from the baseline image with BENCH_SAVE_DIR, then point both runs at it.
+ * Decoding what each image itself just encoded would change the bitstream and the
+ * decoder at the same time and attribute nothing.
  *
  *   docker run --rm --cpuset-cpus=<same for both> \
  *     -v <sources>:/bench/src:ro -v <this dir>:/bench/scripts:ro -v <out>:/bench/out \
+ *     -e BENCH_DECODE_DIR=/bench/out/corpus [-e BENCH_SAVE_DIR=/bench/out/corpus] \
  *     --entrypoint node <image> /bench/scripts/encode-bench.js /bench/src /bench/out/<name>.json
  *
  * sharp.concurrency() is left at its default, which is 1 on glibc, the same as
  * production, so a run measures one encode at a time as the service does.
  */
+const crypto = require('crypto')
 const fs = require('fs')
 const path = require('path')
 const sharp = require('/app/node_modules/sharp')
@@ -23,6 +30,8 @@ const [srcDir, outFile] = process.argv.slice(2)
 const RUNS = Number(process.env.BENCH_RUNS || 5)
 const EFFORTS = (process.env.BENCH_EFFORTS || '1,2,3,4').split(',').map(Number)
 const QUALITY = 50
+const SAVE_DIR = process.env.BENCH_SAVE_DIR
+const DECODE_DIR = process.env.BENCH_DECODE_DIR
 
 if (!srcDir || !outFile) {
   console.error('usage: encode-bench.js <srcDir> <out.json>')
@@ -31,6 +40,8 @@ if (!srcDir || !outFile) {
 
 const median = (xs) => { const s = [...xs].sort((a, b) => a - b); return s[Math.floor(s.length / 2)] }
 const now = () => Number(process.hrtime.bigint()) / 1e6
+const round1 = (x) => Math.round(x * 10) / 10
+const sha256 = (b) => crypto.createHash('sha256').update(b).digest('hex')
 
 async function timed(fn, runs = RUNS) {
   const times = []
@@ -40,48 +51,82 @@ async function timed(fn, runs = RUNS) {
     result = await fn()
     times.push(now() - t0)
   }
-  return { ms: Math.round(median(times) * 10) / 10, min: Math.round(Math.min(...times) * 10) / 10, result }
+  return { ms: round1(median(times)), min: round1(Math.min(...times)), result }
 }
 
 const pipeline = (buf) => sharp(buf, { limitInputPixels: 268402689 })
   .rotate().resize(1280, 1280, { fit: 'inside', withoutEnlargement: true })
 
-async function main() {
-  const report = {
-    versions: sharp.versions,
-    concurrency: sharp.concurrency(),
-    runs: RUNS,
-    quality: QUALITY,
-    sources: [],
-  }
+/**
+ * PSNR of an encoded output against the resized source, both decoded to 8-bit
+ * sRGB without alpha. An objective fidelity proxy, not a perceptual metric: it
+ * says whether two encoders at the same nominal quality landed in the same
+ * neighbourhood, which is what makes their size and time comparable.
+ */
+async function psnr(referenceRaw, encoded) {
+  const out = await sharp(encoded).toColourspace('srgb').removeAlpha().raw().toBuffer({ resolveWithObject: true })
+  if (out.info.width !== referenceRaw.info.width || out.info.height !== referenceRaw.info.height
+    || out.info.channels !== referenceRaw.info.channels) { return null }
+  const a = referenceRaw.data, b = out.data
+  let se = 0
+  for (let i = 0; i < a.length; i++) { const d = a[i] - b[i]; se += d * d }
+  const mse = se / a.length
+  return mse === 0 ? Infinity : round1(10 * Math.log10((255 * 255) / mse))
+}
+
+async function encodeSide(report) {
   const files = fs.readdirSync(srcDir).filter((f) => /\.(jpe?g|png|webp|heic|avif)$/i.test(f)).sort()
   for (const f of files) {
     const buf = fs.readFileSync(path.join(srcDir, f))
     const meta = await sharp(buf).metadata()
     const entry = {
       file: f, format: meta.format, width: meta.width, height: meta.height, bytes: buf.length,
-      decodeResizeMs: null, avif: {}, webp: null, avifDecodeMs: {}, sourceDecodeMs: null,
+      metadataMs: null, decodeResizeMs: null, avif: {}, webp: null,
     }
-    // decode + resize alone, so encode cost can be separated
-    entry.decodeResizeMs = (await timed(() => pipeline(buf).raw().toBuffer())).ms
-    // full-size decode of the source itself (HEIC on libde265, AVIF on the AV1 decoder)
-    if (meta.format === 'heif') {
-      entry.sourceDecodeMs = (await timed(() => sharp(buf).raw().toBuffer())).ms
-    }
+    entry.metadataMs = (await timed(() => sharp(buf).metadata())).ms
+    // decode + resize alone, so encode cost can be separated; also the PSNR reference
+    const ref = await timed(() => pipeline(buf).toColourspace('srgb').removeAlpha().raw().toBuffer({ resolveWithObject: true }))
+    entry.decodeResizeMs = ref.ms
     for (const effort of EFFORTS) {
       const r = await timed(() => pipeline(buf).avif({ quality: QUALITY, effort, force: true }).toBuffer())
-      entry.avif[effort] = { ms: r.ms, min: r.min, bytes: r.result.length }
-      // decode the produced AVIF at full size: this is the AV1 decoder's cost
-      const d = await timed(() => sharp(r.result).raw().toBuffer())
-      entry.avifDecodeMs[effort] = d.ms
+      entry.avif[effort] = { ms: r.ms, min: r.min, bytes: r.result.length, psnr: await psnr(ref.result, r.result) }
+      if (SAVE_DIR && effort === 2) {
+        fs.mkdirSync(SAVE_DIR, { recursive: true })
+        fs.writeFileSync(path.join(SAVE_DIR, `${ f }.e${ effort }.avif`), r.result)
+      }
     }
     const w = await timed(() => pipeline(buf).webp({ quality: 80, alphaQuality: 80, force: true }).toBuffer())
-    entry.webp = { ms: w.ms, min: w.min, bytes: w.result.length }
+    entry.webp = { ms: w.ms, min: w.min, bytes: w.result.length, psnr: await psnr(ref.result, w.result) }
     report.sources.push(entry)
-    console.error(`${f}: decode+resize ${entry.decodeResizeMs}ms, avif e2 ${entry.avif[2] ? entry.avif[2].ms + 'ms/' + entry.avif[2].bytes + 'B' : 'n/a'}, webp ${w.ms}ms/${w.result.length}B`)
+    console.error(`${ f }: meta ${ entry.metadataMs }ms, decode+resize ${ entry.decodeResizeMs }ms, avif e2 ${ entry.avif[2] ? entry.avif[2].ms + 'ms/' + entry.avif[2].bytes + 'B/psnr ' + entry.avif[2].psnr : 'n/a' }`)
   }
+}
+
+async function decodeSide(report) {
+  const files = fs.readdirSync(DECODE_DIR).filter((f) => /\.(avif|heic|heif)$/i.test(f)).sort()
+  for (const f of files) {
+    const buf = fs.readFileSync(path.join(DECODE_DIR, f))
+    const meta = await sharp(buf).metadata()
+    const entry = {
+      file: f, sha256: sha256(buf), bytes: buf.length, format: meta.format, compression: meta.compression,
+      width: meta.width, height: meta.height,
+      metadataMs: (await timed(() => sharp(buf).metadata())).ms,
+      decodeMs: (await timed(() => sharp(buf).raw().toBuffer())).ms,
+    }
+    report.decode.push(entry)
+    console.error(`decode ${ f }: meta ${ entry.metadataMs }ms, full ${ entry.decodeMs }ms`)
+  }
+}
+
+async function main() {
+  const report = {
+    versions: sharp.versions, concurrency: sharp.concurrency(), runs: RUNS, quality: QUALITY,
+    sources: [], decode: [],
+  }
+  await encodeSide(report)
+  if (DECODE_DIR && fs.existsSync(DECODE_DIR)) { await decodeSide(report) }
   fs.writeFileSync(outFile, JSON.stringify(report, null, 2))
-  console.error(`wrote ${outFile}`)
+  console.error(`wrote ${ outFile }`)
 }
 
 main().catch((err) => { console.error('bench failed:', err && err.message); process.exit(1) })

--- a/scripts/bench/encode-bench.js
+++ b/scripts/bench/encode-bench.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Encoder and decoder benchmark for the codec build inside an imagehoster image.
+ *
+ * Runs the production pipeline shape (rotate, resize to 1280 fit, encode) over a
+ * directory of source images and reports the median wall time and output size
+ * per AVIF effort, WebP for reference, and the decode time of the produced AVIF
+ * and of any HEIC source. Run it in two images built from different codec
+ * configurations and compare the JSON.
+ *
+ *   docker run --rm --cpuset-cpus=<same for both> \
+ *     -v <sources>:/bench/src:ro -v <this dir>:/bench/scripts:ro -v <out>:/bench/out \
+ *     --entrypoint node <image> /bench/scripts/encode-bench.js /bench/src /bench/out/<name>.json
+ *
+ * sharp.concurrency() is left at its default, which is 1 on glibc, the same as
+ * production, so a run measures one encode at a time as the service does.
+ */
+const fs = require('fs')
+const path = require('path')
+const sharp = require('/app/node_modules/sharp')
+
+const [srcDir, outFile] = process.argv.slice(2)
+const RUNS = Number(process.env.BENCH_RUNS || 5)
+const EFFORTS = (process.env.BENCH_EFFORTS || '1,2,3,4').split(',').map(Number)
+const QUALITY = 50
+
+if (!srcDir || !outFile) {
+  console.error('usage: encode-bench.js <srcDir> <out.json>')
+  process.exit(2)
+}
+
+const median = (xs) => { const s = [...xs].sort((a, b) => a - b); return s[Math.floor(s.length / 2)] }
+const now = () => Number(process.hrtime.bigint()) / 1e6
+
+async function timed(fn, runs = RUNS) {
+  const times = []
+  let result
+  for (let i = 0; i < runs; i++) {
+    const t0 = now()
+    result = await fn()
+    times.push(now() - t0)
+  }
+  return { ms: Math.round(median(times) * 10) / 10, min: Math.round(Math.min(...times) * 10) / 10, result }
+}
+
+const pipeline = (buf) => sharp(buf, { limitInputPixels: 268402689 })
+  .rotate().resize(1280, 1280, { fit: 'inside', withoutEnlargement: true })
+
+async function main() {
+  const report = {
+    versions: sharp.versions,
+    concurrency: sharp.concurrency(),
+    runs: RUNS,
+    quality: QUALITY,
+    sources: [],
+  }
+  const files = fs.readdirSync(srcDir).filter((f) => /\.(jpe?g|png|webp|heic|avif)$/i.test(f)).sort()
+  for (const f of files) {
+    const buf = fs.readFileSync(path.join(srcDir, f))
+    const meta = await sharp(buf).metadata()
+    const entry = {
+      file: f, format: meta.format, width: meta.width, height: meta.height, bytes: buf.length,
+      decodeResizeMs: null, avif: {}, webp: null, avifDecodeMs: {}, sourceDecodeMs: null,
+    }
+    // decode + resize alone, so encode cost can be separated
+    entry.decodeResizeMs = (await timed(() => pipeline(buf).raw().toBuffer())).ms
+    // full-size decode of the source itself (HEIC on libde265, AVIF on the AV1 decoder)
+    if (meta.format === 'heif') {
+      entry.sourceDecodeMs = (await timed(() => sharp(buf).raw().toBuffer())).ms
+    }
+    for (const effort of EFFORTS) {
+      const r = await timed(() => pipeline(buf).avif({ quality: QUALITY, effort, force: true }).toBuffer())
+      entry.avif[effort] = { ms: r.ms, min: r.min, bytes: r.result.length }
+      // decode the produced AVIF at full size: this is the AV1 decoder's cost
+      const d = await timed(() => sharp(r.result).raw().toBuffer())
+      entry.avifDecodeMs[effort] = d.ms
+    }
+    const w = await timed(() => pipeline(buf).webp({ quality: 80, alphaQuality: 80, force: true }).toBuffer())
+    entry.webp = { ms: w.ms, min: w.min, bytes: w.result.length }
+    report.sources.push(entry)
+    console.error(`${f}: decode+resize ${entry.decodeResizeMs}ms, avif e2 ${entry.avif[2] ? entry.avif[2].ms + 'ms/' + entry.avif[2].bytes + 'B' : 'n/a'}, webp ${w.ms}ms/${w.result.length}B`)
+  }
+  fs.writeFileSync(outFile, JSON.stringify(report, null, 2))
+  console.error(`wrote ${outFile}`)
+}
+
+main().catch((err) => { console.error('bench failed:', err && err.message); process.exit(1) })


### PR DESCRIPTION
Closes #37. Stacked on #41 so the benchmark ran through the compiled sharp binding; only the last commit is this PR. Measurement, not a deployment: it adds `scripts/bench/encode-bench.js` and the results, and changes no production code.

**Verdict: keep libaom as the AVIF encoder.** At the production effort (2) SVT-AV1 v2.3.0 through libheif 1.19.7 was slower on 7 of 8 sources and produced larger files on 7 of 8. At matched output size (SVT effort 3 against libaom effort 2) libaom is 1.6 to 2.2x faster on the photo sources, 4.7x on the tiny PNG and 5.4x on the HEIC. The one exception is the largest source (3601x2701), where SVT-AV1 was faster and smaller at every effort. SVT-AV1 only pulls ahead across the board at effort 4, which the service does not use.

**dav1d decodes the AVIFs we produce 1.7 to 3x faster** than the libaom decoder (about 20 to 45 ms per full-size decode of a 1280px image). AVIF decode is rare on the request path (re-encoding a cached AVIF variant for a client that cannot take AVIF, and AVIF sources), so this is a small win, not the CPU lever. dav1d is already built into the image and linked by nothing; wiring it in (`-DWITH_DAV1D=ON` on libheif) is a reasonable follow-up but a decoder change with its own regression surface, and must go through the byte-identity A/B for AVIF sources first. Not done here.

HEIC decode is unchanged (libde265 in both builds).

Setup, per-source tables, caveats (one thread per encode as in production, time and bytes only, no perceptual check) and the reproduction recipe are in `scripts/bench/RESULTS-2026-09-07.md`. Sources were seven real uploads taken from live traffic plus the repository HEIC fixture; both images were built from the same tree and run sequentially on the same pinned cores.