### PR TITLE
Only let formats that can animate decide animation by their page count

### DIFF
--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -28,6 +28,7 @@ import {
   safeParseInt,
   ScalingMode,
   storeExists,
+  storeStat,
   storeRemove,
   supportsAvif,
   supportsWebP,
@@ -133,9 +134,10 @@ async function handleAvatar(ctx: KoaContext) {
   const imageKey = getImageKey(origKey, options)
 
   // No validator yet: a real variant's ETag is derived from its stored bytes
-  // (see realEtag) and is set once those are in hand. Last-Modified is set now
-  // because it describes the profile, not the bytes.
-  ctx.set('Last-Modified', profile ? new Date(`${profile.active}Z`).toUTCString() : new Date().toUTCString())
+  // (see realEtag) and is set once those are in hand. No Last-Modified either:
+  // it used to carry the profile's timestamp, which says nothing about the
+  // stored bytes, so an If-Modified-Since-only revalidation could answer 304
+  // for a variant that had since been repaired or re-encoded.
 
   // ctx.fresh only consults the conditional headers once the status is
   // 2xx/304, and Koa's default is 404 at this point, so without an explicit 200
@@ -146,7 +148,8 @@ async function handleAvatar(ctx: KoaContext) {
   // client keep a copy of whatever it holds.
   ctx.status = 200
 
-  if (await storeExists(proxyStore, imageKey) && !shouldBypassCache) {
+  const variantStat = shouldBypassCache ? {exists: false} : await storeStat(proxyStore, imageKey)
+  if (variantStat.exists) {
     ctx.tag({ store: 'resized' })
     const file = proxyStore.createReadStream(imageKey)
     const { head, stream } = await import('stream-head').then((mod) => mod.default(file, { bytes: 16384 }))
@@ -156,7 +159,7 @@ async function handleAvatar(ctx: KoaContext) {
     const served: ServedImage<NodeJS.ReadableStream> = isProfileFallback
       ? fallbackImage(stream, 'profile lookup fell back, default substituted')
       : realImage(stream)
-    ctx.set('ETag', etagFor(served, imageKey, head))
+    ctx.set('ETag', etagFor(served, imageKey, head, variantStat.size))
     // never take the freshness shortcut for a fallback response: the substituted
     // default changes the ETag, but Last-Modified still carries the profile's
     // timestamp, so an If-Modified-Since-only revalidation would answer 304 and let
@@ -305,7 +308,7 @@ async function handleAvatar(ctx: KoaContext) {
   } else {
     ctx.set('Cache-Control', cacheControlFor(response, REAL_CACHE_CONTROL))
   }
-  ctx.set('ETag', etagFor(response, imageKey, response.bytes))
+  ctx.set('ETag', etagFor(response, imageKey, response.bytes, response.bytes.length))
   ctx.body = response.bytes
 }
 

--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -2,7 +2,6 @@
 
 import { AbstractBlobStore } from 'abstract-blob-store'
 import config from 'config'
-import etag from 'etag'
 import {URL} from 'url'
 import {fetchImageWithFallbacks} from './fetch-image'
 import {clientGoneSignal} from './encode-limit'
@@ -133,23 +132,19 @@ async function handleAvatar(ctx: KoaContext) {
   }
   const imageKey = getImageKey(origKey, options)
 
-  ctx.set({
-    'ETag': etag(imageKey),
-    'Last-Modified': profile ? new Date(`${profile.active}Z`).toUTCString() : new Date().toUTCString(),
-  })
+  // No validator yet: a real variant's ETag is derived from its stored bytes
+  // (see realEtag) and is set once those are in hand. Last-Modified is set now
+  // because it describes the profile, not the bytes.
+  ctx.set('Last-Modified', profile ? new Date(`${profile.active}Z`).toUTCString() : new Date().toUTCString())
 
   // ctx.fresh only consults the conditional headers once the status is
-  // 2xx/304, and Koa's default is 404 at this point — without an explicit 200
-  // the revalidation branch below can never fire
+  // 2xx/304, and Koa's default is 404 at this point, so without an explicit 200
+  // the revalidation branch inside the cache-hit block could never fire. The 304
+  // itself is answered only there, with a healthy stored variant in hand: a
+  // validator alone does not prove the bytes behind it are what this key renders
+  // to today, and an If-Modified-Since-only revalidation would otherwise let the
+  // client keep a copy of whatever it holds.
   ctx.status = 200
-  // The substituted default changes the ETag, but Last-Modified still carries
-  // the profile's timestamp, so an If-Modified-Since-only revalidation would
-  // answer 304 and let the client keep its cached (possibly blocked) bytes —
-  // never take the freshness shortcut for fallback responses
-  if (ctx.fresh && !shouldBypassCache && !isProfileFallback) {
-    ctx.status = 304
-    return
-  }
 
   if (await storeExists(proxyStore, imageKey) && !shouldBypassCache) {
     ctx.tag({ store: 'resized' })
@@ -161,10 +156,19 @@ async function handleAvatar(ctx: KoaContext) {
     const served: ServedImage<NodeJS.ReadableStream> = isProfileFallback
       ? fallbackImage(stream, 'profile lookup fell back, default substituted')
       : realImage(stream)
+    ctx.set('ETag', etagFor(served, imageKey, head))
+    // never take the freshness shortcut for a fallback response: the substituted
+    // default changes the ETag, but Last-Modified still carries the profile's
+    // timestamp, so an If-Modified-Since-only revalidation would answer 304 and let
+    // the client keep its cached (possibly blocked) bytes
+    if (ctx.fresh && !shouldBypassCache && !isProfileFallback) {
+      if ((stream as any).destroy) { (stream as any).destroy() }
+      ctx.status = 304
+      return
+    }
     ctx.set('Content-Type', await mimeMagic(head))
     ctx.set('Vary', 'Accept')
     ctx.set('Cache-Control', cacheControlFor(served, REAL_CACHE_CONTROL))
-    ctx.set('ETag', etagFor(served, imageKey))
     ctx.body = stream
     return
   }
@@ -301,7 +305,7 @@ async function handleAvatar(ctx: KoaContext) {
   } else {
     ctx.set('Cache-Control', cacheControlFor(response, REAL_CACHE_CONTROL))
   }
-  ctx.set('ETag', etagFor(response, imageKey))
+  ctx.set('ETag', etagFor(response, imageKey, response.bytes))
   ctx.body = response.bytes
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -321,7 +321,15 @@ function loadStore(key: string): AbstractBlobStore {
         return new ShardedFsStore(fsPath) as any
     } else if (conf.type === 'memory') {
         logger.warn('using memory store for %s', key)
-        return require('abstract-blob-store')()
+        const mem = require('abstract-blob-store')()
+        // report the size like the fs and S3 stores do: the validator of a stored
+        // variant includes it, and hit and miss must agree
+        mem.exists = function(opts: any, cb: (err: any, exists?: boolean, size?: number) => void) {
+            const k = typeof opts === 'string' ? opts : opts.key
+            const data = this.data[k]
+            cb(null, !!data, data ? data.length : undefined)
+        }
+        return mem
     } else if (conf.type === 's3') {
         if (!s3Client) {
             const rawEndpoint = config.get('S3_ENDPOINT') as string

--- a/src/cover.ts
+++ b/src/cover.ts
@@ -27,6 +27,7 @@ import {
   readStream,
   ScalingMode,
   storeExists,
+  storeStat,
   storeRemove,
   supportsAvif,
   supportsWebP,
@@ -132,9 +133,10 @@ async function handleCover(ctx: KoaContext) {
   const imageKey = getImageKey(origKey, options)
 
   // No validator yet: a real variant's ETag is derived from its stored bytes
-  // (see realEtag) and is set once those are in hand. Last-Modified is set now
-  // because it describes the profile, not the bytes.
-  ctx.set('Last-Modified', profile ? new Date(`${profile.active}Z`).toUTCString() : new Date().toUTCString())
+  // (see realEtag) and is set once those are in hand. No Last-Modified either:
+  // it used to carry the profile's timestamp, which says nothing about the
+  // stored bytes, so an If-Modified-Since-only revalidation could answer 304
+  // for a variant that had since been repaired or re-encoded.
 
   // ctx.fresh only consults the conditional headers once the status is
   // 2xx/304, and Koa's default is 404 at this point, so without an explicit 200
@@ -145,7 +147,8 @@ async function handleCover(ctx: KoaContext) {
   // client keep a copy of whatever it holds.
   ctx.status = 200
 
-  if (await storeExists(proxyStore, imageKey) && !shouldBypassCache) {
+  const variantStat = shouldBypassCache ? {exists: false} : await storeStat(proxyStore, imageKey)
+  if (variantStat.exists) {
     ctx.tag({ store: 'resized' })
     const file = proxyStore.createReadStream(imageKey)
     const { head, stream } = await import('stream-head').then((mod) => mod.default(file, { bytes: 16384 }))
@@ -155,7 +158,7 @@ async function handleCover(ctx: KoaContext) {
     const served: ServedImage<NodeJS.ReadableStream> = isProfileFallback
       ? fallbackImage(stream, 'profile lookup fell back, default substituted')
       : realImage(stream)
-    ctx.set('ETag', etagFor(served, imageKey, head))
+    ctx.set('ETag', etagFor(served, imageKey, head, variantStat.size))
     // never take the freshness shortcut for a fallback response: the substituted
     // default changes the ETag, but Last-Modified still carries the profile's
     // timestamp, so an If-Modified-Since-only revalidation would answer 304 and let
@@ -297,7 +300,7 @@ async function handleCover(ctx: KoaContext) {
   } else {
     ctx.set('Cache-Control', cacheControlFor(response, REAL_CACHE_CONTROL))
   }
-  ctx.set('ETag', etagFor(response, imageKey, response.bytes))
+  ctx.set('ETag', etagFor(response, imageKey, response.bytes, response.bytes.length))
   ctx.body = response.bytes
 }
 

--- a/src/cover.ts
+++ b/src/cover.ts
@@ -2,7 +2,6 @@
 
 import { AbstractBlobStore } from 'abstract-blob-store'
 import config from 'config'
-import etag from 'etag'
 import {URL} from 'url'
 
 import { getProfile, KoaContext, proxyStore, retentionStore, uploadStore } from './common'
@@ -132,23 +131,19 @@ async function handleCover(ctx: KoaContext) {
   }
   const imageKey = getImageKey(origKey, options)
 
-  ctx.set({
-    'ETag': etag(imageKey),
-    'Last-Modified': profile ? new Date(`${profile.active}Z`).toUTCString() : new Date().toUTCString(),
-  })
+  // No validator yet: a real variant's ETag is derived from its stored bytes
+  // (see realEtag) and is set once those are in hand. Last-Modified is set now
+  // because it describes the profile, not the bytes.
+  ctx.set('Last-Modified', profile ? new Date(`${profile.active}Z`).toUTCString() : new Date().toUTCString())
 
   // ctx.fresh only consults the conditional headers once the status is
-  // 2xx/304, and Koa's default is 404 at this point — without an explicit 200
-  // the revalidation branch below can never fire
+  // 2xx/304, and Koa's default is 404 at this point, so without an explicit 200
+  // the revalidation branch inside the cache-hit block could never fire. The 304
+  // itself is answered only there, with a healthy stored variant in hand: a
+  // validator alone does not prove the bytes behind it are what this key renders
+  // to today, and an If-Modified-Since-only revalidation would otherwise let the
+  // client keep a copy of whatever it holds.
   ctx.status = 200
-  // The substituted default changes the ETag, but Last-Modified still carries
-  // the profile's timestamp, so an If-Modified-Since-only revalidation would
-  // answer 304 and let the client keep its cached (possibly blocked) bytes —
-  // never take the freshness shortcut for fallback responses
-  if (ctx.fresh && !shouldBypassCache && !isProfileFallback) {
-    ctx.status = 304
-    return
-  }
 
   if (await storeExists(proxyStore, imageKey) && !shouldBypassCache) {
     ctx.tag({ store: 'resized' })
@@ -160,10 +155,19 @@ async function handleCover(ctx: KoaContext) {
     const served: ServedImage<NodeJS.ReadableStream> = isProfileFallback
       ? fallbackImage(stream, 'profile lookup fell back, default substituted')
       : realImage(stream)
+    ctx.set('ETag', etagFor(served, imageKey, head))
+    // never take the freshness shortcut for a fallback response: the substituted
+    // default changes the ETag, but Last-Modified still carries the profile's
+    // timestamp, so an If-Modified-Since-only revalidation would answer 304 and let
+    // the client keep its cached (possibly blocked) bytes
+    if (ctx.fresh && !shouldBypassCache && !isProfileFallback) {
+      if ((stream as any).destroy) { (stream as any).destroy() }
+      ctx.status = 304
+      return
+    }
     ctx.set('Content-Type', await mimeMagic(head))
     ctx.set('Vary', 'Accept')
     ctx.set('Cache-Control', cacheControlFor(served, REAL_CACHE_CONTROL))
-    ctx.set('ETag', etagFor(served, imageKey))
     ctx.body = stream
     return
   }
@@ -293,7 +297,7 @@ async function handleCover(ctx: KoaContext) {
   } else {
     ctx.set('Cache-Control', cacheControlFor(response, REAL_CACHE_CONTROL))
   }
-  ctx.set('ETag', etagFor(response, imageKey))
+  ctx.set('ETag', etagFor(response, imageKey, response.bytes))
   ctx.body = response.bytes
 }
 

--- a/src/image-resizer.ts
+++ b/src/image-resizer.ts
@@ -4,7 +4,7 @@ import { runEncode } from './encode-limit'
 import { AVIF_EFFORT } from './constants'
 import { APIError } from './error'
 import {
-    buildSharpPipeline, getProxyImageLimits, mimeMagic,
+    buildSharpPipeline, getProxyImageLimits, isAnimatedSource, mimeMagic,
     OutputFormat, ProxyOptions, safeParseInt, ScalingMode,
 } from './utils'
 
@@ -42,14 +42,9 @@ export async function resizeImageWithOptions(
         isFallback = fallbackUsed
         origData = buffer
         contentType = await mimeMagic(origData)
-        // Use metadata.pages when available; if null, fall back to content-type detection
-        // (conservative: assume GIF/APNG are animated when pages can't be determined)
-        const isGifOrApng = contentType === 'image/gif' || contentType === 'image/apng'
-        if (metadata.pages != null) {
-            isAnimated = metadata.pages > 1
-        } else {
-            isAnimated = isGifOrApng
-        }
+        // Only formats that can animate may say so through their page count;
+        // a HEIF with an auxiliary image is a still, see isAnimatedSource
+        isAnimated = isAnimatedSource(metadata, contentType)
     } catch (err) {
         throw new APIError({ cause: err, code: APIError.Code.InvalidImage, info: { metadata: 'read' } })
     }

--- a/src/image-resizer.ts
+++ b/src/image-resizer.ts
@@ -5,7 +5,7 @@ import { AVIF_EFFORT } from './constants'
 import { APIError } from './error'
 import {
     buildSharpPipeline, getProxyImageLimits, isAnimatedSource, mimeMagic,
-    OutputFormat, ProxyOptions, safeParseInt, ScalingMode,
+    OutputFormat, primaryPageOf, ProxyOptions, safeParseInt, ScalingMode,
 } from './utils'
 
 export async function resizeImageWithOptions(
@@ -61,7 +61,7 @@ export async function resizeImageWithOptions(
 
     // First frame only. Reaching here with isAnimated true implies forceStill, so
     // we never decode every frame — that is the memory-heavy path we are avoiding.
-    const image = buildSharpPipeline(origData, false)
+    const image = buildSharpPipeline(origData, false, primaryPageOf(meta))
 
     const { maxWidth, maxHeight, maxCustomWidth, maxCustomHeight } = getProxyImageLimits()
     let width = safeParseInt(options.width)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,6 @@
 import {AbstractBlobStore} from 'abstract-blob-store'
 import config from 'config'
 import {createHash} from 'crypto'
-import etag from 'etag'
 import * as multihash from 'multihashes'
 import Sharp from 'sharp'
 import streamHead from 'stream-head/dist-es6'
@@ -380,7 +379,8 @@ export async function proxyHandler(ctx: KoaContext) {
         )
     }
     const imageKey = getImageKey(origKey, options)
-    ctx.set('ETag', etag(imageKey))
+    // No validator yet: a real variant's ETag is derived from its stored bytes
+    // (see realEtag), so it is set once those are in hand, on a hit or a render
     ctx.tag({imageKey})
     if (options.invalidate) {
         // Purge CDN first (fire-and-forget)
@@ -445,6 +445,9 @@ export async function proxyHandler(ctx: KoaContext) {
         // substituted request derives its key from the default image, so a
         // client's copy of a blocked source cannot match; the guard is belt and
         // braces.
+        // The validator names the stored bytes, so a client holding a copy the
+        // repair replaced presents a different one and is not told to keep it
+        ctx.set('ETag', etagFor(realImage(head), imageKey, head))
         if (ctx.fresh && !shouldBypassCache && !substitution) {
             file.destroy()
             ctx.status = 304
@@ -477,7 +480,7 @@ export async function proxyHandler(ctx: KoaContext) {
         ctx.set('Content-Type', servedType)
         ctx.set('Vary', 'Accept')
         ctx.set('Cache-Control', cacheControlFor(served, IMMUTABLE_CACHE_CONTROL))
-        ctx.set('ETag', etagFor(served, imageKey))
+        ctx.set('ETag', etagFor(served, imageKey, head))
         ctx.body = served.bytes
         return
         } // end healthy cached variant
@@ -820,6 +823,6 @@ export async function proxyHandler(ctx: KoaContext) {
         ctx.log.error({ finalUrl: urlString, reason: rendered.reason }, 'Responding with default image')
     }
     ctx.set('Cache-Control', cacheControlFor(rendered, IMMUTABLE_CACHE_CONTROL))
-    ctx.set('ETag', etagFor(rendered, imageKey))
+    ctx.set('ETag', etagFor(rendered, imageKey, rendered.bytes))
     ctx.body = rendered.bytes
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -57,6 +57,7 @@ import {
     storeExists,
     storeRemove,
     isAnimatedSource,
+    primaryPageOf,
     supportsAvif,
     supportsWebP
 } from './utils'
@@ -94,6 +95,17 @@ export function shouldCacheOriginal(
 const SERVICE_URL = new URL(config.get('service_url'))
 /** A rendered variant is addressed by a key that encodes its inputs, so it never changes. */
 const IMMUTABLE_CACHE_CONTROL = 'public,max-age=31536000,immutable'
+
+/**
+ * A stored variant the service could never have produced. Output formats are
+ * JPEG, PNG, WebP, AVIF or the source's own bytes for `match`, and `match` never
+ * keeps HEIF because no browser renders it (see needsMatchFallback); so HEIF under
+ * a variant key can only be a raw container stored by the old animated branch.
+ */
+export function isPoisonedVariant(mimeType: string): boolean {
+    const t = mimeType.toLowerCase()
+    return t === 'image/heif' || t === 'image/heic'
+}
 
 const fromFetch = (result: {res: NeedleResponse, isFallback: boolean}): ServedImage =>
     result.isFallback
@@ -179,7 +191,7 @@ async function convertCachedMatchVariant(
         if (isAnimatedSource(metadata, mimeType)) {
             return {image: realImage(cached), contentType: mimeType}
         }
-        const image = buildSharpPipeline(cached, false)
+        const image = buildSharpPipeline(cached, false, primaryPageOf(metadata))
         const contentType = applyMatchFallbackFormat(image, mimeType, acceptHeader, metadata.hasAlpha)
         const buffer = await runEncode(() => image.toBuffer(), options, clientGoneSignal(ctx))
         ctx.log.debug({ mimeType, contentType }, 'converted cached match variant for client')
@@ -418,6 +430,17 @@ export async function proxyHandler(ctx: KoaContext) {
         })
         const {head, stream} = await streamHead(file, {bytes: 16384})
         const mimeType = await mimeMagic(head)
+        if (isPoisonedVariant(mimeType)) {
+            // The service never renders to HEIF, so a stored HEIF under a variant
+            // key is a raw container written back when a multi-image HEIC was
+            // mistaken for an animation (#43): unresized, and for most clients
+            // undisplayable. Drop it and take the miss path, which re-renders from
+            // the original or refetches; the repaired variant is stored on the way.
+            ctx.tag({repaired_variant: true})
+            ctx.log.warn({ imageKey, mimeType }, 'stored variant is a raw HEIF container, discarding and re-rendering')
+            file.destroy()
+            try { await storeRemove(proxyStore, imageKey) } catch (_e) { /* best effort */ }
+        } else {
         // Match variants are one bucket for every client that negotiated neither
         // AVIF nor WebP, so a stored AVIF/HEIF passthrough can be undecodable for
         // the client asking now. Convert the cached bytes rather than falling
@@ -448,6 +471,7 @@ export async function proxyHandler(ctx: KoaContext) {
         ctx.set('ETag', etagFor(served, imageKey))
         ctx.body = served.bytes
         return
+        } // end healthy cached variant
     }
 
     // check if we have the original
@@ -649,7 +673,7 @@ export async function proxyHandler(ctx: KoaContext) {
             // key: every request for it gets these same bytes
             rendered = origin
         } else {
-        const image = buildSharpPipeline(origin.bytes, isAnimated)
+        const image = buildSharpPipeline(origin.bytes, isAnimated, isAnimated ? undefined : primaryPageOf(metadata))
 
         const { maxWidth, maxHeight, maxCustomWidth, maxCustomHeight } = getProxyImageLimits()
         let width: number | undefined = safeParseInt(options.width)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -56,6 +56,7 @@ import {
     ScalingMode,
     storeExists,
     storeRemove,
+    isAnimatedSource,
     supportsAvif,
     supportsWebP
 } from './utils'
@@ -175,7 +176,7 @@ async function convertCachedMatchVariant(
 ): Promise<{image: ServedImage, contentType: string}> {
     try {
         const metadata = await Sharp(cached, { limitInputPixels: MAX_INPUT_PIXELS }).metadata()
-        if (metadata.pages != null && metadata.pages > 1) {
+        if (isAnimatedSource(metadata, mimeType)) {
             return {image: realImage(cached), contentType: mimeType}
         }
         const image = buildSharpPipeline(cached, false)
@@ -612,14 +613,9 @@ export async function proxyHandler(ctx: KoaContext) {
                 ? fallbackImage(metaResult.buffer, 'source unreadable, default substituted')
                 : derive(origin, metaResult.buffer)
             contentType = await mimeMagic(origin.bytes)
-            // Use metadata.pages when available; if null, fall back to content-type detection
-            // (conservative: assume GIF/APNG are animated when pages can't be determined)
-            const isGifOrApng = contentType === 'image/gif' || contentType === 'image/apng'
-            if (metadata.pages != null) {
-                isAnimated = metadata.pages > 1
-            } else {
-                isAnimated = isGifOrApng
-            }
+            // Only formats that can animate may say so through their page count;
+            // a HEIF with an auxiliary image is a still, see isAnimatedSource
+            isAnimated = isAnimatedSource(metadata, contentType)
         } catch (err) {
             ctx.log.error({ url: urlString, key: imageKey }, 'getSharpMetadataWithRetry failed')
             captureImageFailure('metadata_extraction_failed', ctx, { urlString, imageKey, origFromCache, error: String(err) })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -55,6 +55,7 @@ import {
     ScalingMode,
     storeExists,
     storeRemove,
+    storeStat,
     isAnimatedSource,
     primaryPageOf,
     supportsAvif,
@@ -406,7 +407,9 @@ export async function proxyHandler(ctx: KoaContext) {
     // behind it are the ones this service would render today.
     ctx.status = 200
     // check if we already have a converted image for a requested key
-    if (await storeExists(proxyStore, imageKey) && !options.ignorecache && !options.invalidate) {
+    const variantStat = (!options.ignorecache && !options.invalidate)
+        ? await storeStat(proxyStore, imageKey) : {exists: false}
+    if (variantStat.exists) {
         ctx.tag({store: 'resized'})
         ctx.log.debug('streaming %s from store', imageKey)
         const file = proxyStore.createReadStream(imageKey)
@@ -447,7 +450,7 @@ export async function proxyHandler(ctx: KoaContext) {
         // braces.
         // The validator names the stored bytes, so a client holding a copy the
         // repair replaced presents a different one and is not told to keep it
-        ctx.set('ETag', etagFor(realImage(head), imageKey, head))
+        ctx.set('ETag', etagFor(realImage(head), imageKey, head, variantStat.size))
         if (ctx.fresh && !shouldBypassCache && !substitution) {
             file.destroy()
             ctx.status = 304
@@ -480,7 +483,7 @@ export async function proxyHandler(ctx: KoaContext) {
         ctx.set('Content-Type', servedType)
         ctx.set('Vary', 'Accept')
         ctx.set('Cache-Control', cacheControlFor(served, IMMUTABLE_CACHE_CONTROL))
-        ctx.set('ETag', etagFor(served, imageKey, head))
+        ctx.set('ETag', etagFor(served, imageKey, head, variantStat.size))
         ctx.body = served.bytes
         return
         } // end healthy cached variant
@@ -823,6 +826,6 @@ export async function proxyHandler(ctx: KoaContext) {
         ctx.log.error({ finalUrl: urlString, reason: rendered.reason }, 'Responding with default image')
     }
     ctx.set('Cache-Control', cacheControlFor(rendered, IMMUTABLE_CACHE_CONTROL))
-    ctx.set('ETag', etagFor(rendered, imageKey, rendered.bytes))
+    ctx.set('ETag', etagFor(rendered, imageKey, rendered.bytes, rendered.bytes.length))
     ctx.body = rendered.bytes
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -400,17 +400,11 @@ export async function proxyHandler(ctx: KoaContext) {
     }
     // ctx.fresh only consults the conditional headers once the status is
     // 2xx/304, and Koa's default is 404 at this point, so without an explicit
-    // 200 this branch could never fire (and never did). The ETag set above is
-    // the REAL variant's: a placeholder never shares it (see etagFor), so a
-    // match means the client holds the real bytes for this key, and those are
-    // immutable whatever the source is doing today. A substituted request
-    // derives its key from the default image, so a client's copy of a blocked
-    // source can never match it either; the guard is belt and braces.
+    // 200 the revalidation branch inside the cache-hit block could never fire.
+    // The 304 itself is answered only once a stored variant has been inspected
+    // and found healthy, see below: a validator alone does not prove the bytes
+    // behind it are the ones this service would render today.
     ctx.status = 200
-    if (ctx.fresh && !shouldBypassCache && !substitution) {
-        ctx.status = 304
-        return
-    }
     // check if we already have a converted image for a requested key
     if (await storeExists(proxyStore, imageKey) && !options.ignorecache && !options.invalidate) {
         ctx.tag({store: 'resized'})
@@ -441,6 +435,21 @@ export async function proxyHandler(ctx: KoaContext) {
             file.destroy()
             try { await storeRemove(proxyStore, imageKey) } catch (_e) { /* best effort */ }
         } else {
+        // A 304 is a promise that the client's copy is what this key renders to,
+        // and it is made only here, with a healthy stored variant in hand. Before
+        // this point a client could present the validator of a raw container the
+        // old animated branch stored (#43) and be told to keep it. Without a
+        // stored variant the request renders and answers 200 instead, so the
+        // client replaces whatever it held. The ETag set earlier is the REAL
+        // variant's: a placeholder never shares it (see etagFor), and a
+        // substituted request derives its key from the default image, so a
+        // client's copy of a blocked source cannot match; the guard is belt and
+        // braces.
+        if (ctx.fresh && !shouldBypassCache && !substitution) {
+            file.destroy()
+            ctx.status = 304
+            return
+        }
         // Match variants are one bucket for every client that negotiated neither
         // AVIF nor WebP, so a stored AVIF/HEIF passthrough can be undecodable for
         // the client asking now. Convert the cached bytes rather than falling

--- a/src/s3-store.ts
+++ b/src/s3-store.ts
@@ -68,13 +68,14 @@ export class S3BlobStore {
         return passthrough
     }
 
-    exists(opts: any, done: (error: any, exists?: boolean) => void) {
+    /** Reports the size as a third argument: the validator of a stored variant includes it. */
+    exists(opts: any, done: (error: any, exists?: boolean, size?: number) => void) {
         const key = typeof opts === 'string' ? opts : opts.key
         this.s3.send(new HeadObjectCommand({
             Bucket: this.bucket,
             Key: key,
-        })).then(() => {
-            done(null, true)
+        })).then((res) => {
+            done(null, true, typeof res.ContentLength === 'number' ? res.ContentLength : undefined)
         }).catch((err) => {
             if (err.name === 'NotFound' || err.$metadata?.httpStatusCode === 404) {
                 done(null, false)

--- a/src/served-image.ts
+++ b/src/served-image.ts
@@ -124,11 +124,44 @@ export function passthroughEtag(imageKey: string): string {
     return etag(imageKey + '|passthrough')
 }
 
-export function etagFor(image: {kind: Provenance}, imageKey: string): string {
+/**
+ * How many leading bytes of a real variant take part in its validator. Every
+ * encoder writes its identity into the first few hundred bytes (container
+ * boxes, headers, quantisation tables), so a prefix distinguishes a repaired
+ * render from the bytes it replaced, a re-encode from the render before it, and
+ * a raw container from a variant, while staying cheap on the cache-hit path,
+ * which already reads this much to sniff the type.
+ */
+export const REAL_ETAG_HEAD_BYTES = 16384
+
+/**
+ * Validator of a real variant: the key together with the leading bytes of the
+ * stored representation.
+ *
+ * A validator derived from the key alone said "same key, same bytes", which was
+ * false whenever the bytes under a key changed: a repaired variant, a fixed
+ * encoder, a raw container written by a bug and later replaced. Clients holding
+ * the old copy were told it was current forever. Tying the validator to the
+ * bytes makes any change of representation change the validator, so
+ * revalidation replaces the copy. The key is mixed in so two keys whose renders
+ * happen to share a prefix never validate each other.
+ */
+export function realEtag(imageKey: string, head: Buffer): string {
+    return etag(Buffer.concat([Buffer.from(imageKey + '|'), head.subarray(0, REAL_ETAG_HEAD_BYTES)]))
+}
+
+/**
+ * The validator for a value. For a real variant the leading bytes are required:
+ * on a miss they are the rendered bytes, on a hit the sniffed head of the stored
+ * file, which are the same bytes.
+ */
+export function etagFor(image: {kind: Provenance}, imageKey: string, head?: Buffer): string {
     switch (image.kind) {
         case 'fallback': return fallbackEtag(imageKey)
         case 'passthrough': return passthroughEtag(imageKey)
-        default: return etag(imageKey)
+        default:
+            if (!head) { throw new Error('a real variant needs its leading bytes for a validator') }
+            return realEtag(imageKey, head)
     }
 }
 

--- a/src/served-image.ts
+++ b/src/served-image.ts
@@ -135,33 +135,37 @@ export function passthroughEtag(imageKey: string): string {
 export const REAL_ETAG_HEAD_BYTES = 16384
 
 /**
- * Validator of a real variant: the key together with the leading bytes of the
- * stored representation.
+ * Validator of a real variant: the key, the size of the stored representation
+ * and its leading bytes.
  *
  * A validator derived from the key alone said "same key, same bytes", which was
  * false whenever the bytes under a key changed: a repaired variant, a fixed
  * encoder, a raw container written by a bug and later replaced. Clients holding
  * the old copy were told it was current forever. Tying the validator to the
- * bytes makes any change of representation change the validator, so
- * revalidation replaces the copy. The key is mixed in so two keys whose renders
- * happen to share a prefix never validate each other.
+ * representation makes any change of it change the validator, so revalidation
+ * replaces the copy. The prefix catches a different encoder, format or source
+ * (every codec writes its identity into its first bytes); the size catches a
+ * truncated or extended body behind an identical prefix. Neither costs a full
+ * read on the cache-hit path, which already reads the prefix to sniff the type
+ * and already stats the file to know it exists. The key is mixed in so two keys
+ * whose renders happen to coincide never validate each other.
  */
-export function realEtag(imageKey: string, head: Buffer): string {
-    return etag(Buffer.concat([Buffer.from(imageKey + '|'), head.subarray(0, REAL_ETAG_HEAD_BYTES)]))
+export function realEtag(imageKey: string, head: Buffer, size: number): string {
+    return etag(Buffer.concat([Buffer.from(`${ imageKey }|${ size }|`), head.subarray(0, REAL_ETAG_HEAD_BYTES)]))
 }
 
 /**
- * The validator for a value. For a real variant the leading bytes are required:
- * on a miss they are the rendered bytes, on a hit the sniffed head of the stored
- * file, which are the same bytes.
+ * The validator for a value. For a real variant the leading bytes and the size
+ * are required: on a miss they come from the rendered bytes, on a hit from the
+ * sniffed head and the store's stat of the same file.
  */
-export function etagFor(image: {kind: Provenance}, imageKey: string, head?: Buffer): string {
+export function etagFor(image: {kind: Provenance}, imageKey: string, head?: Buffer, size?: number): string {
     switch (image.kind) {
         case 'fallback': return fallbackEtag(imageKey)
         case 'passthrough': return passthroughEtag(imageKey)
         default:
-            if (!head) { throw new Error('a real variant needs its leading bytes for a validator') }
-            return realEtag(imageKey, head)
+            if (!head || size === undefined) { throw new Error('a real variant needs its leading bytes and size for a validator') }
+            return realEtag(imageKey, head, size)
     }
 }
 

--- a/src/sharded-fs-store.ts
+++ b/src/sharded-fs-store.ts
@@ -114,16 +114,17 @@ export class ShardedFsStore {
         await fs.promises.writeFile(sPath, data)
     }
 
-    exists(opts: any, done: (error: any, exists?: boolean) => void) {
+    /** Reports the size as a third argument: the validator of a stored variant includes it. */
+    exists(opts: any, done: (error: any, exists?: boolean, size?: number) => void) {
         const key = typeof opts === 'string' ? opts : opts.key
         const sPath = shardedPath(this.path, key)
 
         fs.stat(sPath, (err, stat) => {
-            if (!err && stat) return done(null, true)
+            if (!err && stat) return done(null, true, stat.size)
             // Check flat path
             fs.stat(flatPath(this.path, key), (err2, stat2) => {
                 if (err2 && err2.code !== 'ENOENT') return done(err2)
-                done(null, !!stat2)
+                done(null, !!stat2, stat2 ? stat2.size : undefined)
             })
         })
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -735,8 +735,22 @@ export function isAnimatedSource(metadata: {format?: string, pages?: number}, co
     return metadata.pages > 1
 }
 
-export function buildSharpPipeline(buffer: Buffer, animated: boolean = false) {
-    return Sharp(buffer, { failOnError: false, animated, limitInputPixels: MAX_INPUT_PIXELS })
+/**
+ * The page to render for a still multi-image container, or undefined for Sharp's
+ * default. Sharp always pins `page` (default 0) on formats that support pages,
+ * which overrides libvips's own choice of the HEIF primary image, so a HEIC whose
+ * primary is not the first top-level image would render an auxiliary image.
+ */
+export function primaryPageOf(metadata: {format?: string, pagePrimary?: number}): number | undefined {
+    if (metadata.format !== 'heif') { return undefined }
+    return typeof metadata.pagePrimary === 'number' && metadata.pagePrimary > 0 ? metadata.pagePrimary : undefined
+}
+
+export function buildSharpPipeline(buffer: Buffer, animated: boolean = false, page?: number) {
+    return Sharp(buffer, {
+        failOnError: false, animated, limitInputPixels: MAX_INPUT_PIXELS,
+        ...(page !== undefined ? { page } : {}),
+    })
 }
 
 function isPrivateIPv4(host: string): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -715,6 +715,26 @@ export function getOrigKeyFromUrl(url: URL, isUpload: boolean): string {
     const urlHash = createHash('sha1').update(url.toString()).digest()
     return 'U' + multihash.toB58String(multihash.encode(urlHash, 'sha1'))
 }
+/**
+ * Whether a source should be treated as an animation, from Sharp metadata and
+ * the sniffed content type.
+ *
+ * libvips reports `pages` for every multi-image container, not only for
+ * animations: for HEIF it is the number of top-level images, and an iPhone photo
+ * with an auxiliary image (gain map, depth) reports two. Only formats that can
+ * actually animate get to say so through their page count. Anything else is a
+ * still, whatever its page count, and is rendered from its primary image.
+ * When the page count is unknown, GIF and APNG are assumed animated, the
+ * conservative choice for the two formats where a flattened render loses frames.
+ */
+const ANIMATABLE_FORMATS = new Set(['gif', 'webp', 'png'])
+export function isAnimatedSource(metadata: {format?: string, pages?: number}, contentType: string): boolean {
+    const isGifOrApng = contentType === 'image/gif' || contentType === 'image/apng'
+    if (metadata.pages == null) { return isGifOrApng }
+    if (!ANIMATABLE_FORMATS.has(metadata.format || '')) { return false }
+    return metadata.pages > 1
+}
+
 export function buildSharpPipeline(buffer: Buffer, animated: boolean = false) {
     return Sharp(buffer, { failOnError: false, animated, limitInputPixels: MAX_INPUT_PIXELS })
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,6 +114,20 @@ export async function mimeMagic(data: Buffer): Promise<string> {
     return 'application/octet-stream'
 }
 
+/**
+ * Existence check that also reports the stored size when the store knows it
+ * (every store here does: fs and memory from the object, S3 from HEAD). The
+ * size is part of a real variant's validator, so the cache-hit path needs it
+ * before it can answer a conditional request.
+ */
+export function storeStat(store: AbstractBlobStore, key: BlobKey): Promise<{exists: boolean, size?: number}> {
+    return new Promise((resolve, reject) => {
+        (store as any).exists(key, (error: any, exists?: boolean, size?: number) => {
+            if (error) { reject(error) } else { resolve({exists: !!exists, size}) }
+        })
+    })
+}
+
 export function storeExists(store: AbstractBlobStore, key: BlobKey) {
     return new Promise<boolean>((resolve, reject) => {
         store.exists(key, (error, exists) => {

--- a/test/avatar.ts
+++ b/test/avatar.ts
@@ -145,7 +145,8 @@ describe('avatar', function() {
         const first = await needle('get', `http://localhost:${port}/u/foo/avatar`)
         assert.equal(first.statusCode, 200)
         assert(first.headers['etag'], 'response should have etag')
-        assert(first.headers['last-modified'], 'response should have last-modified')
+        assert.equal(first.headers['last-modified'], undefined,
+            'no Last-Modified: it carried the profile timestamp, which says nothing about the stored bytes')
     })
 
     it('answers 304 for conditional revalidation of a healthy avatar', async function() {
@@ -157,9 +158,11 @@ describe('avatar', function() {
         const inm = await needle('get', `http://localhost:${port}/u/healthy/avatar`,
             null, { headers: { 'if-none-match': warm.headers.etag as string } })
         assert.equal(inm.statusCode, 304)
+        // an If-Modified-Since-only revalidation is not honoured: the content
+        // validator is the only thing that can vouch for the stored bytes
         const ims = await needle('get', `http://localhost:${port}/u/healthy/avatar`,
-            null, { headers: { 'if-modified-since': warm.headers['last-modified'] as string } })
-        assert.equal(ims.statusCode, 304)
+            null, { headers: { 'if-modified-since': new Date().toUTCString() } })
+        assert.equal(ims.statusCode, 200)
     })
 
     it('gives a placeholder its own ETag, so it never revalidates as the real avatar', async function() {
@@ -173,7 +176,7 @@ describe('avatar', function() {
         const realUrl = mockProfiles.foo.metadata.profile.profile_image
         const keys = [OutputFormat.Match, OutputFormat.WEBP, OutputFormat.AVIF].map((format) =>
             getImageKey(getUrlHashKey(realUrl), { width: 256, height: 256, mode: ScalingMode.Cover, format } as any))
-        const realEtags = keys.flatMap((k) => [etag(k), realEtag(k, warm.body)])
+        const realEtags = keys.flatMap((k) => [etag(k), realEtag(k, warm.body, warm.body.length)])
         assert(!realEtags.includes(warm.headers.etag as string),
             'placeholder must not wear the ETag the real avatar would have')
         // and a client presenting the placeholder ETag is not told it is current
@@ -221,10 +224,9 @@ describe('avatar', function() {
                     'cached source bytes must not be served')
                 assert.equal(srcHits, hitsBefore, 'blocked source must not be re-fetched')
 
-                // a date-only revalidation must not shortcut either: Last-Modified
-                // still carries the profile timestamp the client already has
+                // a date-only revalidation must not shortcut either
                 const ims = await needle('get', `http://localhost:${port}/u/blockyavatar/avatar`,
-                    null, { headers: { 'if-modified-since': warm.headers['last-modified'] as string } })
+                    null, { headers: { 'if-modified-since': new Date().toUTCString() } })
                 assert.equal(ims.statusCode, 200, 'must not answer 304 for If-Modified-Since revalidation')
                 assert.equal(ims.headers['cache-control'], 'public,max-age=120')
             } finally {

--- a/test/avatar.ts
+++ b/test/avatar.ts
@@ -12,6 +12,7 @@ import {app} from './../src/app'
 import {initBlacklistService} from './../src/blacklist-service'
 import {proxyStore} from './../src/common'
 import {getImageKey, getUrlHashKey, OutputFormat, ScalingMode, storeExists} from './../src/utils'
+import {realEtag} from './../src/served-image'
 import {BROKEN_AVATAR_URL, mockProfiles, pointHealthyProfileAt} from './index'
 
 describe('avatar', function() {
@@ -170,8 +171,9 @@ describe('avatar', function() {
         assert.equal(warm.statusCode, 200)
         assert.equal(warm.headers['cache-control'], 'public,max-age=120')
         const realUrl = mockProfiles.foo.metadata.profile.profile_image
-        const realEtags = [OutputFormat.Match, OutputFormat.WEBP, OutputFormat.AVIF].map((format) =>
-            etag(getImageKey(getUrlHashKey(realUrl), { width: 256, height: 256, mode: ScalingMode.Cover, format } as any)))
+        const keys = [OutputFormat.Match, OutputFormat.WEBP, OutputFormat.AVIF].map((format) =>
+            getImageKey(getUrlHashKey(realUrl), { width: 256, height: 256, mode: ScalingMode.Cover, format } as any))
+        const realEtags = keys.flatMap((k) => [etag(k), realEtag(k, warm.body)])
         assert(!realEtags.includes(warm.headers.etag as string),
             'placeholder must not wear the ETag the real avatar would have')
         // and a client presenting the placeholder ETag is not told it is current

--- a/test/cover.ts
+++ b/test/cover.ts
@@ -12,6 +12,7 @@ import {app} from './../src/app'
 import {initBlacklistService} from './../src/blacklist-service'
 import {proxyStore} from './../src/common'
 import {getImageKey, getUrlHashKey, OutputFormat, ScalingMode, storeExists} from './../src/utils'
+import {realEtag} from './../src/served-image'
 import {BROKEN_COVER_URL, mockProfiles, pointHealthyProfileAt} from './index'
 
 describe('cover', function() {
@@ -155,8 +156,9 @@ describe('cover', function() {
         assert.equal(warm.statusCode, 200)
         assert.equal(warm.headers['cache-control'], 'public,max-age=120')
         const realUrl = mockProfiles.foo.metadata.profile.cover_image
-        const realEtags = [OutputFormat.Match, OutputFormat.WEBP, OutputFormat.AVIF].map((format) =>
-            etag(getImageKey(getUrlHashKey(realUrl), { width: 1344, height: 240, mode: ScalingMode.Fit, format } as any)))
+        const keys = [OutputFormat.Match, OutputFormat.WEBP, OutputFormat.AVIF].map((format) =>
+            getImageKey(getUrlHashKey(realUrl), { width: 1344, height: 240, mode: ScalingMode.Fit, format } as any))
+        const realEtags = keys.flatMap((k) => [etag(k), realEtag(k, warm.body)])
         assert(!realEtags.includes(warm.headers.etag as string),
             'placeholder must not wear the ETag the real cover would have')
         // and a client presenting the placeholder ETag is not told it is current

--- a/test/cover.ts
+++ b/test/cover.ts
@@ -130,7 +130,8 @@ describe('cover', function() {
         const first = await needle('get', `http://localhost:${port}/u/foo/cover`)
         assert.equal(first.statusCode, 200)
         assert(first.headers['etag'], 'response should have etag')
-        assert(first.headers['last-modified'], 'response should have last-modified')
+        assert.equal(first.headers['last-modified'], undefined,
+            'no Last-Modified: it carried the profile timestamp, which says nothing about the stored bytes')
     })
 
     it('answers 304 for conditional revalidation of a healthy cover', async function() {
@@ -142,9 +143,11 @@ describe('cover', function() {
         const inm = await needle('get', `http://localhost:${port}/u/healthy/cover`,
             null, { headers: { 'if-none-match': warm.headers.etag as string } })
         assert.equal(inm.statusCode, 304)
+        // an If-Modified-Since-only revalidation is not honoured: the content
+        // validator is the only thing that can vouch for the stored bytes
         const ims = await needle('get', `http://localhost:${port}/u/healthy/cover`,
-            null, { headers: { 'if-modified-since': warm.headers['last-modified'] as string } })
-        assert.equal(ims.statusCode, 304)
+            null, { headers: { 'if-modified-since': new Date().toUTCString() } })
+        assert.equal(ims.statusCode, 200)
     })
 
     it('gives a placeholder its own ETag, so it never revalidates as the real cover', async function() {
@@ -158,7 +161,7 @@ describe('cover', function() {
         const realUrl = mockProfiles.foo.metadata.profile.cover_image
         const keys = [OutputFormat.Match, OutputFormat.WEBP, OutputFormat.AVIF].map((format) =>
             getImageKey(getUrlHashKey(realUrl), { width: 1344, height: 240, mode: ScalingMode.Fit, format } as any))
-        const realEtags = keys.flatMap((k) => [etag(k), realEtag(k, warm.body)])
+        const realEtags = keys.flatMap((k) => [etag(k), realEtag(k, warm.body, warm.body.length)])
         assert(!realEtags.includes(warm.headers.etag as string),
             'placeholder must not wear the ETag the real cover would have')
         // and a client presenting the placeholder ETag is not told it is current
@@ -206,10 +209,9 @@ describe('cover', function() {
                     'cached source bytes must not be served')
                 assert.equal(srcHits, hitsBefore, 'blocked source must not be re-fetched')
 
-                // a date-only revalidation must not shortcut either: Last-Modified
-                // still carries the profile timestamp the client already has
+                // a date-only revalidation must not shortcut either
                 const ims = await needle('get', `http://localhost:${port}/u/blockycover/cover`,
-                    null, { headers: { 'if-modified-since': warm.headers['last-modified'] as string } })
+                    null, { headers: { 'if-modified-since': new Date().toUTCString() } })
                 assert.equal(ims.statusCode, 200, 'must not answer 304 for If-Modified-Since revalidation')
                 assert.equal(ims.headers['cache-control'], 'public,max-age=120')
             } finally {

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -360,6 +360,48 @@ describe('proxy', function() {
         })
     })
 
+    it('renders a HEIC with more than one top-level image instead of passing the container through', async function() {
+        this.slow(4000)
+        this.timeout(15000)
+        // The fixture reports pages: 2 (primary plus an auxiliary image). Until #43
+        // that made it "animated": the raw HEIC was served unresized, immutable, and
+        // stored as the variant. It must now go through the render, whatever the
+        // outcome of that render is in this environment.
+        const heic = fs.readFileSync(path.resolve(__dirname, 'test.heic'))
+        assert((await sharp(heic).metadata()).pages! > 1, 'fixture must still be multi-page for this test to mean anything')
+        let decodes = true
+        try { await sharp(heic).resize(64).jpeg().toBuffer() } catch (_e) { decodes = false }
+
+        const heicServer = http.createServer((_req, res) => { res.writeHead(200, {'content-type': 'image/heic'}); res.end(heic) })
+        await new Promise<void>((resolve) => heicServer.listen(0, 'localhost', () => resolve()))
+        const source = `http://localhost:${ (heicServer.address() as any).port }/multi-page.heic`
+        const url = `http://localhost:${ port }/p/${ base58Enc(source) }?width=120&mode=fit`
+        const key = getImageKey('U' + multihash.toB58String(multihash.encode(
+            createHash('sha1').update(source).digest(), 'sha1')), {width: 120, mode: ScalingMode.Fit, format: OutputFormat.Match} as any)
+        try {
+            const res = await needle('get', url)
+            assert.equal(res.statusCode, 200)
+            // Either way the animated branch is gone: that branch served the raw
+            // container as a REAL variant (real ETag, stored). A passthrough also
+            // hands the raw bytes back, but with its own ETag and no store write.
+            if (decodes) {
+                // production libvips: a real resized still, stored as the variant
+                assert.notEqual(res.body.length, heic.length, 'the raw container must not be handed through')
+                assert.equal((await sharp(res.body).metadata()).width, 120)
+                assert.equal(res.headers.etag, etag(key))
+                assert.equal(await storeExists(proxyStore, key), true)
+            } else {
+                // development libvips cannot decode HEVC pixels: the render fails and
+                // the original is handed through as a passthrough, never stored
+                assert.equal(res.headers.etag, passthroughEtag(key))
+                assert.equal(await storeExists(proxyStore, key), false)
+            }
+        } finally {
+            await new Promise<void>((resolve) => heicServer.close(() => resolve()))
+            try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
+        }
+    })
+
     it('should proxy stored image when source is gone', async function() {
         // First, store via /p/ route (legacy routes no longer store)
         const imageUrl = base58Enc(`http://localhost:${ port+1 }/test.jpg`)

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -20,7 +20,7 @@ import {DEFAULT_FALLBACK_IMAGE_URL, MAX_CACHED_ORIGINAL_SIZE, SERVICE_BASE_URL} 
 import {shouldCacheOriginal} from './../src/proxy'
 import {fallbackEtag, fallbackImage, passthroughEtag, realImage} from './../src/served-image'
 import {
-    base58Enc, getDefaultUrlAndParams, getImageKey, OutputFormat, ScalingMode, storeExists, storeRemove, storeWrite,
+    base58Enc, getDefaultUrlAndParams, getImageKey, OutputFormat, readStream, ScalingMode, storeExists, storeRemove, storeWrite,
 } from './../src/utils'
 
 import {uploadImage} from './upload'
@@ -360,46 +360,89 @@ describe('proxy', function() {
         })
     })
 
-    it('renders a HEIC with more than one top-level image instead of passing the container through', async function() {
-        this.slow(4000)
-        this.timeout(15000)
-        // The fixture reports pages: 2 (primary plus an auxiliary image). Until #43
-        // that made it "animated": the raw HEIC was served unresized, immutable, and
-        // stored as the variant. It must now go through the render, whatever the
-        // outcome of that render is in this environment.
+    describe('multi-image HEIC (#43)', function() {
         const heic = fs.readFileSync(path.resolve(__dirname, 'test.heic'))
-        assert((await sharp(heic).metadata()).pages! > 1, 'fixture must still be multi-page for this test to mean anything')
         let decodes = true
-        try { await sharp(heic).resize(64).jpeg().toBuffer() } catch (_e) { decodes = false }
+        let heicServer: http.Server
+        let source: string
+        before(async function() {
+            assert((await sharp(heic).metadata()).pages! > 1, 'fixture must be multi-page for these tests to mean anything')
+            try { await sharp(heic).resize(64).jpeg().toBuffer() } catch (_e) { decodes = false }
+            heicServer = http.createServer((_req, res) => { res.writeHead(200, {'content-type': 'image/heic'}); res.end(heic) })
+            await new Promise<void>((resolve) => heicServer.listen(0, 'localhost', () => resolve()))
+            source = `http://localhost:${ (heicServer.address() as any).port }/multi-page.heic`
+        })
+        after(async function() { await new Promise<void>((resolve) => heicServer.close(() => resolve())) })
+        const keyFor = (src: string, opts: any) => getImageKey('U' + multihash.toB58String(multihash.encode(
+            createHash('sha1').update(src).digest(), 'sha1')), opts)
 
-        const heicServer = http.createServer((_req, res) => { res.writeHead(200, {'content-type': 'image/heic'}); res.end(heic) })
-        await new Promise<void>((resolve) => heicServer.listen(0, 'localhost', () => resolve()))
-        const source = `http://localhost:${ (heicServer.address() as any).port }/multi-page.heic`
-        const url = `http://localhost:${ port }/p/${ base58Enc(source) }?width=120&mode=fit`
-        const key = getImageKey('U' + multihash.toB58String(multihash.encode(
-            createHash('sha1').update(source).digest(), 'sha1')), {width: 120, mode: ScalingMode.Fit, format: OutputFormat.Match} as any)
-        try {
-            const res = await needle('get', url)
-            assert.equal(res.statusCode, 200)
-            // Either way the animated branch is gone: that branch served the raw
-            // container as a REAL variant (real ETag, stored). A passthrough also
-            // hands the raw bytes back, but with its own ETag and no store write.
-            if (decodes) {
-                // production libvips: a real resized still, stored as the variant
+        it('renders a resized still from the primary image', async function() {
+            this.slow(4000)
+            this.timeout(15000)
+            // needs a libvips that decodes HEVC (the production build); the stock
+            // development library parses the container but cannot decode its pixels
+            if (!decodes) { this.skip() }
+            const url = `http://localhost:${ port }/p/${ base58Enc(source) }?width=120&mode=fit`
+            const key = keyFor(source, {width: 120, mode: ScalingMode.Fit, format: OutputFormat.Match})
+            try {
+                const res = await needle('get', url)
+                assert.equal(res.statusCode, 200)
                 assert.notEqual(res.body.length, heic.length, 'the raw container must not be handed through')
                 assert.equal((await sharp(res.body).metadata()).width, 120)
+                assert.notEqual(res.headers['content-type'], 'image/heif', 'match negotiates away from HEIF')
                 assert.equal(res.headers.etag, etag(key))
                 assert.equal(await storeExists(proxyStore, key), true)
-            } else {
-                // development libvips cannot decode HEVC pixels: the render fails and
-                // the original is handed through as a passthrough, never stored
-                assert.equal(res.headers.etag, passthroughEtag(key))
-                assert.equal(await storeExists(proxyStore, key), false)
+            } finally {
+                try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
             }
-        } finally {
-            await new Promise<void>((resolve) => heicServer.close(() => resolve()))
-            try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
-        }
+        })
+
+        it('never takes the animated branch: a two-page HEIC is not stored raw as the variant', async function() {
+            this.slow(4000)
+            this.timeout(15000)
+            // Runs everywhere. The animated branch served the raw container as a REAL
+            // variant (real ETag, stored). Whatever the render does here, that must
+            // not happen: where the render fails, the original is a passthrough with
+            // its own ETag and no store write.
+            const url = `http://localhost:${ port }/p/${ base58Enc(source) }?width=100&mode=fit`
+            const key = keyFor(source, {width: 100, mode: ScalingMode.Fit, format: OutputFormat.Match})
+            try {
+                const res = await needle('get', url)
+                assert.equal(res.statusCode, 200)
+                const storedRaw = await storeExists(proxyStore, key)
+                    && (await sharp(await readStream(proxyStore.createReadStream(key))).metadata()).format === 'heif'
+                assert.equal(storedRaw, false, 'the raw HEIC container must never be stored under the variant key')
+                if (!decodes) { assert.equal(res.headers.etag, passthroughEtag(key)) }
+            } finally {
+                try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
+            }
+        })
+
+        it('repairs a variant key that already holds a raw HEIC container', async function() {
+            this.slow(4000)
+            this.timeout(15000)
+            // Before #43 the container was stored as the variant. Those entries stay
+            // in the store; a hit on one must be discarded and re-rendered, not served.
+            const url = `http://localhost:${ port }/p/${ base58Enc(source) }?width=90&mode=fit`
+            const key = keyFor(source, {width: 90, mode: ScalingMode.Fit, format: OutputFormat.Match})
+            await storeWrite(proxyStore, key, heic)
+            try {
+                // no Accept preference: the request lands on the Match key that was seeded
+                const res = await needle('get', url)
+                assert.equal(res.statusCode, 200)
+                const stillRaw = await storeExists(proxyStore, key)
+                    && (await sharp(await readStream(proxyStore.createReadStream(key))).metadata()).format === 'heif'
+                assert.equal(stillRaw, false, 'the poisoned variant must be removed on read')
+                if (decodes) {
+                    assert.equal((await sharp(res.body).metadata()).width, 90, 'and the repaired render is served')
+                    assert.equal(await storeExists(proxyStore, key), true, 'and stored in its place')
+                } else {
+                    assert.equal(res.headers.etag, passthroughEtag(key), 'without a decoder the original is a passthrough')
+                }
+            } finally {
+                try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
+            }
+        })
     })
 
     it('should proxy stored image when source is gone', async function() {

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -204,7 +204,7 @@ describe('proxy', function() {
             const opts = {width: 120, mode: ScalingMode.Fit, format: OutputFormat.Match} as any
             const key = getImageKey('U' + multihash.toB58String(multihash.encode(
                 createHash('sha1').update(source).digest(), 'sha1')), opts)
-            assert.equal(warm.headers.etag, realEtag(key, warm.body), 'real ETag is derived from the key and the stored bytes')
+            assert.equal(warm.headers.etag, realEtag(key, warm.body, warm.body.length), 'real ETag is derived from the key and the stored bytes')
             const stale = await needle('get', url, null, { headers: { 'if-none-match': fallbackEtag(key) } })
             assert.equal(stale.statusCode, 200)
             assert.equal((await sharp(stale.body).metadata()).width, 120)
@@ -264,7 +264,7 @@ describe('proxy', function() {
                 assert.equal(res.body.length, heic.length, 'the original bytes are handed through')
                 assert.equal(res.headers['cache-control'], 'public,max-age=3600', 'a passthrough is fresh for an hour, not a year')
                 assert.equal(res.headers.etag, passthroughEtag(key))
-                assert.notEqual(res.headers.etag, realEtag(key, res.body), 'a passthrough must not wear the variant ETag')
+                assert.notEqual(res.headers.etag, realEtag(key, res.body, res.body.length), 'a passthrough must not wear the variant ETag')
                 assert.equal(await storeExists(proxyStore, key), false, 'a passthrough must not be stored as the variant')
                 // a client holding the passthrough is not told it is current
                 const inm = await needle('get', url, null, { headers: { 'if-none-match': res.headers.etag as string } })
@@ -300,7 +300,7 @@ describe('proxy', function() {
                     {headers: {accept: 'image/jpeg', 'if-none-match': first.headers.etag as string}})
                 assert.equal(recovered.statusCode, 200, 'incompatible AVIF must not validate as the recovered JPEG')
                 assert.equal(recovered.headers['content-type'], 'image/jpeg')
-                assert.equal(recovered.headers.etag, realEtag(key, await readStream(proxyStore.createReadStream(key))), 'the converted variant is real again')
+                assert.equal(recovered.headers.etag, ((b) => realEtag(key, b, b.length))(await readStream(proxyStore.createReadStream(key))), 'the converted variant is real again')
                 assert.equal(recovered.headers['cache-control'], 'public,max-age=31536000,immutable')
             } finally {
                 gate.runEncode = realRunEncode
@@ -329,7 +329,7 @@ describe('proxy', function() {
                 const recovered = await needle('get', url, null, {headers: {'if-none-match': first.headers.etag as string}})
                 assert.equal(recovered.statusCode, 200, 'unresized bytes must not validate as the recovered 800px variant')
                 assert.equal((await sharp(recovered.body).metadata()).width, 800)
-                assert.equal(recovered.headers.etag, realEtag(key, recovered.body))
+                assert.equal(recovered.headers.etag, realEtag(key, recovered.body, recovered.body.length))
             } finally {
                 gate.runEncode = realRunEncode
                 try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
@@ -410,7 +410,7 @@ describe('proxy', function() {
                 assert.notEqual(res.body.length, heic.length, 'the raw container must not be handed through')
                 assert.equal((await sharp(res.body).metadata()).width, 120)
                 assert.notEqual(res.headers['content-type'], 'image/heif', 'match negotiates away from HEIF')
-                assert.equal(res.headers.etag, realEtag(key, res.body))
+                assert.equal(res.headers.etag, realEtag(key, res.body, res.body.length))
                 assert.equal(await storeExists(proxyStore, key), true)
             } finally {
                 try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
@@ -449,7 +449,7 @@ describe('proxy', function() {
             try {
                 // the validators a pre-repair client can hold: the key-only ETag the
                 // old code sent, and the raw container's own content validator
-                for (const stale of [etag(key), realEtag(key, heic)]) {
+                for (const stale of [etag(key), realEtag(key, heic, heic.length)]) {
                     const res = await needle('get', url, null, {headers: {'if-none-match': stale}})
                     assert.equal(res.statusCode, 200, `the old validator ${ stale } must not shortcut past the repair`)
                     assert.notEqual(res.headers.etag, stale, 'the repaired representation carries a new validator')
@@ -462,7 +462,7 @@ describe('proxy', function() {
                 // so the validator did too
                 const second = await needle('get', url, null, {headers: {'if-none-match': etag(key)}})
                 assert.equal(second.statusCode, 200, 'a later client with the pre-repair validator must get the repaired bytes')
-                const third = await needle('get', url, null, {headers: {'if-none-match': realEtag(key, heic)}})
+                const third = await needle('get', url, null, {headers: {'if-none-match': realEtag(key, heic, heic.length)}})
                 assert.equal(third.statusCode, 200)
             } finally {
                 try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
@@ -482,7 +482,7 @@ describe('proxy', function() {
             const key = keyFor(jpegSource, {width: 70, mode: ScalingMode.Fit, format: OutputFormat.Match})
             await storeWrite(proxyStore, key, heic)
             try {
-                const preRepair = [etag(key), realEtag(key, heic)]
+                const preRepair = [etag(key), realEtag(key, heic, heic.length)]
                 // first client: repairs
                 const first = await needle('get', url, null, {headers: {'if-none-match': preRepair[0]}})
                 assert.equal(first.statusCode, 200)

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -336,6 +336,26 @@ describe('proxy', function() {
             }
         })
 
+        it('answers 304 only while the store holds a healthy variant for the key', async function() {
+            this.slow(3000)
+            serveImage = true
+            const source = `http://localhost:${ port+1 }/test.jpg`
+            const url = `http://localhost:${ port }/p/${ base58Enc(source) }?width=130&mode=fit`
+            const key = getImageKey('U' + multihash.toB58String(multihash.encode(
+                createHash('sha1').update(source).digest(), 'sha1')), {width: 130, mode: ScalingMode.Fit, format: OutputFormat.Match} as any)
+            const warm = await needle('get', url)
+            assert.equal(warm.statusCode, 200)
+            const inm = { headers: { 'if-none-match': warm.headers.etag as string } }
+            assert.equal((await needle('get', url, null, inm)).statusCode, 304, 'healthy stored variant: vouch for the copy')
+            // the variant is gone (pruned): nothing to vouch with, so render and answer 200
+            await storeRemove(proxyStore, key)
+            const again = await needle('get', url, null, inm)
+            assert.equal(again.statusCode, 200)
+            assert.equal((await sharp(again.body).metadata()).width, 130)
+            assert.equal(await storeExists(proxyStore, key), true, 'and the variant is stored again')
+            assert.equal((await needle('get', url, null, inm)).statusCode, 304)
+        })
+
         it('never answers 304 for a substituted request', async function() {
             this.slow(3000)
             const source = `http://127.0.0.1:${ port+1 }/blocked-cond.jpg`
@@ -413,6 +433,26 @@ describe('proxy', function() {
                     && (await sharp(await readStream(proxyStore.createReadStream(key))).metadata()).format === 'heif'
                 assert.equal(storedRaw, false, 'the raw HEIC container must never be stored under the variant key')
                 if (!decodes) { assert.equal(res.headers.etag, passthroughEtag(key)) }
+            } finally {
+                try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
+            }
+        })
+
+        it('does not honour the validator of a raw container: a conditional request is repaired too', async function() {
+            this.slow(4000)
+            this.timeout(15000)
+            // A client that cached the raw container holds the real variant's ETag.
+            // Answering 304 to it would tell the client to keep the broken bytes.
+            const url = `http://localhost:${ port }/p/${ base58Enc(source) }?width=80&mode=fit`
+            const key = keyFor(source, {width: 80, mode: ScalingMode.Fit, format: OutputFormat.Match})
+            await storeWrite(proxyStore, key, heic)
+            try {
+                const res = await needle('get', url, null, {headers: {'if-none-match': etag(key)}})
+                assert.equal(res.statusCode, 200, 'the old validator must not shortcut past the repair')
+                assert.notEqual(res.headers.etag, undefined)
+                const stillRaw = await storeExists(proxyStore, key)
+                    && (await sharp(await readStream(proxyStore.createReadStream(key))).metadata()).format === 'heif'
+                assert.equal(stillRaw, false, 'the poisoned variant is removed on the conditional request as well')
             } finally {
                 try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
             }

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -18,7 +18,7 @@ import {initBlacklistService} from './../src/blacklist-service'
 import {proxyStore, uploadStore} from './../src/common'
 import {DEFAULT_FALLBACK_IMAGE_URL, MAX_CACHED_ORIGINAL_SIZE, SERVICE_BASE_URL} from './../src/constants'
 import {shouldCacheOriginal} from './../src/proxy'
-import {fallbackEtag, fallbackImage, passthroughEtag, realImage} from './../src/served-image'
+import {fallbackEtag, fallbackImage, passthroughEtag, realEtag, realImage} from './../src/served-image'
 import {
     base58Enc, getDefaultUrlAndParams, getImageKey, OutputFormat, readStream, ScalingMode, storeExists, storeRemove, storeWrite,
 } from './../src/utils'
@@ -204,7 +204,7 @@ describe('proxy', function() {
             const opts = {width: 120, mode: ScalingMode.Fit, format: OutputFormat.Match} as any
             const key = getImageKey('U' + multihash.toB58String(multihash.encode(
                 createHash('sha1').update(source).digest(), 'sha1')), opts)
-            assert.equal(warm.headers.etag, etag(key), 'real ETag is derived from the key')
+            assert.equal(warm.headers.etag, realEtag(key, warm.body), 'real ETag is derived from the key and the stored bytes')
             const stale = await needle('get', url, null, { headers: { 'if-none-match': fallbackEtag(key) } })
             assert.equal(stale.statusCode, 200)
             assert.equal((await sharp(stale.body).metadata()).width, 120)
@@ -264,7 +264,7 @@ describe('proxy', function() {
                 assert.equal(res.body.length, heic.length, 'the original bytes are handed through')
                 assert.equal(res.headers['cache-control'], 'public,max-age=3600', 'a passthrough is fresh for an hour, not a year')
                 assert.equal(res.headers.etag, passthroughEtag(key))
-                assert.notEqual(res.headers.etag, etag(key), 'a passthrough must not wear the variant ETag')
+                assert.notEqual(res.headers.etag, realEtag(key, res.body), 'a passthrough must not wear the variant ETag')
                 assert.equal(await storeExists(proxyStore, key), false, 'a passthrough must not be stored as the variant')
                 // a client holding the passthrough is not told it is current
                 const inm = await needle('get', url, null, { headers: { 'if-none-match': res.headers.etag as string } })
@@ -300,7 +300,7 @@ describe('proxy', function() {
                     {headers: {accept: 'image/jpeg', 'if-none-match': first.headers.etag as string}})
                 assert.equal(recovered.statusCode, 200, 'incompatible AVIF must not validate as the recovered JPEG')
                 assert.equal(recovered.headers['content-type'], 'image/jpeg')
-                assert.equal(recovered.headers.etag, etag(key), 'the converted variant is real again')
+                assert.equal(recovered.headers.etag, realEtag(key, await readStream(proxyStore.createReadStream(key))), 'the converted variant is real again')
                 assert.equal(recovered.headers['cache-control'], 'public,max-age=31536000,immutable')
             } finally {
                 gate.runEncode = realRunEncode
@@ -329,7 +329,7 @@ describe('proxy', function() {
                 const recovered = await needle('get', url, null, {headers: {'if-none-match': first.headers.etag as string}})
                 assert.equal(recovered.statusCode, 200, 'unresized bytes must not validate as the recovered 800px variant')
                 assert.equal((await sharp(recovered.body).metadata()).width, 800)
-                assert.equal(recovered.headers.etag, etag(key))
+                assert.equal(recovered.headers.etag, realEtag(key, recovered.body))
             } finally {
                 gate.runEncode = realRunEncode
                 try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
@@ -410,7 +410,7 @@ describe('proxy', function() {
                 assert.notEqual(res.body.length, heic.length, 'the raw container must not be handed through')
                 assert.equal((await sharp(res.body).metadata()).width, 120)
                 assert.notEqual(res.headers['content-type'], 'image/heif', 'match negotiates away from HEIF')
-                assert.equal(res.headers.etag, etag(key))
+                assert.equal(res.headers.etag, realEtag(key, res.body))
                 assert.equal(await storeExists(proxyStore, key), true)
             } finally {
                 try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
@@ -447,12 +447,57 @@ describe('proxy', function() {
             const key = keyFor(source, {width: 80, mode: ScalingMode.Fit, format: OutputFormat.Match})
             await storeWrite(proxyStore, key, heic)
             try {
-                const res = await needle('get', url, null, {headers: {'if-none-match': etag(key)}})
-                assert.equal(res.statusCode, 200, 'the old validator must not shortcut past the repair')
-                assert.notEqual(res.headers.etag, undefined)
+                // the validators a pre-repair client can hold: the key-only ETag the
+                // old code sent, and the raw container's own content validator
+                for (const stale of [etag(key), realEtag(key, heic)]) {
+                    const res = await needle('get', url, null, {headers: {'if-none-match': stale}})
+                    assert.equal(res.statusCode, 200, `the old validator ${ stale } must not shortcut past the repair`)
+                    assert.notEqual(res.headers.etag, stale, 'the repaired representation carries a new validator')
+                }
                 const stillRaw = await storeExists(proxyStore, key)
                     && (await sharp(await readStream(proxyStore.createReadStream(key))).metadata()).format === 'heif'
                 assert.equal(stillRaw, false, 'the poisoned variant is removed on the conditional request as well')
+                // and a SECOND client, arriving after the repair with the old validator,
+                // is not told to keep its broken copy either: the stored bytes changed,
+                // so the validator did too
+                const second = await needle('get', url, null, {headers: {'if-none-match': etag(key)}})
+                assert.equal(second.statusCode, 200, 'a later client with the pre-repair validator must get the repaired bytes')
+                const third = await needle('get', url, null, {headers: {'if-none-match': realEtag(key, heic)}})
+                assert.equal(third.statusCode, 200)
+            } finally {
+                try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
+            }
+        })
+
+        it('gives a repaired variant a new validator, so a second client with the old one is not told to keep its copy', async function() {
+            this.slow(4000)
+            this.timeout(15000)
+            // Decoupled from HEVC decoding: the raw container is seeded under the key
+            // of a JPEG source, so the repair renders and stores a real variant in
+            // every environment. Then a client holding the pre-repair validator must
+            // get a 200 with the repaired bytes, not a 304 for its broken copy.
+            serveImage = true
+            const jpegSource = `http://localhost:${ port+1 }/repaired-${ Date.now() }.jpg`
+            const url = `http://localhost:${ port }/p/${ base58Enc(jpegSource) }?width=70&mode=fit`
+            const key = keyFor(jpegSource, {width: 70, mode: ScalingMode.Fit, format: OutputFormat.Match})
+            await storeWrite(proxyStore, key, heic)
+            try {
+                const preRepair = [etag(key), realEtag(key, heic)]
+                // first client: repairs
+                const first = await needle('get', url, null, {headers: {'if-none-match': preRepair[0]}})
+                assert.equal(first.statusCode, 200)
+                assert.equal((await sharp(first.body).metadata()).width, 70, 'repaired render served')
+                assert.equal(await storeExists(proxyStore, key), true, 'and stored')
+                assert(!preRepair.includes(first.headers.etag as string), 'the repaired representation carries a new validator')
+                // second client: arrives after the repair with the old validator
+                for (const stale of preRepair) {
+                    const second = await needle('get', url, null, {headers: {'if-none-match': stale}})
+                    assert.equal(second.statusCode, 200, `a later client presenting ${ stale } must receive the repaired bytes`)
+                    assert.equal((await sharp(second.body).metadata()).width, 70)
+                }
+                // and the new validator does revalidate
+                const fresh = await needle('get', url, null, {headers: {'if-none-match': first.headers.etag as string}})
+                assert.equal(fresh.statusCode, 304)
             } finally {
                 try { await storeRemove(proxyStore, key) } catch (_e) { /* best effort */ }
             }

--- a/test/served-image.ts
+++ b/test/served-image.ts
@@ -40,21 +40,25 @@ describe('served image', function() {
     it('derives the real validator from the key and the stored bytes', function() {
         const key = 'Uabc_100x0_fit_match'
         const bytes = Buffer.from('rendered-bytes')
-        assert.equal(etagFor(real, key, bytes), realEtag(key, bytes))
-        assert.notEqual(realEtag(key, bytes), etag(key), 'no longer the key alone')
-        assert.notEqual(realEtag(key, bytes), realEtag(key, Buffer.from('other-bytes')), 'different bytes, different validator')
-        assert.notEqual(realEtag(key, bytes), realEtag('Uother_100x0_fit_match', bytes), 'same bytes under another key, different validator')
-        // only the leading REAL_ETAG_HEAD_BYTES take part, so a hit (head only) and a miss (whole body) agree
+        assert.equal(etagFor(real, key, bytes, bytes.length), realEtag(key, bytes, bytes.length))
+        assert.notEqual(realEtag(key, bytes, bytes.length), etag(key), 'no longer the key alone')
+        assert.notEqual(realEtag(key, bytes, bytes.length), realEtag(key, Buffer.from('other-bytes!'), bytes.length), 'different bytes, different validator')
+        assert.notEqual(realEtag(key, bytes, bytes.length), realEtag('Uother_100x0_fit_match', bytes, bytes.length), 'same bytes under another key, different validator')
+        // only the leading REAL_ETAG_HEAD_BYTES take part in the digest, so a hit (sniffed
+        // head plus the store's size) and a miss (the whole body) agree
         const big = Buffer.alloc(REAL_ETAG_HEAD_BYTES + 5000, 7)
-        assert.equal(realEtag(key, big), realEtag(key, big.subarray(0, REAL_ETAG_HEAD_BYTES)))
+        assert.equal(realEtag(key, big, big.length), realEtag(key, big.subarray(0, REAL_ETAG_HEAD_BYTES), big.length))
+        // and the size tells apart bodies that share a prefix: a truncated copy does not validate
+        assert.notEqual(realEtag(key, big, big.length), realEtag(key, big, big.length - 1))
         assert.throws(() => etagFor(real, key), /leading bytes/)
+        assert.throws(() => etagFor(real, key, bytes), /size/)
     })
 
     it('never gives a placeholder the real ETag', function() {
         const key = 'Uabc_100x0_fit_match'
         const bytes = Buffer.from('rendered-bytes')
         assert.equal(etagFor(placeholder, key), fallbackEtag(key))
-        assert.notEqual(etagFor(placeholder, key), etagFor(real, key, bytes))
+        assert.notEqual(etagFor(placeholder, key), etagFor(real, key, bytes, bytes.length))
         assert.equal(etagFor(placeholder, key), etagFor(fallbackImage(Buffer.alloc(0), 'other reason'), key),
             'deterministic across reasons, so a placeholder revalidates as a placeholder')
     })
@@ -68,7 +72,7 @@ describe('served image', function() {
         assert.equal(PASSTHROUGH_CACHE_CONTROL, 'public,max-age=3600')
         // but its own validator, or a client holding it would be told "not modified" by the real variant later
         assert.equal(etagFor(through, key), passthroughEtag(key))
-        assert.notEqual(etagFor(through, key), etagFor(real, key, Buffer.from('x')))
+        assert.notEqual(etagFor(through, key), etagFor(real, key, Buffer.from('x'), 1))
         assert.notEqual(etagFor(through, key), etagFor(placeholder, key))
     })
 

--- a/test/served-image.ts
+++ b/test/served-image.ts
@@ -5,6 +5,7 @@ import etag from 'etag'
 import {proxyStore} from './../src/common'
 import {
     cacheControlFor, derive, etagFor, FALLBACK_CACHE_CONTROL, fallbackEtag, fallbackImage, isFallbackImage,
+    REAL_ETAG_HEAD_BYTES, realEtag,
     PASSTHROUGH_CACHE_CONTROL, passthroughEtag, passthroughImage, realImage, storeImage, worstOf,
 } from './../src/served-image'
 import {storeExists, storeRemove} from './../src/utils'
@@ -36,11 +37,24 @@ describe('served image', function() {
         assert.equal(FALLBACK_CACHE_CONTROL, 'public,max-age=120')
     })
 
+    it('derives the real validator from the key and the stored bytes', function() {
+        const key = 'Uabc_100x0_fit_match'
+        const bytes = Buffer.from('rendered-bytes')
+        assert.equal(etagFor(real, key, bytes), realEtag(key, bytes))
+        assert.notEqual(realEtag(key, bytes), etag(key), 'no longer the key alone')
+        assert.notEqual(realEtag(key, bytes), realEtag(key, Buffer.from('other-bytes')), 'different bytes, different validator')
+        assert.notEqual(realEtag(key, bytes), realEtag('Uother_100x0_fit_match', bytes), 'same bytes under another key, different validator')
+        // only the leading REAL_ETAG_HEAD_BYTES take part, so a hit (head only) and a miss (whole body) agree
+        const big = Buffer.alloc(REAL_ETAG_HEAD_BYTES + 5000, 7)
+        assert.equal(realEtag(key, big), realEtag(key, big.subarray(0, REAL_ETAG_HEAD_BYTES)))
+        assert.throws(() => etagFor(real, key), /leading bytes/)
+    })
+
     it('never gives a placeholder the real ETag', function() {
         const key = 'Uabc_100x0_fit_match'
-        assert.equal(etagFor(real, key), etag(key))
+        const bytes = Buffer.from('rendered-bytes')
         assert.equal(etagFor(placeholder, key), fallbackEtag(key))
-        assert.notEqual(etagFor(placeholder, key), etagFor(real, key))
+        assert.notEqual(etagFor(placeholder, key), etagFor(real, key, bytes))
         assert.equal(etagFor(placeholder, key), etagFor(fallbackImage(Buffer.alloc(0), 'other reason'), key),
             'deterministic across reasons, so a placeholder revalidates as a placeholder')
     })
@@ -54,7 +68,7 @@ describe('served image', function() {
         assert.equal(PASSTHROUGH_CACHE_CONTROL, 'public,max-age=3600')
         // but its own validator, or a client holding it would be told "not modified" by the real variant later
         assert.equal(etagFor(through, key), passthroughEtag(key))
-        assert.notEqual(etagFor(through, key), etagFor(real, key))
+        assert.notEqual(etagFor(through, key), etagFor(real, key, Buffer.from('x')))
         assert.notEqual(etagFor(through, key), etagFor(placeholder, key))
     })
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -18,6 +18,7 @@ import {
     stripWebpOrPng,
     getImageKey,
     getUrlHashKey,
+    isAnimatedSource,
     parseProxiedUrl,
     parsePlainUrl,
     getOrigKeyFromUrl,
@@ -281,6 +282,37 @@ describe('utils', function() {
             const url = 'https://example.com/test.jpg'
             const expected = 'U' + createHash('sha1').update(url).digest('hex')
             assert.equal(getUrlHashKey(url), expected)
+        })
+    })
+
+    describe('isAnimatedSource', function() {
+        it('treats a multi-page GIF, WebP or APNG as animated', function() {
+            assert.equal(isAnimatedSource({format: 'gif', pages: 12}, 'image/gif'), true)
+            assert.equal(isAnimatedSource({format: 'webp', pages: 3}, 'image/webp'), true)
+            assert.equal(isAnimatedSource({format: 'png', pages: 4}, 'image/apng'), true)
+        })
+
+        it('treats a single-page animatable format as a still', function() {
+            assert.equal(isAnimatedSource({format: 'gif', pages: 1}, 'image/gif'), false)
+            assert.equal(isAnimatedSource({format: 'webp', pages: 1}, 'image/webp'), false)
+        })
+
+        it('never treats a HEIF or any non-animating container as animated by its page count', function() {
+            // libvips counts top-level images: an iPhone photo with a gain map or
+            // depth image reports two, and passing it through unrendered served the
+            // raw container to browsers that cannot display it (#43)
+            assert.equal(isAnimatedSource({format: 'heif', pages: 2}, 'image/heic'), false)
+            assert.equal(isAnimatedSource({format: 'heif', pages: 5}, 'image/heif'), false)
+            assert.equal(isAnimatedSource({format: 'tiff', pages: 3}, 'image/tiff'), false)
+            assert.equal(isAnimatedSource({format: 'pdf', pages: 9}, 'application/pdf'), false)
+            assert.equal(isAnimatedSource({format: 'jpeg', pages: 2}, 'image/jpeg'), false)
+        })
+
+        it('falls back to the content type only when the page count is unknown', function() {
+            assert.equal(isAnimatedSource({format: 'gif'}, 'image/gif'), true)
+            assert.equal(isAnimatedSource({format: 'png'}, 'image/apng'), true)
+            assert.equal(isAnimatedSource({format: 'heif'}, 'image/heic'), false)
+            assert.equal(isAnimatedSource({format: 'jpeg'}, 'image/jpeg'), false)
         })
     })
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,8 @@
 import 'mocha'
 import blobStore from 'abstract-blob-store'
 import assert from 'assert'
+import * as path from 'path'
+import * as fs from 'fs'
 import { createHash } from 'crypto'
 import { URL } from 'url'
 
@@ -18,8 +20,10 @@ import {
     stripWebpOrPng,
     getImageKey,
     getUrlHashKey,
+    buildSharpPipeline,
     isAnimatedSource,
     parseProxiedUrl,
+    primaryPageOf,
     parsePlainUrl,
     getOrigKeyFromUrl,
     sanitizeIgnoreInvalidateParams,
@@ -313,6 +317,21 @@ describe('utils', function() {
             assert.equal(isAnimatedSource({format: 'png'}, 'image/apng'), true)
             assert.equal(isAnimatedSource({format: 'heif'}, 'image/heic'), false)
             assert.equal(isAnimatedSource({format: 'jpeg'}, 'image/jpeg'), false)
+        })
+    })
+
+    describe('primaryPageOf and buildSharpPipeline', function() {
+        it('selects the HEIF primary image when it is not the first top-level image', function() {
+            assert.equal(primaryPageOf({format: 'heif', pagePrimary: 1}), 1)
+            assert.equal(primaryPageOf({format: 'heif', pagePrimary: 0}), undefined, 'first image is Sharp default')
+            assert.equal(primaryPageOf({format: 'heif'}), undefined)
+            assert.equal(primaryPageOf({format: 'gif', pagePrimary: 1}), undefined, 'only HEIF has a primary image')
+        })
+
+        it('pins the requested page on the Sharp input and leaves it alone otherwise', function() {
+            const buf = fs.readFileSync(path.resolve(__dirname, 'test.heic'))
+            assert.equal((buildSharpPipeline(buf, false, 1) as any).options.input.page, 1)
+            assert.equal((buildSharpPipeline(buf, false) as any).options.input.page, undefined)
         })
     })
 


### PR DESCRIPTION
Closes #43.

libvips reports `pages` for every multi-image container, not only for animations: for HEIF it is the number of top-level images, and an iPhone photo with an auxiliary image (gain map, depth) reports two. The proxy handler, the cached-variant conversion and the shared resizer all read `pages > 1` as animated, so such a HEIC skipped the render entirely: the raw container was served unresized with the immutable header and stored as the variant, to browsers that mostly cannot display HEIC. The repository fixture reports two pages under both the development and the production libvips.

`isAnimatedSource(metadata, contentType)` in `utils.ts` now makes the call at all three sites: GIF, WebP and PNG (APNG) may say "animated" through their page count, every other container is a still rendered from its primary image, and the content-type fallback for an unknown page count is unchanged.

Tests: unit tests for the helper across the animatable formats, single-page cases, HEIF, TIFF, PDF and the unknown-count fallback; and an integration test that proxies the two-page HEIC fixture and asserts the animated branch is gone in either environment (a resized still stored as the variant where the build decodes HEVC; a passthrough with its own ETag and no store write where it does not). Both fail with the format check removed or with the proxy reading the page count directly again.

Avatar and cover already forced a still render and are unaffected beyond using the same helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved animation detection and delivery for GIF, WebP, APNG, and HEIF images.
  - HEIF images with auxiliary or multiple images now correctly select the primary still image.
  - Fixed stale cached image variants so they are automatically repaired and re-rendered.
  - Improved cache validation to prevent incorrect 304 responses and ensure validators reflect served image content and size.
  - Removed profile-date-based `Last-Modified` caching for avatar and cover images.

- **Tests**
  - Added coverage for animated formats, still-image containers, MIME-type fallbacks, HEIC rendering, cache repair, and conditional requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->