### PR TITLE
Bound every object-store call and charge the pre-fetch lookups to the request budget

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -143,6 +143,14 @@ max_custom_image_height = 2000
 # under that budget or the placeholder path is dead code again.
 #fetch_deadline_ms = 12000
 
+# Per-lookup budget for object-store HEAD/GET calls on a request path, in ms.
+# Read handlers charge every store call made before their upstream fetch to the
+# request's fetch deadline, capped by this, so a stalled store costs one bounded
+# wait and the request falls through to the fetch path or the placeholder. The
+# raw upload route allows three times this and answers 504 past it. The S3
+# client also carries connection/socket floors (S3_* in src/constants.ts).
+#store_op_timeout_ms = 5000
+
 # Threads libvips uses per operation. Sharp already clamps this to 1 on glibc,
 # but only while it does not detect jemalloc, so setting it explicitly makes the
 # invariant independent of allocator detection. Note libvips ignores the

--- a/config/test.toml
+++ b/config/test.toml
@@ -1,5 +1,7 @@
 # Fixed encode-concurrency limit so tests exercise a real ceiling (>1)
 max_concurrent_encodes = 3
+# Small so the store-timeout tests finish quickly (serve route allows 3x this)
+store_op_timeout_ms = 300
 
 log_level = 'fatal'
 

--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -267,7 +267,7 @@ async function handleAvatar(ctx: KoaContext) {
       if (res.bytes <= Number.parseInt(config.get('max_image_size')) && !isFallbackImage(origin)) {
         ctx.log.debug('storing original %s', origKey)
         try {
-          await storeImage(origStore, origKey, origin)
+          await storeImage(origStore, origKey, origin, storeSignal())
           // Purge Cloudflare cache for this user's avatar endpoint since we fetched a new image
           // One call, not four: purgeCache expands each URL across every service
           // hostname, so four separate calls would be eight requests to Cloudflare.
@@ -314,7 +314,7 @@ async function handleAvatar(ctx: KoaContext) {
   // enforces that; a profile-lookup fallback is unaffected because it derives
   // both keys from the default image's own URL and never occupies a user's key.
   try {
-    if (await storeImage(proxyStore, imageKey, rendered)) {
+    if (await storeImage(proxyStore, imageKey, rendered, storeSignal())) {
       ctx.log.debug('stored converted %s', imageKey)
     } else {
       ctx.log.debug('not-storing fallback variant %s (%s)', imageKey, (rendered as FallbackImage).reason)

--- a/src/avatar.ts
+++ b/src/avatar.ts
@@ -8,7 +8,7 @@ import {clientGoneSignal} from './encode-limit'
 import {resizeImageWithOptions} from './image-resizer'
 
 import { getProfile, KoaContext, proxyStore, retentionStore, uploadStore } from './common'
-import { FETCH_DEADLINE_MS } from './constants'
+import { budgetSignal, FETCH_DEADLINE_MS, STORE_OP_TIMEOUT_MS } from './constants'
 import { APIError } from './error'
 import {
   cacheControlFor, derive, etagFor, fallbackImage, FallbackImage, isFallbackImage, realImage, ServedImage,
@@ -28,7 +28,10 @@ import {
   safeParseInt,
   ScalingMode,
   storeExists,
+  storeExistsBounded,
   storeStat,
+  storeStatBounded,
+  streamHeadBounded,
   storeRemove,
   supportsAvif,
   supportsWebP,
@@ -148,11 +151,25 @@ async function handleAvatar(ctx: KoaContext) {
   // client keep a copy of whatever it holds.
   ctx.status = 200
 
-  const variantStat = shouldBypassCache ? {exists: false} : await storeStat(proxyStore, imageKey)
+  // Every store call before the upstream fetch, this first variant lookup
+  // included, is bounded and charged to the request budget; a stall reads as a
+  // miss and the handler carries on to the original and the fetch (see #44)
+  const storeSignal = () => budgetSignal(fetchDeadlineAt, STORE_OP_TIMEOUT_MS)
+  let cachedVariant: {head: Buffer, stream: NodeJS.ReadableStream} | undefined
+  const variantStat = shouldBypassCache ? {exists: false}
+    : await storeStatBounded(proxyStore, imageKey, storeSignal(), ctx.log, 'variant')
   if (variantStat.exists) {
+    const headSignal = storeSignal()
+    try {
+      cachedVariant = await streamHeadBounded(
+        proxyStore.createReadStream({ key: imageKey, signal: headSignal } as any), 16384, headSignal)
+    } catch (err) {
+      ctx.log.warn({ err: (err as Error).message, imageKey }, 'cached variant read failed or timed out, treating as a miss')
+    }
+  }
+  if (cachedVariant) {
     ctx.tag({ store: 'resized' })
-    const file = proxyStore.createReadStream(imageKey)
-    const { head, stream } = await import('stream-head').then((mod) => mod.default(file, { bytes: 16384 }))
+    const { head, stream } = cachedVariant
     // The store only holds real variants (storeImage refuses the rest), so a hit
     // is real unless the whole request was substituted for a missing or blocked
     // profile; the response then carries the fallback contract and its own ETag
@@ -198,24 +215,37 @@ async function handleAvatar(ctx: KoaContext) {
   let origin: ServedImage
   let contentType: string
 
-  const haveLocalOriginal = await storeExists(origStore, origKey) && !shouldBypassCache
+  const haveLocalOriginal = await storeExistsBounded(origStore, origKey, storeSignal(), ctx.log, 'original') && !shouldBypassCache
   // Archive of originals whose upstream is gone. An origin, not a cache, so
   // cache-bypass flags deliberately do not skip it. An object-store outage must
   // not fail the request, so any error falls through to the normal fetch path.
   let retentionData: Buffer | undefined
   if (!haveLocalOriginal && retentionStore) {
     try {
-      if (await storeExists(retentionStore, origKey)) {
-        retentionData = await readStream(retentionStore.createReadStream(origKey))
+      if (await storeExistsBounded(retentionStore, origKey, storeSignal(), ctx.log, 'retention original')) {
+        const readSignal = storeSignal()
+        retentionData = await readStream(retentionStore.createReadStream({ key: origKey, signal: readSignal } as any), readSignal)
       }
     } catch (err) {
-      ctx.log.warn({ err, origKey }, 'retention store lookup failed, falling through to fetch')
+      ctx.log.warn({ err: (err as Error).message, origKey }, 'retention store read failed, falling through to fetch')
     }
   }
 
+  let localOriginal: Buffer | undefined
   if (haveLocalOriginal) {
+    try {
+      const readSignal = storeSignal()
+      localOriginal = await readStream(origStore.createReadStream({ key: origKey, signal: readSignal } as any), readSignal)
+    } catch (err) {
+      // A stored original that cannot be read in time is treated like one that is
+      // not there: the fetch path below is the fallback
+      ctx.log.warn({ err: (err as Error).message, origKey }, 'stored original read failed, falling through to fetch')
+    }
+  }
+
+  if (localOriginal) {
     ctx.tag({ store: 'original' })
-    origin = realImage(await readStream(origStore.createReadStream(origKey)))
+    origin = realImage(localOriginal)
     contentType = await mimeMagic(origin.bytes)
   } else if (retentionData) {
     ctx.tag({ store: 'retention' })

--- a/src/common.ts
+++ b/src/common.ts
@@ -308,6 +308,7 @@ export async function getRatelimit(account: string, max: number, duration: numbe
 /** Blob storage — only initialized in worker processes. */
 
 import { S3Client } from '@aws-sdk/client-s3'
+import { S3_MAX_ATTEMPTS, s3RequestHandlerOptions } from './constants'
 import { S3BlobStore } from './s3-store'
 import { ShardedFsStore } from './sharded-fs-store'
 
@@ -342,6 +343,10 @@ function loadStore(key: string): AbstractBlobStore {
                 endpoint,
                 region: config.get('S3_REGION') as string,
                 forcePathStyle: true,
+                // Floors for a stalled object store; see s3RequestHandlerOptions in
+                // constants.ts. The SDK builds its NodeHttpHandler from this object.
+                requestHandler: s3RequestHandlerOptions(),
+                maxAttempts: S3_MAX_ATTEMPTS,
             })
         }
         return new S3BlobStore({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -221,3 +221,63 @@ export const FETCH_DEADLINE_MS = (() => {
     const v = Number(config.get('fetch_deadline_ms'))
     return Number.isSafeInteger(v) && v > 0 ? v : FETCH_DEADLINE_DEFAULT_MS
 })()
+
+/**
+ * Object-store (S3) request floors, set on the shared client.
+ *
+ * The SDK's defaults leave connection and socket timeouts unbounded and retry
+ * three times, so a stalled HEAD or GET against object storage blocked a request
+ * until the edge cut it off at 20 s, and it did so BEFORE the mirror walk, whose
+ * budget it silently consumed (a 503'd walk was seen logging `attempted: 0`).
+ * The upload and retention stores live in the same data centre as the service:
+ * a healthy call is tens of milliseconds, the measured p99 on the serve route was
+ * 3.2 s, so these are floors for a stall, not budgets for normal work.
+ */
+export const S3_CONNECT_TIMEOUT_MS = 3000
+export const S3_REQUEST_TIMEOUT_MS = 10000
+export const S3_MAX_ATTEMPTS = 2
+
+/**
+ * The SDK's NodeHttpHandler options. `requestTimeout` alone only LOGS when it
+ * elapses; it aborts the request only with `throwOnRequestTimeout`, and the idle
+ * socket guard is the separate `socketTimeout`. Kept in one place so the client
+ * and the test that proves a stalled endpoint is actually cut off share it.
+ */
+export function s3RequestHandlerOptions(overrides: Partial<{connectionTimeout: number, requestTimeout: number}> = {}) {
+    const requestTimeout = overrides.requestTimeout ?? S3_REQUEST_TIMEOUT_MS
+    return {
+        connectionTimeout: overrides.connectionTimeout ?? S3_CONNECT_TIMEOUT_MS,
+        requestTimeout,
+        throwOnRequestTimeout: true,
+        socketTimeout: requestTimeout,
+    }
+}
+
+/**
+ * Per-lookup budget for a store HEAD or GET on a request path, in ms.
+ *
+ * Every store call a read handler makes before its upstream fetch (upload-store
+ * and retention HEADs, the read of a stored original) carries an AbortSignal of
+ * at most this long, further clamped to what is left of the request's fetch
+ * deadline, so a stall costs the request one bounded wait and then falls
+ * through to the fetch path or the placeholder instead of eating the whole
+ * budget. The serve route, which has no fetch to fall through to, allows three
+ * times this for an original of up to max_image_size and answers 504 past it.
+ * Configurable as `store_op_timeout_ms` (tests set it low).
+ */
+export const STORE_OP_TIMEOUT_MS = (() => {
+    if (!config.has('store_op_timeout_ms')) { return 5000 }
+    const v = Number(config.get('store_op_timeout_ms'))
+    return Number.isSafeInteger(v) && v > 0 ? v : 5000
+})()
+export const SERVE_READ_TIMEOUT_MS = STORE_OP_TIMEOUT_MS * 3
+
+/**
+ * An AbortSignal for one store call: `capMs`, or what is left until `deadlineAt`
+ * if that is sooner, never less than 1 ms so a blown budget aborts immediately
+ * rather than disabling the timer.
+ */
+export function budgetSignal(deadlineAt: number | undefined, capMs: number): AbortSignal {
+    const remaining = deadlineAt === undefined ? capMs : deadlineAt - Date.now()
+    return AbortSignal.timeout(Math.max(1, Math.min(capMs, remaining)))
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -231,11 +231,21 @@ export const FETCH_DEADLINE_MS = (() => {
  * budget it silently consumed (a 503'd walk was seen logging `attempted: 0`).
  * The upload and retention stores live in the same data centre as the service:
  * a healthy call is tens of milliseconds, the measured p99 on the serve route was
- * 3.2 s, so these are floors for a stall, not budgets for normal work.
+ * 3.2 s, so these are floors for a stall, not budgets for normal work. Calls on
+ * a request path additionally carry a signal from `budgetSignal`, reads and the
+ * writes awaited before the response alike, so the floors only decide calls
+ * made without one.
  */
-export const S3_CONNECT_TIMEOUT_MS = 3000
-export const S3_REQUEST_TIMEOUT_MS = 10000
+export const S3_CONNECT_TIMEOUT_MS = 2000
+export const S3_REQUEST_TIMEOUT_MS = 5000
 export const S3_MAX_ATTEMPTS = 2
+/**
+ * Worst case for one unsignalled call: every attempt connects and then stalls
+ * for the full request timeout. Pinned by a test to stay under the edge's 20 s
+ * with room for backoff, because these floors are the only bound on calls made
+ * without a request signal (writes off the request path, purges, removals).
+ */
+export const S3_WORST_CASE_MS = S3_MAX_ATTEMPTS * (S3_CONNECT_TIMEOUT_MS + S3_REQUEST_TIMEOUT_MS)
 
 /**
  * The SDK's NodeHttpHandler options. `requestTimeout` alone only LOGS when it

--- a/src/cover.ts
+++ b/src/cover.ts
@@ -263,7 +263,7 @@ async function handleCover(ctx: KoaContext) {
       if (res.bytes <= Number.parseInt(config.get('max_image_size')) && !isFallbackImage(origin)) {
         ctx.log.debug('storing original %s', origKey)
         try {
-          await storeImage(origStore, origKey, origin)
+          await storeImage(origStore, origKey, origin, storeSignal())
           // Purge Cloudflare cache for this user's cover endpoint since we fetched a new image
           const serviceUrl = new URL(config.get('service_url'))
           purgeCache(`${serviceUrl.origin}/u/${username}/cover`)
@@ -306,7 +306,7 @@ async function handleCover(ctx: KoaContext) {
   // enforces that; a profile-lookup fallback is unaffected because it derives
   // both keys from the default image's own URL and never occupies a user's key.
   try {
-    if (await storeImage(proxyStore, imageKey, rendered)) {
+    if (await storeImage(proxyStore, imageKey, rendered, storeSignal())) {
       ctx.log.debug('stored converted %s', imageKey)
     } else {
       ctx.log.debug('not-storing fallback variant %s (%s)', imageKey, (rendered as FallbackImage).reason)

--- a/src/cover.ts
+++ b/src/cover.ts
@@ -12,7 +12,7 @@ import {
 } from './served-image'
 import {fetchImageWithFallbacks} from './fetch-image'
 import {clientGoneSignal} from './encode-limit'
-import { FETCH_DEADLINE_MS } from './constants'
+import { budgetSignal, FETCH_DEADLINE_MS, STORE_OP_TIMEOUT_MS } from './constants'
 import {resizeImageWithOptions} from './image-resizer'
 import {
   getDefaultUrlAndParams,
@@ -27,7 +27,10 @@ import {
   readStream,
   ScalingMode,
   storeExists,
+  storeExistsBounded,
   storeStat,
+  storeStatBounded,
+  streamHeadBounded,
   storeRemove,
   supportsAvif,
   supportsWebP,
@@ -147,11 +150,25 @@ async function handleCover(ctx: KoaContext) {
   // client keep a copy of whatever it holds.
   ctx.status = 200
 
-  const variantStat = shouldBypassCache ? {exists: false} : await storeStat(proxyStore, imageKey)
+  // Every store call before the upstream fetch, this first variant lookup
+  // included, is bounded and charged to the request budget; a stall reads as a
+  // miss and the handler carries on to the original and the fetch (see #44)
+  const storeSignal = () => budgetSignal(fetchDeadlineAt, STORE_OP_TIMEOUT_MS)
+  let cachedVariant: {head: Buffer, stream: NodeJS.ReadableStream} | undefined
+  const variantStat = shouldBypassCache ? {exists: false}
+    : await storeStatBounded(proxyStore, imageKey, storeSignal(), ctx.log, 'variant')
   if (variantStat.exists) {
+    const headSignal = storeSignal()
+    try {
+      cachedVariant = await streamHeadBounded(
+        proxyStore.createReadStream({ key: imageKey, signal: headSignal } as any), 16384, headSignal)
+    } catch (err) {
+      ctx.log.warn({ err: (err as Error).message, imageKey }, 'cached variant read failed or timed out, treating as a miss')
+    }
+  }
+  if (cachedVariant) {
     ctx.tag({ store: 'resized' })
-    const file = proxyStore.createReadStream(imageKey)
-    const { head, stream } = await import('stream-head').then((mod) => mod.default(file, { bytes: 16384 }))
+    const { head, stream } = cachedVariant
     // The store only holds real variants (storeImage refuses the rest), so a hit
     // is real unless the whole request was substituted for a missing or blocked
     // profile; the response then carries the fallback contract and its own ETag
@@ -194,24 +211,37 @@ async function handleCover(ctx: KoaContext) {
   let origin: ServedImage
   let contentType: string
 
-  const haveLocalOriginal = await storeExists(origStore, origKey) && !shouldBypassCache
+  const haveLocalOriginal = await storeExistsBounded(origStore, origKey, storeSignal(), ctx.log, 'original') && !shouldBypassCache
   // Archive of originals whose upstream is gone. An origin, not a cache, so
   // cache-bypass flags deliberately do not skip it. An object-store outage must
   // not fail the request, so any error falls through to the normal fetch path.
   let retentionData: Buffer | undefined
   if (!haveLocalOriginal && retentionStore) {
     try {
-      if (await storeExists(retentionStore, origKey)) {
-        retentionData = await readStream(retentionStore.createReadStream(origKey))
+      if (await storeExistsBounded(retentionStore, origKey, storeSignal(), ctx.log, 'retention original')) {
+        const readSignal = storeSignal()
+        retentionData = await readStream(retentionStore.createReadStream({ key: origKey, signal: readSignal } as any), readSignal)
       }
     } catch (err) {
-      ctx.log.warn({ err, origKey }, 'retention store lookup failed, falling through to fetch')
+      ctx.log.warn({ err: (err as Error).message, origKey }, 'retention store read failed, falling through to fetch')
     }
   }
 
+  let localOriginal: Buffer | undefined
   if (haveLocalOriginal) {
+    try {
+      const readSignal = storeSignal()
+      localOriginal = await readStream(origStore.createReadStream({ key: origKey, signal: readSignal } as any), readSignal)
+    } catch (err) {
+      // A stored original that cannot be read in time is treated like one that is
+      // not there: the fetch path below is the fallback
+      ctx.log.warn({ err: (err as Error).message, origKey }, 'stored original read failed, falling through to fetch')
+    }
+  }
+
+  if (localOriginal) {
     ctx.tag({ store: 'original' })
-    origin = realImage(await readStream(origStore.createReadStream(origKey)))
+    origin = realImage(localOriginal)
     contentType = await mimeMagic(origin.bytes)
   } else if (retentionData) {
     ctx.tag({ store: 'retention' })

--- a/src/error.ts
+++ b/src/error.ts
@@ -21,6 +21,7 @@ enum ErrorCode {
     NotFound,
     PayloadTooLarge,
     QoutaExceeded,
+    StoreTimeout,
     UpstreamError,
 }
 
@@ -41,6 +42,7 @@ const HttpCodes = new Map<ErrorCode, number>([
     [ErrorCode.NotFound, 404],
     [ErrorCode.PayloadTooLarge, 413],
     [ErrorCode.QoutaExceeded, 429],
+    [ErrorCode.StoreTimeout, 504],
     [ErrorCode.UpstreamError, 400],
 ])
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,7 +5,6 @@ import config from 'config'
 import {createHash} from 'crypto'
 import * as multihash from 'multihashes'
 import Sharp from 'sharp'
-import streamHead from 'stream-head/dist-es6'
 import {URL} from 'url'
 import {isArchiveStore, KoaContext, proxyStore, retentionStore, uploadStore} from './common'
 import {
@@ -19,6 +18,7 @@ import {
     FETCH_DEFAULT_WALL_MS,
     MAX_CACHED_ORIGINAL_SIZE,
     MAX_INPUT_PIXELS,
+    budgetSignal, STORE_OP_TIMEOUT_MS,
 } from './constants'
 import {APIError} from './error'
 import {serveOrBuildFallbackImage} from './fallback'
@@ -53,11 +53,15 @@ import {
     readStream,
     safeParseInt,
     ScalingMode,
+    isStoreAbort,
     storeExists,
+    storeExistsBounded,
     storeRemove,
     storeStat,
+    storeStatBounded,
     isAnimatedSource,
     primaryPageOf,
+    streamHeadBounded,
     supportsAvif,
     supportsWebP
 } from './utils'
@@ -406,13 +410,38 @@ export async function proxyHandler(ctx: KoaContext) {
     // and found healthy, see below: a validator alone does not prove the bytes
     // behind it are the ones this service would render today.
     ctx.status = 200
+    // Every store call before the upstream fetch, this first variant lookup
+    // included, is bounded and charged to the same request budget the fetch
+    // uses: a stalled store used to eat the whole budget here, so the walk
+    // started with nothing left (see #44). A stall reads as a miss.
+    const storeSignal = () => budgetSignal(fetchDeadlineAt, STORE_OP_TIMEOUT_MS)
     // check if we already have a converted image for a requested key
+    let cachedVariant: {head: Buffer, stream: NodeJS.ReadableStream} | undefined
+    // the store's own stream, kept so a branch that abandons the hit (304, repair)
+    // can release the file handle rather than leave an unconsumed pipe behind
+    let cachedInput: NodeJS.ReadableStream | undefined
     const variantStat = (!options.ignorecache && !options.invalidate)
-        ? await storeStat(proxyStore, imageKey) : {exists: false}
+        ? await storeStatBounded(proxyStore, imageKey, storeSignal(), ctx.log, 'variant') : {exists: false}
     if (variantStat.exists) {
+        const headSignal = storeSignal()
+        cachedInput = proxyStore.createReadStream({ key: imageKey, signal: headSignal } as any)
+        try {
+            cachedVariant = await streamHeadBounded(cachedInput, 16384, headSignal)
+        } catch (err) {
+            ctx.log.warn({ err: (err as Error).message, imageKey }, isStoreAbort(err)
+                ? 'cached variant read timed out, treating as a miss'
+                : 'cached variant read failed, treating as a miss')
+        }
+    }
+    if (cachedVariant) {
         ctx.tag({store: 'resized'})
         ctx.log.debug('streaming %s from store', imageKey)
-        const file = proxyStore.createReadStream(imageKey)
+        const {head, stream} = cachedVariant
+        const file = stream as NodeJS.ReadableStream & {destroy: () => void}
+        const abandonHit = () => {
+            file.destroy()
+            if (cachedInput && (cachedInput as any).destroy) { (cachedInput as any).destroy() }
+        }
         file.on('error', async (err) => {
             ctx.log.error({ err, imageKey }, 'unable to read')
             try {
@@ -425,7 +454,6 @@ export async function proxyHandler(ctx: KoaContext) {
             ctx.res.writeHead(500, 'Internal Error')
             ctx.res.end()
         })
-        const {head, stream} = await streamHead(file, {bytes: 16384})
         const mimeType = await mimeMagic(head)
         if (isPoisonedVariant(mimeType)) {
             // The service never renders to HEIF, so a stored HEIF under a variant
@@ -435,7 +463,7 @@ export async function proxyHandler(ctx: KoaContext) {
             // the original or refetches; the repaired variant is stored on the way.
             ctx.tag({repaired_variant: true})
             ctx.log.warn({ imageKey, mimeType }, 'stored variant is a raw HEIF container, discarding and re-rendering')
-            file.destroy()
+            abandonHit()
             try { await storeRemove(proxyStore, imageKey) } catch (_e) { /* best effort */ }
         } else {
         // A 304 is a promise that the client's copy is what this key renders to,
@@ -452,7 +480,7 @@ export async function proxyHandler(ctx: KoaContext) {
         // repair replaced presents a different one and is not told to keep it
         ctx.set('ETag', etagFor(realImage(head), imageKey, head, variantStat.size))
         if (ctx.fresh && !shouldBypassCache && !substitution) {
-            file.destroy()
+            abandonHit()
             ctx.status = 304
             return
         }
@@ -500,8 +528,9 @@ export async function proxyHandler(ctx: KoaContext) {
     // whenever the proxy-store original is absent or bypassed, and cache-bypass
     // flags never skip it (there is no live origin to refetch from).
     let servingStore = origStore
-    let haveOriginal = await storeExists(origStore, origKey) && !bypassStoredOriginal
-    if (!haveOriginal && !usesUploadStore && await storeExists(uploadStore, origKey)) {
+    let haveOriginal = await storeExistsBounded(origStore, origKey, storeSignal(), ctx.log, 'original') && !bypassStoredOriginal
+    if (!haveOriginal && !usesUploadStore
+        && await storeExistsBounded(uploadStore, origKey, storeSignal(), ctx.log, 'rescued original')) {
         servingStore = uploadStore
         haveOriginal = true
         ctx.tag({rescued_original: true})
@@ -509,23 +538,20 @@ export async function proxyHandler(ctx: KoaContext) {
     // Retention archive: same contract as the upload store above — an origin,
     // not a cache — for originals migrated off local disk. A backend outage here
     // must not fail the request: fall through to the normal fetch path.
-    if (!haveOriginal && retentionStore) {
-        try {
-            if (await storeExists(retentionStore, origKey)) {
-                servingStore = retentionStore
-                haveOriginal = true
-                ctx.tag({retention_original: true})
-            }
-        } catch (err) {
-            ctx.log.warn({ err, origKey }, 'retention store lookup failed, falling through')
-        }
+    if (!haveOriginal && retentionStore
+        && await storeExistsBounded(retentionStore, origKey, storeSignal(), ctx.log, 'retention original')) {
+        servingStore = retentionStore
+        haveOriginal = true
+        ctx.tag({retention_original: true})
     }
     if (haveOriginal) {
         origFromCache = true
         ctx.tag({store: 'original'})
         let res: NeedleResponse
         try {
-            origin = worstOf(realImage(await readStream(servingStore.createReadStream(origKey))), substitution)
+            const readSignal = storeSignal()
+            origin = worstOf(realImage(await readStream(
+                servingStore.createReadStream({ key: origKey, signal: readSignal } as any), readSignal)), substitution)
             contentType = await mimeMagic(origin.bytes)
             // Validate stored data is actually an image — stale error pages or
             // truncated responses may have been cached by a previous request

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -580,7 +580,7 @@ export async function proxyHandler(ctx: KoaContext) {
             if (shouldCacheOriginal(res.bytes, {image: origin, usesUploadStore, isLegacy})) {
                 ctx.log.debug('storing original readStream catch %s', origKey)
                 try {
-                    await storeImage(origStore, origKey, origin)
+                    await storeImage(origStore, origKey, origin, storeSignal())
                 } catch (err) {
                     ctx.log.error({ err, origKey }, 'failed to store original proxy image (readStream catch)')
                     // Continue serving - storage failure shouldn't block response
@@ -640,7 +640,7 @@ export async function proxyHandler(ctx: KoaContext) {
         if (shouldCacheOriginal(res.bytes, {image: origin, usesUploadStore, isLegacy})) {
             ctx.log.debug('storing original image %s', origKey)
             try {
-                await storeImage(origStore, origKey, origin)
+                await storeImage(origStore, origKey, origin, storeSignal())
             } catch (err) {
                 ctx.log.error({ err, origKey }, 'failed to store original proxy image')
                 // Continue serving - storage failure shouldn't block response
@@ -833,7 +833,7 @@ export async function proxyHandler(ctx: KoaContext) {
         // and refuses a placeholder or a passthrough, whichever branch produced it.
         if (!isLegacy) {
             try {
-                if (await storeImage(proxyStore, imageKey, rendered)) {
+                if (await storeImage(proxyStore, imageKey, rendered, storeSignal())) {
                     ctx.log.debug('stored converted %s', imageKey)
                 }
             } catch (err) {

--- a/src/s3-store.ts
+++ b/src/s3-store.ts
@@ -37,12 +37,12 @@ export class S3BlobStore {
     }
 
     /** Direct buffer upload — no streaming overhead. */
-    async putBuffer(key: string, data: Buffer): Promise<void> {
+    async putBuffer(key: string, data: Buffer, signal?: AbortSignal): Promise<void> {
         await this.s3.send(new PutObjectCommand({
             Bucket: this.bucket,
             Key: key,
             Body: data,
-        }))
+        }), signal ? { abortSignal: signal } : undefined)
     }
 
     createWriteStream(opts: any, done?: (error: any, metadata?: any) => void): PassThrough {

--- a/src/s3-store.ts
+++ b/src/s3-store.ts
@@ -23,6 +23,13 @@ export class S3BlobStore {
             Bucket: this.bucket,
             Key: key,
         }), abortSignal ? { abortSignal } : undefined).then((res) => {
+            if (passthrough.destroyed) {
+                // the consumer gave up (budget abort) before the GET answered:
+                // release the body instead of piping into a destroyed stream
+                const body = res.Body as any
+                if (body && typeof body.destroy === 'function') { body.destroy() }
+                return
+            }
             if (!res.Body || typeof (res.Body as any).pipe !== 'function') {
                 passthrough.destroy(new Error('S3 response body is not a readable stream'))
                 return

--- a/src/s3-store.ts
+++ b/src/s3-store.ts
@@ -17,11 +17,12 @@ export class S3BlobStore {
 
     createReadStream(opts: any): Readable {
         const key = typeof opts === 'string' ? opts : opts.key
+        const abortSignal: AbortSignal | undefined = typeof opts === 'string' ? undefined : opts.signal
         const passthrough = new PassThrough()
         this.s3.send(new GetObjectCommand({
             Bucket: this.bucket,
             Key: key,
-        })).then((res) => {
+        }), abortSignal ? { abortSignal } : undefined).then((res) => {
             if (!res.Body || typeof (res.Body as any).pipe !== 'function') {
                 passthrough.destroy(new Error('S3 response body is not a readable stream'))
                 return
@@ -71,10 +72,11 @@ export class S3BlobStore {
     /** Reports the size as a third argument: the validator of a stored variant includes it. */
     exists(opts: any, done: (error: any, exists?: boolean, size?: number) => void) {
         const key = typeof opts === 'string' ? opts : opts.key
+        const abortSignal: AbortSignal | undefined = typeof opts === 'string' ? undefined : opts.signal
         this.s3.send(new HeadObjectCommand({
             Bucket: this.bucket,
             Key: key,
-        })).then((res) => {
+        }), abortSignal ? { abortSignal } : undefined).then((res) => {
             done(null, true, typeof res.ContentLength === 'number' ? res.ContentLength : undefined)
         }).catch((err) => {
             if (err.name === 'NotFound' || err.$metadata?.httpStatusCode === 404) {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,9 +1,9 @@
 /** Serve files from upload store. */
 
-import {isBlacklistedUrl, readStream} from './utils'
+import {isBlacklistedUrl, isStoreAbort, readStream} from './utils'
 import {KoaContext, uploadStore} from './common'
 import {APIError} from './error'
-import {DEFAULT_AVATAR_HASH, MAX_INPUT_PIXELS, SERVICE_BASE_URL} from './constants'
+import {budgetSignal, DEFAULT_AVATAR_HASH, MAX_INPUT_PIXELS, SERVE_READ_TIMEOUT_MS, SERVICE_BASE_URL} from './constants'
 import Sharp from 'sharp'
 
 function detectMimeType(metadata: Sharp.Metadata): string {
@@ -42,9 +42,18 @@ export async function serveHandler(ctx: KoaContext) {
     }
 
     let buffer: Buffer
+    // This route has no fetch path to fall through to, so a stalled object store
+    // is answered as such: a 504 that the error middleware marks no-store, rather
+    // than a wait until the edge cuts the request off at its own timeout, and
+    // rather than a 404, which caches and would tell the client the upload is gone
+    const signal = budgetSignal(undefined, SERVE_READ_TIMEOUT_MS)
     try {
-        buffer = await readStream(uploadStore.createReadStream(_hash))
+        buffer = await readStream(uploadStore.createReadStream({ key: _hash, signal } as any), signal)
     } catch (error) {
+        if (isStoreAbort(error)) {
+            ctx.log.warn({hash: _hash, timeoutMs: SERVE_READ_TIMEOUT_MS}, 'upload store read timed out')
+            throw new APIError({ cause: error as Error, code: APIError.Code.StoreTimeout, info: { hash: _hash } })
+        }
         // File not found in uploadStore — return 404 to let the client
         // retry via the proxy path (/p/) which has a full fallback chain.
         // Do NOT fetch from external proxies and write to uploadStore here —

--- a/src/served-image.ts
+++ b/src/served-image.ts
@@ -180,8 +180,10 @@ export function etagFor(image: {kind: Provenance}, imageKey: string, head?: Buff
  * whether a write happened; the caller still owns error handling for a write
  * that fails.
  */
-export async function storeImage(store: AbstractBlobStore, key: BlobKey, image: ServedImage): Promise<boolean> {
+export async function storeImage(
+    store: AbstractBlobStore, key: BlobKey, image: ServedImage, signal?: AbortSignal,
+): Promise<boolean> {
     if (!isRealImage(image)) { return false }
-    await storeWrite(store, key, image.bytes)
+    await storeWrite(store, key, image.bytes, signal)
     return true
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -233,25 +233,38 @@ export async function streamHeadBounded(
 }
 
 interface PutBufferStore {
-    putBuffer(key: string, buf: Buffer): Promise<void>
+    putBuffer(key: string, buf: Buffer, signal?: AbortSignal): Promise<void>
 }
 
 function hasPutBuffer(store: any): store is PutBufferStore {
     return typeof store.putBuffer === 'function'
 }
 
-export async function storeWrite(store: AbstractBlobStore, key: BlobKey, data: Buffer | string) {
+/**
+ * Writes a blob. With a signal the S3 upload is aborted when it fires and the
+ * caller gets an AbortError; a write on a request path is awaited before the
+ * response goes out, so a stalled object store must not hold it either.
+ */
+export async function storeWrite(store: AbstractBlobStore, key: BlobKey, data: Buffer | string, signal?: AbortSignal) {
     const buf = Buffer.isBuffer(data) ? data : Buffer.from(data)
     // Use direct buffer upload for S3 stores (avoids stream double-buffering)
     if (hasPutBuffer(store)) {
         const k = typeof key === 'string' ? key : (key as any).key
-        await store.putBuffer(k, buf)
+        if (signal && signal.aborted) { throw storeAbortError(signal) }
+        await store.putBuffer(k, buf, signal)
         return { key: k }
     }
     return new Promise((resolve, reject) => {
-        const stream = store.createWriteStream(key, (error, metadata) => {
+        let settled = false
+        const finish = (fn: () => void) => { if (!settled) { settled = true; if (signal) { signal.removeEventListener('abort', onAbort) } fn() } }
+        const onAbort = () => finish(() => reject(storeAbortError(signal)))
+        if (signal) {
+            if (signal.aborted) { onAbort(); return }
+            signal.addEventListener('abort', onAbort, {once: true})
+        }
+        const stream = store.createWriteStream(key, (error, metadata) => finish(() => {
             if (error) { reject(error) } else { resolve(metadata) }
-        })
+        }))
         stream.write(buf)
         stream.end()
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -211,6 +211,13 @@ export async function storeExistsBounded(
  * Reads the first `bytes` of a stream (for sniffing) under a budget. On abort the
  * stream is destroyed and the caller gets an AbortError, so a stalled store cannot
  * hold a cache hit open past the request's budget.
+ *
+ * stream-head listens for errors only on its own internal stream, never on the
+ * input, so an input that fails (an object-store GET that errors after the stream
+ * was handed out) would emit an unhandled 'error' and take the process down. The
+ * input's errors are owned here: before the head is read they reject this
+ * promise; after it, they are forwarded to the output stream the caller holds,
+ * where Koa's body handling or readStream() will see them.
  */
 export async function streamHeadBounded(
     stream: NodeJS.ReadableStream, bytes: number, signal: AbortSignal,
@@ -218,16 +225,25 @@ export async function streamHeadBounded(
     const streamHead = (await import('stream-head')).default
     return new Promise((resolve, reject) => {
         let settled = false
+        let output: NodeJS.ReadableStream | undefined
+        const destroyInput = (err?: Error) => { if ((stream as any).destroy) { (stream as any).destroy(err) } }
         const finish = (fn: () => void) => { if (!settled) { settled = true; signal.removeEventListener('abort', onAbort); fn() } }
         const onAbort = () => finish(() => {
-            if ((stream as any).destroy) { (stream as any).destroy() }
+            destroyInput()
             reject(storeAbortError(signal))
         })
+        const onInputError = (err: Error) => {
+            if (!settled) { finish(() => reject(err)); return }
+            // the caller now owns the output; hand the failure to it rather than
+            // letting an unlistened input emit
+            if (output && (output as any).destroy) { (output as any).destroy(err) }
+        }
+        stream.on('error', onInputError)
         if (signal.aborted) { onAbort(); return }
         signal.addEventListener('abort', onAbort, {once: true})
         streamHead(stream as any, {bytes}).then(
-            (r: any) => finish(() => resolve(r)),
-            (err: any) => finish(() => reject(err)),
+            (r: any) => finish(() => { output = r.stream; resolve(r) }),
+            (err: any) => finish(() => { destroyInput(); reject(err) }),
         )
     })
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,15 +89,41 @@ export function camelToSnake(value: string) {
     return value.replace(/([A-Z])/g, (_, m) => `_${m.toLowerCase()}`).replace(/^_/, '')
 }
 
-export function readStream(stream: NodeJS.ReadableStream) {
+/** The error a store call rejects with when its AbortSignal fires. */
+export function storeAbortError(signal?: AbortSignal): Error {
+    const err = new Error('store operation aborted: ' + ((signal && (signal.reason as any)?.message) || 'timeout'))
+    err.name = 'AbortError'
+    return err
+}
+
+export function isStoreAbort(err: any): boolean {
+    return !!err && (err.name === 'AbortError' || err.name === 'TimeoutError')
+}
+
+/**
+ * Collects a stream into a Buffer. With a signal, aborts the read and destroys the
+ * stream when it fires, so a stalled object-store body cannot hold a request past
+ * its budget whatever the store implementation does with the signal itself.
+ */
+export function readStream(stream: NodeJS.ReadableStream, signal?: AbortSignal) {
     return new Promise<Buffer>((resolve, reject) => {
         const chunks: Buffer[] = []
+        let settled = false
+        const finish = (fn: () => void) => { if (!settled) { settled = true; if (signal) { signal.removeEventListener('abort', onAbort) } fn() } }
+        const onAbort = () => finish(() => {
+            if ((stream as any).destroy) { (stream as any).destroy() }
+            reject(storeAbortError(signal))
+        })
+        if (signal) {
+            if (signal.aborted) { onAbort(); return }
+            signal.addEventListener('abort', onAbort, {once: true})
+        }
         stream.on('data', (chunk) => chunks.push(chunk))
-        stream.on('error', (err) => {
+        stream.on('error', (err) => finish(() => {
             if ((stream as any).destroy) { (stream as any).destroy() }
             reject(err)
-        })
-        stream.on('end', () => resolve(Buffer.concat(chunks)))
+        }))
+        stream.on('end', () => finish(() => resolve(Buffer.concat(chunks))))
     })
 }
 
@@ -115,24 +141,94 @@ export async function mimeMagic(data: Buffer): Promise<string> {
 }
 
 /**
+/**
  * Existence check that also reports the stored size when the store knows it
  * (every store here does: fs and memory from the object, S3 from HEAD). The
  * size is part of a real variant's validator, so the cache-hit path needs it
- * before it can answer a conditional request.
+ * before it can answer a conditional request. With a signal, the budget is
+ * handed to the store (the S3 store aborts the HEAD) and raced here as well, so
+ * a store that ignores it still cannot hold the caller past the budget.
  */
-export function storeStat(store: AbstractBlobStore, key: BlobKey): Promise<{exists: boolean, size?: number}> {
+export function storeStat(store: AbstractBlobStore, key: BlobKey, signal?: AbortSignal): Promise<{exists: boolean, size?: number}> {
     return new Promise((resolve, reject) => {
-        (store as any).exists(key, (error: any, exists?: boolean, size?: number) => {
+        let settled = false
+        const finish = (fn: () => void) => { if (!settled) { settled = true; if (signal) { signal.removeEventListener('abort', onAbort) } fn() } }
+        const onAbort = () => finish(() => reject(storeAbortError(signal)))
+        if (signal) {
+            if (signal.aborted) { onAbort(); return }
+            signal.addEventListener('abort', onAbort, {once: true})
+        }
+        const opts: any = signal ? {key: typeof key === 'string' ? key : (key as any).key, signal} : key
+        ;(store as any).exists(opts, (error: any, exists?: boolean, size?: number) => finish(() => {
             if (error) { reject(error) } else { resolve({exists: !!exists, size}) }
-        })
+        }))
     })
 }
 
-export function storeExists(store: AbstractBlobStore, key: BlobKey) {
-    return new Promise<boolean>((resolve, reject) => {
-        store.exists(key, (error, exists) => {
-            if (error) { reject(error) } else { resolve(exists) }
+/** Existence check with an optional budget; see storeStat. */
+export function storeExists(store: AbstractBlobStore, key: BlobKey, signal?: AbortSignal): Promise<boolean> {
+    return storeStat(store, key, signal).then((r) => r.exists)
+}
+
+/**
+ * storeExistsBounded with the size: a stall or an error reads as absent.
+ */
+export async function storeStatBounded(
+    store: AbstractBlobStore, key: string, signal: AbortSignal, log: any, what: string,
+): Promise<{exists: boolean, size?: number}> {
+    try {
+        return await storeStat(store, key, signal)
+    } catch (err) {
+        log.warn({ err: (err as Error).message, key, what }, isStoreAbort(err)
+            ? 'store lookup timed out, treating as absent'
+            : 'store lookup failed, treating as absent')
+        return {exists: false}
+    }
+}
+
+/**
+ * A store existence check that treats a stall as "absent". Every read handler
+ * consults its stores before it fetches upstream, so a HEAD that hangs used to
+ * consume the fetch budget before the first candidate was tried; with a budget
+ * from `budgetSignal` the request loses one bounded wait and carries on to the
+ * fetch path or the placeholder. A genuine error is logged and treated the same
+ * way: the fetch path is the fallback for a store that cannot answer.
+ */
+export async function storeExistsBounded(
+    store: AbstractBlobStore, key: string, signal: AbortSignal, log: any, what: string,
+): Promise<boolean> {
+    try {
+        return await storeExists(store, key, signal)
+    } catch (err) {
+        log.warn({ err: (err as Error).message, key, what }, isStoreAbort(err)
+            ? 'store lookup timed out, treating as absent'
+            : 'store lookup failed, treating as absent')
+        return false
+    }
+}
+
+/**
+ * Reads the first `bytes` of a stream (for sniffing) under a budget. On abort the
+ * stream is destroyed and the caller gets an AbortError, so a stalled store cannot
+ * hold a cache hit open past the request's budget.
+ */
+export async function streamHeadBounded(
+    stream: NodeJS.ReadableStream, bytes: number, signal: AbortSignal,
+): Promise<{head: Buffer, stream: NodeJS.ReadableStream}> {
+    const streamHead = (await import('stream-head')).default
+    return new Promise((resolve, reject) => {
+        let settled = false
+        const finish = (fn: () => void) => { if (!settled) { settled = true; signal.removeEventListener('abort', onAbort); fn() } }
+        const onAbort = () => finish(() => {
+            if ((stream as any).destroy) { (stream as any).destroy() }
+            reject(storeAbortError(signal))
         })
+        if (signal.aborted) { onAbort(); return }
+        signal.addEventListener('abort', onAbort, {once: true})
+        streamHead(stream as any, {bytes}).then(
+            (r: any) => finish(() => resolve(r)),
+            (err: any) => finish(() => reject(err)),
+        )
     })
 }
 

--- a/test/avatar.ts
+++ b/test/avatar.ts
@@ -51,6 +51,24 @@ describe('avatar', function() {
         assert(meta.height && meta.height <= 256, 'avatar height should be <= 256')
     })
 
+    it('reaches the fetch when the first variant lookup stalls', async function() {
+        this.slow(3000)
+        this.timeout(10000)
+        const realExists = proxyStore.exists
+        const pending: any[] = []
+        ;(proxyStore as any).exists = (_key: any, done: any) => { pending.push(done) }
+        const t0 = Date.now()
+        try {
+            const res = await needle('get', `http://localhost:${port}/u/healthy/avatar/64`)
+            assert.equal(res.statusCode, 200)
+            assert.equal((await sharp(res.body).metadata()).width, 64)
+            assert(Date.now() - t0 < 2000, 'stalled lookups must cost at most a store budget each')
+        } finally {
+            ;(proxyStore as any).exists = realExists
+            for (const done of pending) { try { done(null, false) } catch (_e) { /* settled */ } }
+        }
+    })
+
     it('should serve avatar with size parameter', async function() {
         this.slow(2000)
         this.timeout(10000)

--- a/test/proxy.ts
+++ b/test/proxy.ts
@@ -530,6 +530,58 @@ describe('proxy', function() {
         })
     })
 
+    it('falls through to the fetch when a store lookup stalls, inside the request budget', async function() {
+        this.slow(3000)
+        this.timeout(10000)
+        // The rescued-original check is a HEAD against the upload store, made before
+        // the mirror walk. A stall there used to consume the whole fetch budget, so
+        // the walk started with nothing left and the placeholder was served too late.
+        serveImage = true
+        const source = `http://localhost:${ port+1 }/stalled-store-${ Date.now() }.jpg`
+        const url = `http://localhost:${ port }/p/${ base58Enc(source) }?width=100&mode=fit`
+        const realExists = uploadStore.exists
+        let hung = 0
+        ;(uploadStore as any).exists = () => { hung++ } // never calls back
+        const t0 = Date.now()
+        try {
+            const res = await needle('get', url)
+            const elapsed = Date.now() - t0
+            assert.equal(res.statusCode, 200)
+            assert.equal((await sharp(res.body).metadata()).width, 100, 'the fetch path served the real image')
+            assert.equal(res.headers['cache-control'], 'public,max-age=31536000,immutable')
+            assert(hung >= 1, 'the stalled lookup was attempted')
+            // store_op_timeout_ms is 300 in the test config: one bounded wait, then the fetch
+            assert(elapsed < 3000, `request took ${ elapsed }ms; the stalled lookup must cost at most one store budget`)
+        } finally {
+            ;(uploadStore as any).exists = realExists
+        }
+    })
+
+    it('bounds the first variant lookup too, so a stalled proxy store still reaches the fetch', async function() {
+        this.slow(3000)
+        this.timeout(10000)
+        // The variant HEAD is the very first store call. It used to be unbounded, so a
+        // stall there never reached any of the bounded lookups that follow it.
+        serveImage = true
+        const source = `http://localhost:${ port+1 }/stalled-variant-${ Date.now() }.jpg`
+        const url = `http://localhost:${ port }/p/${ base58Enc(source) }?width=120&mode=fit`
+        const realExists = proxyStore.exists
+        const pending: any[] = []
+        ;(proxyStore as any).exists = (_key: any, done: any) => { pending.push(done) } // never answers
+        const t0 = Date.now()
+        try {
+            const res = await needle('get', url)
+            const elapsed = Date.now() - t0
+            assert.equal(res.statusCode, 200)
+            assert.equal((await sharp(res.body).metadata()).width, 120)
+            // variant HEAD and original HEAD each cost one 300ms budget, then the fetch
+            assert(elapsed < 1500, `took ${ elapsed }ms; two stalled lookups must cost at most two store budgets`)
+        } finally {
+            ;(proxyStore as any).exists = realExists
+            for (const done of pending) { try { done(null, false) } catch (_e) { /* settled */ } }
+        }
+    })
+
     it('should proxy stored image when source is gone', async function() {
         // First, store via /p/ route (legacy routes no longer store)
         const imageUrl = base58Enc(`http://localhost:${ port+1 }/test.jpg`)

--- a/test/s3-store.ts
+++ b/test/s3-store.ts
@@ -1,5 +1,8 @@
 import 'mocha'
 import assert from 'assert'
+import {s3RequestHandlerOptions} from './../src/constants'
+import {HeadObjectCommand, S3Client} from '@aws-sdk/client-s3'
+import * as http from 'http'
 import { Readable } from 'stream'
 
 import { S3BlobStore } from './../src/s3-store'
@@ -144,6 +147,60 @@ describe('S3BlobStore', function() {
             } catch (err: any) {
                 assert.equal(err.message, 'S3 connection reset')
             }
+        })
+    })
+
+    describe('client floors', function() {
+        it('cuts off an accepted but stalled request with the configured handler options', async function() {
+            this.timeout(5000)
+            // An endpoint that accepts the connection and never answers. requestTimeout
+            // alone only logs when it elapses; the options must make it throw.
+            const endpoint = http.createServer((_req, _res) => undefined)
+            await new Promise<void>((resolve) => endpoint.listen(0, '127.0.0.1', () => resolve()))
+            const client = new S3Client({
+                endpoint: `http://127.0.0.1:${ (endpoint.address() as any).port }`,
+                region: 'us-east-1', credentials: {accessKeyId: 'test', secretAccessKey: 'test'},
+                forcePathStyle: true, maxAttempts: 1,
+                requestHandler: s3RequestHandlerOptions({connectionTimeout: 500, requestTimeout: 100}),
+            })
+            const t0 = Date.now()
+            try {
+                await assert.rejects(client.send(new HeadObjectCommand({Bucket: 'b', Key: 'k'})),
+                    (err: any) => err.name === 'TimeoutError' || /timeout/i.test(err.message))
+                assert(Date.now() - t0 < 3000, 'the stalled request must be cut off by the handler, not by anything outside it')
+            } finally {
+                client.destroy()
+                endpoint.closeAllConnections()
+                await new Promise<void>((resolve) => endpoint.close(() => resolve()))
+            }
+        })
+    })
+
+    describe('abort signals', function() {
+        it('forwards the signal to the SDK for exists and createReadStream', async function() {
+            const calls: any[] = []
+            const client: any = {
+                send: async (command: any, options: any) => {
+                    calls.push({name: command.constructor.name, options})
+                    if (command.constructor.name === 'GetObjectCommand') {
+                        const {Readable} = require('stream')
+                        return {Body: Readable.from([Buffer.from('x')])}
+                    }
+                    return {}
+                }
+            }
+            const store = new S3BlobStore({ client, bucket: 'b' })
+            const signal = AbortSignal.timeout(5000)
+            await new Promise<void>((resolve, reject) => store.exists({key: 'k', signal}, (err) => err ? reject(err) : resolve()))
+            await new Promise<void>((resolve, reject) => {
+                const rs = store.createReadStream({key: 'k', signal})
+                rs.on('error', reject); rs.on('end', () => resolve()); rs.resume()
+            })
+            assert.equal(calls.length, 2)
+            for (const c of calls) { assert.equal(c.options && c.options.abortSignal, signal, `${ c.name } must carry the abortSignal`) }
+            // and nothing is passed when there is no signal
+            await new Promise<void>((resolve, reject) => store.exists('plain', (err) => err ? reject(err) : resolve()))
+            assert.equal(calls[2].options, undefined)
         })
     })
 

--- a/test/s3-store.ts
+++ b/test/s3-store.ts
@@ -177,7 +177,7 @@ describe('S3BlobStore', function() {
     })
 
     describe('abort signals', function() {
-        it('forwards the signal to the SDK for exists and createReadStream', async function() {
+        it('forwards the signal to the SDK for exists, createReadStream and putBuffer', async function() {
             const calls: any[] = []
             const client: any = {
                 send: async (command: any, options: any) => {
@@ -196,11 +196,12 @@ describe('S3BlobStore', function() {
                 const rs = store.createReadStream({key: 'k', signal})
                 rs.on('error', reject); rs.on('end', () => resolve()); rs.resume()
             })
-            assert.equal(calls.length, 2)
+            await store.putBuffer('k', Buffer.from('x'), signal)
+            assert.equal(calls.length, 3)
             for (const c of calls) { assert.equal(c.options && c.options.abortSignal, signal, `${ c.name } must carry the abortSignal`) }
             // and nothing is passed when there is no signal
             await new Promise<void>((resolve, reject) => store.exists('plain', (err) => err ? reject(err) : resolve()))
-            assert.equal(calls[2].options, undefined)
+            assert.equal(calls[3].options, undefined)
         })
     })
 

--- a/test/s3-store.ts
+++ b/test/s3-store.ts
@@ -176,6 +176,27 @@ describe('S3BlobStore', function() {
         })
     })
 
+    describe('read stream after the consumer gave up', function() {
+        it('does not pipe a late GET body into a destroyed stream', async function() {
+            let bodyDestroyed = false
+            let release: (v: any) => void = () => undefined
+            const client: any = { send: () => new Promise((resolve) => { release = resolve }) }
+            const store = new S3BlobStore({ client, bucket: 'b' })
+            const rs = store.createReadStream({key: 'k'})
+            let erred: any
+            rs.on('error', (e) => { erred = e })
+            rs.destroy() // consumer aborted (budget)
+            const {Readable} = require('stream')
+            const body = Readable.from([Buffer.from('late')])
+            const origDestroy = body.destroy.bind(body)
+            body.destroy = (...a: any[]) => { bodyDestroyed = true; return origDestroy(...a) }
+            release({Body: body})
+            await new Promise((r) => setTimeout(r, 20))
+            assert.equal(bodyDestroyed, true, 'the late body must be released')
+            assert.equal(erred, undefined, 'and nothing must be written into the destroyed stream')
+        })
+    })
+
     describe('abort signals', function() {
         it('forwards the signal to the SDK for exists, createReadStream and putBuffer', async function() {
             const calls: any[] = []

--- a/test/serve.ts
+++ b/test/serve.ts
@@ -36,6 +36,27 @@ describe('serve', function() {
         assert(crypto.timingSafeEqual(res.body, data), 'served data should match uploaded')
     })
 
+    it('answers 504 with no-store when the upload store stalls, instead of waiting or saying 404', async function() {
+        this.slow(3000)
+        this.timeout(10000)
+        const {uploadStore} = require('./../src/common')
+        const {PassThrough} = require('stream')
+        const realCreate = uploadStore.createReadStream
+        uploadStore.createReadStream = () => new PassThrough() // never ends
+        const t0 = Date.now()
+        try {
+            const res = await needle('get', `http://localhost:${port}/DQmStalledStoreHash/photo.jpg`)
+            const elapsed = Date.now() - t0
+            assert.equal(res.statusCode, 504)
+            assert.equal(res.headers['cache-control'], 'no-store, no-cache', 'a stall must not be cached like a 404 would be')
+            assert.equal(res.headers['etag'], undefined)
+            // serve allows three store budgets (900ms in the test config)
+            assert(elapsed >= 800 && elapsed < 4000, `expected ~900ms, got ${ elapsed }ms`)
+        } finally {
+            uploadStore.createReadStream = realCreate
+        }
+    })
+
     it('should detect correct MIME type', async function() {
         this.slow(1000)
         const file = path.resolve(__dirname, 'test.jpg')

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -24,6 +24,9 @@ import {
     isAnimatedSource,
     parseProxiedUrl,
     primaryPageOf,
+    readStream,
+    storeExists,
+    storeExistsBounded,
     parsePlainUrl,
     getOrigKeyFromUrl,
     sanitizeIgnoreInvalidateParams,
@@ -39,7 +42,9 @@ import {
     expandPurgeUrls,
 } from './../src/utils'
 
-import {AVIF_EFFORT, DEFAULT_AVATAR_HASH, DEFAULT_FALLBACK_IMAGE_URL, EDGE_FIRST_BYTE_TIMEOUT_MS, EMPTY_IMAGE_URL_PATTERNS, FETCH_CANDIDATE_WALL_MS, FETCH_DEADLINE_DEFAULT_MS, FETCH_DEADLINE_MS, FETCH_DEFAULT_WALL_MS, FETCH_MIN_REMAINING_MS, FETCH_RENDER_SLACK_MS, INTERNAL_SERVICE_ORIGINS, LEGACY_SERVICE_BASE_URL, SERVICE_BASE_URL, SPECIAL_EMPTY_IMAGE_PATH, applyUrlReplacements, isEmptyImageUrl, startsWithEmptyImagePrefix} from './../src/constants'
+import {PassThrough} from 'stream'
+
+import {AVIF_EFFORT, budgetSignal, DEFAULT_AVATAR_HASH, DEFAULT_FALLBACK_IMAGE_URL, EDGE_FIRST_BYTE_TIMEOUT_MS, EMPTY_IMAGE_URL_PATTERNS, FETCH_CANDIDATE_WALL_MS, FETCH_DEADLINE_DEFAULT_MS, FETCH_DEADLINE_MS, FETCH_DEFAULT_WALL_MS, FETCH_MIN_REMAINING_MS, FETCH_RENDER_SLACK_MS, INTERNAL_SERVICE_ORIGINS, LEGACY_SERVICE_BASE_URL, SERVE_READ_TIMEOUT_MS, SERVICE_BASE_URL, SPECIAL_EMPTY_IMAGE_PATH, STORE_OP_TIMEOUT_MS, applyUrlReplacements, isEmptyImageUrl, startsWithEmptyImagePrefix} from './../src/constants'
 
 import { APIError } from './../src/error'
 
@@ -332,6 +337,78 @@ describe('utils', function() {
             const buf = fs.readFileSync(path.resolve(__dirname, 'test.heic'))
             assert.equal((buildSharpPipeline(buf, false, 1) as any).options.input.page, 1)
             assert.equal((buildSharpPipeline(buf, false) as any).options.input.page, undefined)
+        })
+    })
+
+    describe('bounded store operations', function() {
+        const hangingStore: any = {
+            exists: () => undefined,           // never calls back
+            createReadStream: () => new PassThrough(), // never ends
+        }
+        const quiet = {warn: () => undefined, debug: () => undefined, info: () => undefined, error: () => undefined}
+
+        it('storeExists rejects with AbortError when the store never answers and the signal fires', async function() {
+            const t0 = Date.now()
+            await assert.rejects(storeExists(hangingStore, 'k', AbortSignal.timeout(50)), (err: any) => err.name === 'AbortError')
+            assert(Date.now() - t0 < 1000, 'must not wait for the store')
+        })
+
+        it('storeExists rejects at once on an already-aborted signal', async function() {
+            const c = new AbortController(); c.abort()
+            await assert.rejects(storeExists(hangingStore, 'k', c.signal), (err: any) => err.name === 'AbortError')
+        })
+
+        it('storeExists hands the key and the signal to the store', async function() {
+            let seen: any
+            const store: any = { exists: (opts: any, done: any) => { seen = opts; done(null, true) } }
+            const signal = AbortSignal.timeout(1000)
+            assert.equal(await storeExists(store, 'thekey', signal), true)
+            assert.equal(seen.key, 'thekey')
+            assert.equal(seen.signal, signal)
+            // and a plain string key when there is no signal, as every store already accepts
+            assert.equal(await storeExists(store, 'plain'), true)
+            assert.equal(seen, 'plain')
+        })
+
+        it('readStream rejects and destroys the stream when the signal fires', async function() {
+            const stream = new PassThrough()
+            let destroyed = false
+            stream.on('close', () => { destroyed = true })
+            await assert.rejects(readStream(stream, AbortSignal.timeout(50)), (err: any) => err.name === 'AbortError')
+            await new Promise((r) => setTimeout(r, 20))
+            assert.equal(destroyed, true, 'the stalled stream must be destroyed, not leaked')
+        })
+
+        it('readStream still resolves normally with a signal that never fires', async function() {
+            const stream = new PassThrough()
+            const p = readStream(stream, AbortSignal.timeout(5000))
+            stream.end(Buffer.from('bytes'))
+            assert.equal((await p).toString(), 'bytes')
+        })
+
+        it('storeExistsBounded treats a timeout and an error as absent', async function() {
+            assert.equal(await storeExistsBounded(hangingStore, 'k', AbortSignal.timeout(50), quiet, 'test'), false)
+            const failing: any = { exists: (_o: any, done: any) => done(new Error('boom')) }
+            assert.equal(await storeExistsBounded(failing, 'k', AbortSignal.timeout(1000), quiet, 'test'), false)
+            const present: any = { exists: (_o: any, done: any) => done(null, true) }
+            assert.equal(await storeExistsBounded(present, 'k', AbortSignal.timeout(1000), quiet, 'test'), true)
+        })
+
+        it('budgetSignal clamps to the remaining deadline, and to the cap, and never disables the timer', async function() {
+            const fired = (sig: AbortSignal) => new Promise<number>((resolve) => {
+                const t0 = Date.now(); sig.addEventListener('abort', () => resolve(Date.now() - t0), {once: true})
+            })
+            // deadline sooner than the cap
+            const a = await fired(budgetSignal(Date.now() + 80, 5000))
+            assert(a >= 60 && a < 600, `expected ~80ms, got ${ a }`)
+            // deadline already gone: aborts immediately rather than never
+            const b = await fired(budgetSignal(Date.now() - 1000, 5000))
+            assert(b < 200, `expected immediate abort, got ${ b }`)
+            // no deadline: the cap rules
+            const c = await fired(budgetSignal(undefined, 60))
+            assert(c >= 40 && c < 600, `expected ~60ms, got ${ c }`)
+            assert.equal(STORE_OP_TIMEOUT_MS, 300, 'test config sets the knob low')
+            assert.equal(SERVE_READ_TIMEOUT_MS, 900)
         })
     })
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -44,7 +44,7 @@ import {
 
 import {PassThrough} from 'stream'
 
-import {AVIF_EFFORT, budgetSignal, DEFAULT_AVATAR_HASH, DEFAULT_FALLBACK_IMAGE_URL, EDGE_FIRST_BYTE_TIMEOUT_MS, EMPTY_IMAGE_URL_PATTERNS, FETCH_CANDIDATE_WALL_MS, FETCH_DEADLINE_DEFAULT_MS, FETCH_DEADLINE_MS, FETCH_DEFAULT_WALL_MS, FETCH_MIN_REMAINING_MS, FETCH_RENDER_SLACK_MS, INTERNAL_SERVICE_ORIGINS, LEGACY_SERVICE_BASE_URL, SERVE_READ_TIMEOUT_MS, SERVICE_BASE_URL, SPECIAL_EMPTY_IMAGE_PATH, STORE_OP_TIMEOUT_MS, applyUrlReplacements, isEmptyImageUrl, startsWithEmptyImagePrefix} from './../src/constants'
+import {AVIF_EFFORT, budgetSignal, DEFAULT_AVATAR_HASH, DEFAULT_FALLBACK_IMAGE_URL, EDGE_FIRST_BYTE_TIMEOUT_MS, EMPTY_IMAGE_URL_PATTERNS, FETCH_CANDIDATE_WALL_MS, FETCH_DEADLINE_DEFAULT_MS, FETCH_DEADLINE_MS, FETCH_DEFAULT_WALL_MS, FETCH_MIN_REMAINING_MS, FETCH_RENDER_SLACK_MS, INTERNAL_SERVICE_ORIGINS, LEGACY_SERVICE_BASE_URL, S3_CONNECT_TIMEOUT_MS, S3_MAX_ATTEMPTS, S3_REQUEST_TIMEOUT_MS, S3_WORST_CASE_MS, SERVE_READ_TIMEOUT_MS, SERVICE_BASE_URL, SPECIAL_EMPTY_IMAGE_PATH, STORE_OP_TIMEOUT_MS, applyUrlReplacements, isEmptyImageUrl, startsWithEmptyImagePrefix} from './../src/constants'
 
 import { APIError } from './../src/error'
 
@@ -392,6 +392,22 @@ describe('utils', function() {
             assert.equal(await storeExistsBounded(failing, 'k', AbortSignal.timeout(1000), quiet, 'test'), false)
             const present: any = { exists: (_o: any, done: any) => done(null, true) }
             assert.equal(await storeExistsBounded(present, 'k', AbortSignal.timeout(1000), quiet, 'test'), true)
+        })
+
+        it('storeWrite rejects with AbortError when the store never finishes and the signal fires', async function() {
+            const hangingWriter: any = { createWriteStream: () => new PassThrough() } // done never called
+            const t0 = Date.now()
+            await assert.rejects(storeWrite(hangingWriter, 'k', Buffer.from('x'), AbortSignal.timeout(50)), (err: any) => err.name === 'AbortError')
+            assert(Date.now() - t0 < 1000)
+            const hangingPut: any = { putBuffer: () => new Promise(() => undefined) }
+            const c = new AbortController(); c.abort()
+            await assert.rejects(storeWrite(hangingPut, 'k', Buffer.from('x'), c.signal), (err: any) => err.name === 'AbortError')
+        })
+
+        it('keeps the client floors comfortably under the edge timeout', function() {
+            // every attempt connects and then stalls for the full request timeout
+            assert(S3_WORST_CASE_MS <= 16000, `worst case ${ S3_WORST_CASE_MS }ms must leave room for backoff under the 20s edge cut`)
+            assert.equal(S3_WORST_CASE_MS, S3_MAX_ATTEMPTS * (S3_CONNECT_TIMEOUT_MS + S3_REQUEST_TIMEOUT_MS))
         })
 
         it('budgetSignal clamps to the remaining deadline, and to the cap, and never disables the timer', async function() {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -39,6 +39,7 @@ import {
     redactUrlForLog,
     storeRemoveByPrefix,
     storeWrite,
+    streamHeadBounded,
     expandPurgeUrls,
 } from './../src/utils'
 
@@ -392,6 +393,45 @@ describe('utils', function() {
             assert.equal(await storeExistsBounded(failing, 'k', AbortSignal.timeout(1000), quiet, 'test'), false)
             const present: any = { exists: (_o: any, done: any) => done(null, true) }
             assert.equal(await storeExistsBounded(present, 'k', AbortSignal.timeout(1000), quiet, 'test'), true)
+        })
+
+        it('streamHeadBounded rejects on an input error instead of letting it escape', async function() {
+            // stream-head listens for errors only on its internal stream; an input that
+            // fails during the head read used to emit an unhandled error and kill the
+            // process (a simulated S3 GET failure exited Node with code 1)
+            const input = new PassThrough()
+            let escaped: any
+            const onUncaught = (err: any) => { escaped = err }
+            process.on('uncaughtException', onUncaught)
+            try {
+                const p = streamHeadBounded(input, 16384, AbortSignal.timeout(5000))
+                setTimeout(() => input.destroy(new Error('simulated S3 GET failure')), 10)
+                await assert.rejects(p, /simulated S3 GET failure/)
+                await new Promise((r) => setTimeout(r, 30))
+                assert.equal(escaped, undefined, 'the input error must be handled, not escape as uncaught')
+            } finally {
+                process.removeListener('uncaughtException', onUncaught)
+            }
+        })
+
+        it('streamHeadBounded forwards a later input error to the output stream it handed out', async function() {
+            const input = new PassThrough()
+            const p = streamHeadBounded(input, 4, AbortSignal.timeout(5000))
+            input.write(Buffer.from('12345678'))
+            const {head, stream} = await p
+            assert(head.toString().startsWith('1234'), 'stream-head returns whole chunks, at least the requested bytes')
+            const seen = new Promise<Error>((resolve) => stream.on('error', resolve))
+            input.destroy(new Error('late failure'))
+            assert.equal((await seen).message, 'late failure')
+        })
+
+        it('streamHeadBounded still resolves the head and passes the rest through', async function() {
+            const input = new PassThrough()
+            const p = streamHeadBounded(input, 3, AbortSignal.timeout(5000))
+            input.end(Buffer.from('abcdef'))
+            const {head, stream} = await p
+            assert(head.toString().startsWith('abc'))
+            assert.equal((await readStream(stream)).toString(), 'abcdef', 'the output carries the whole body, head included')
         })
 
         it('storeWrite rejects with AbortError when the store never finishes and the signal fires', async function() {


### PR DESCRIPTION
Closes #44. Stacked on #45 (both edit the proxy cache-hit block); retargets to main when #45 merges. Only the last two commits are this PR.

After 6af4189 the fetch deadline works (longest of 602 exhausted walks: 12.0 s) but every remaining 503 was still at exactly 20.0 s. A 503'd walk logged `attempted: 0`, meaning the budget was gone before the first mirror was tried, and the raw upload route, which only reads object storage, showed a 3.2 s p99 and a 20 s stall in one six-minute window. The shared `S3Client` had no enforcing timeout and the SDK's default retries, and every store call a handler makes before its fetch sat outside the deadline.

Three layers:

- **Client floors** (`common.ts`, `s3RequestHandlerOptions()` in `constants.ts`): 2 s connect, 5 s request with `throwOnRequestTimeout` (without it `requestTimeout` only logs) and the same `socketTimeout`, two attempts. `S3_WORST_CASE_MS` is pinned by a test under 16 s so backoff fits under the edge's 20 s. A test proves a connection that is accepted and never answered is cut off by the handler alone. No new dependency: the SDK builds its handler from the options object.
- **Signal-aware helpers** (`utils.ts`, `s3-store.ts`, `served-image.ts`): `storeExists`, `readStream`, `streamHeadBounded` and `storeWrite` take an `AbortSignal`, which the S3 store forwards to the SDK for HEAD, GET and PUT and which the helpers race themselves, so a store that ignores it still cannot hold the caller. `storeExistsBounded` treats a timeout or error as "absent".
- **Call sites**: proxy, avatar and cover create `storeSignal()` before their first store call and apply it to every store operation on the request path: the rendered-variant lookup and the head read of a hit (a stall reads as a miss), the original, rescue and retention lookups, the read of a stored original, and the writes awaited before the response. Each signal is `budgetSignal(fetchDeadlineAt, STORE_OP_TIMEOUT_MS)`: the smaller of the per-call cap and what is left of the fetch deadline, never less than 1 ms. The serve route has no fetch to fall through to, so it allows three budgets and answers `504` (new `StoreTimeout`; 504 rather than 502 because the store did not answer, it did not answer wrongly) with `no-store`, instead of a 404 that caches or a wait until Varnish's 20 s.

`store_op_timeout_ms` is configurable (default 5 s; the test config sets 300 ms), sized against the measured tail: healthy same-datacentre calls are tens of milliseconds, the observed p99 3.2 s.

Tests: the helpers (abort while the store never answers, already-aborted signal, key and signal handed to the store, stream destroyed on abort, normal completion with a live signal, bounded lookup treating timeout and error as absent, write aborted on a hung stream and a hung PutObject), `budgetSignal` clamping and immediate abort on a spent budget, the S3 store forwarding the signal for HEAD, GET and PUT and passing nothing without one, the handler options cutting off a stalled endpoint, the retry envelope bound, a proxy request whose upload-store HEAD never answers completing on the fetch path within one budget, proxy and avatar requests whose first variant lookup never answers completing within two budgets, and the serve route answering 504 no-store in about three budgets when its read stalls. Each was checked to fail with its guard removed.