### PR TITLE
Judge an animated render by how it plays, not by its frame count

### DIFF
--- a/src/animated.ts
+++ b/src/animated.ts
@@ -70,7 +70,11 @@ export function countWebpFrames(buffer: Buffer): number {
 export interface AnimationFacts {
     frames: number
     durationMs: number
-    /** Times to play the animation; 0 is forever in both containers. */
+    /**
+     * Times the animation PLAYS, 0 being forever. Normalised, because the two
+     * containers count differently: a GIF's NETSCAPE2.0 block stores repeats
+     * after the first play, a WebP's ANIM chunk stores total plays.
+     */
     loop: number
 }
 
@@ -110,7 +114,13 @@ export function readGifAnimation(buffer: Buffer): AnimationFacts {
                 pending = buffer.readUInt16LE(p + 4)
             } else if (label === 0xff && buffer.toString('ascii', p + 3, p + 14) === 'NETSCAPE2.0' &&
                        p + 19 < buffer.length && buffer[p + 14] === 0x03 && buffer[p + 15] === 0x01) {
-                facts.loop = buffer.readUInt16LE(p + 16)
+                // GIF counts REPEATS AFTER the first play; WebP's ANIM counts total
+                // plays. Normalising here is what lets the two be compared at all:
+                // libvips reads a GIF's stored 3 as 4 and writes ANIM 4, so an
+                // unnormalised reader rejects every correct render of a
+                // finite-loop GIF. 0 means forever in both and stays 0.
+                const stored = buffer.readUInt16LE(p + 16)
+                facts.loop = stored === 0 ? 0 : stored + 1
             }
             p += 2
             skipSubBlocks()
@@ -142,21 +152,31 @@ export function readWebpAnimation(buffer: Buffer): AnimationFacts {
     if (buffer.length < 16 ||
         buffer.toString('ascii', 0, 4) !== 'RIFF' ||
         buffer.toString('ascii', 8, 12) !== 'WEBP') { return facts }
+    // The walk stops where the RIFF header says the file does, not where the
+    // buffer does. Bytes appended past that endpoint are not chunks, and reading
+    // them as chunks would let anything chunk-shaped rewrite the frame count or
+    // the loop of a container that never declared it.
+    const declared = buffer.readUInt32LE(4) + 8
+    const end = Math.min(declared, buffer.length)
     let p = 12
     let isAnimation = false
-    while (p + 8 <= buffer.length) {
+    while (p + 8 <= end) {
         const tag = buffer.toString('ascii', p, p + 4)
         const size = buffer.readUInt32LE(p + 4)
-        if (tag === 'ANIM' && p + 14 <= buffer.length) {
+        const payload = p + 8
+        // A chunk whose declared payload runs past the container is malformed;
+        // there is nothing after it worth reading either.
+        if (payload + size > end) { break }
+        if (tag === 'ANIM' && size >= 6) {
             isAnimation = true
-            facts.loop = buffer.readUInt16LE(p + 12)   // after a 4-byte background colour
+            facts.loop = buffer.readUInt16LE(payload + 4)   // after a 4-byte background colour
         }
-        if (tag === 'ANMF' && p + 24 <= buffer.length) {
+        if (tag === 'ANMF' && size >= 16) {
             facts.frames++
             // 3+3 byte offset, 3+3 byte size, then a 24-bit little-endian duration
-            facts.durationMs += buffer.readUIntLE(p + 20, 3)
+            facts.durationMs += buffer.readUIntLE(payload + 12, 3)
         }
-        p += 8 + size + (size % 2)              // chunks are padded to even length
+        p = payload + size + (size % 2)         // chunks are padded to even length
     }
     return isAnimation ? facts : {frames: 0, durationMs: 0, loop: 1}
 }

--- a/src/animated.ts
+++ b/src/animated.ts
@@ -18,13 +18,19 @@
  *    cannot: handed a multi-page pipeline they write the frames as one tall
  *    "filmstrip" still. An animated source is therefore only ever encoded to
  *    animated WebP (for a client that takes WebP) or back to GIF.
- *  - The bytes we are about to serve must carry the same number of frames as the
- *    source, counted off the output container itself, and must be smaller than
- *    the source. Either check failing hands the original bytes back.
+ *  - The bytes we are about to serve must still PLAY as the source did, read off
+ *    the output container itself, and must be smaller than the source. Either
+ *    check failing hands the original bytes back.
  *
- * The frame count is read from the container rather than from a second libvips
- * decode on purpose: the thing being guarded against is libvips dropping frames,
- * so asking libvips whether it dropped any is not an independent answer.
+ * "Plays as the source did" is not "has as many frames as the source". libwebp
+ * merges consecutive identical frames and adds their delays together, so a
+ * correct re-encode of a GIF that holds a pose comes back with fewer frames and
+ * the same running time (150 -> 35 on the GIF that started this work). The test
+ * is therefore: still an animation, same total duration, same loop count.
+ *
+ * All of that is read from the container rather than from a second libvips
+ * decode on purpose: the thing being guarded against is libvips losing an
+ * animation, so asking libvips whether it lost one is not an independent answer.
  */
 
 import Sharp from 'sharp'
@@ -39,13 +45,52 @@ export type AnimatedOutputType = 'image/webp' | 'image/gif'
 /**
  * Frames declared by a GIF's own container: one per image descriptor.
  *
- * The walk skips extension blocks and each frame's LZW sub-blocks by their
- * length bytes, so it costs a handful of jumps per frame, not a decode. Anything
- * it cannot follow ends the walk and reports what it counted so far, which
- * fails the equality check at the call site rather than passing on a guess.
+ * Reads the same walk as readGifAnimation, so the two can never disagree about
+ * what a container holds.
  */
 export function countGifFrames(buffer: Buffer): number {
-    if (buffer.length < 13 || buffer.toString('ascii', 0, 3) !== 'GIF') { return 0 }
+    return readGifAnimation(buffer).frames
+}
+
+/**
+ * Frames declared by a WebP's own RIFF container: one per ANMF chunk, and only
+ * when the ANIM chunk that makes the file an animation is present.
+ */
+export function countWebpFrames(buffer: Buffer): number {
+    return readWebpAnimation(buffer).frames
+}
+/**
+ * What a container says about its own animation.
+ *
+ * `durationMs` is PLAYBACK time, not the sum of the delays a container stores.
+ * A GIF frame that declares less than 20ms plays at 100ms: browsers have clamped
+ * it that way for decades, and libwebp writes that same 100ms when it re-encodes
+ * one. Comparing raw stored delays would call that correct re-encode a mismatch.
+ */
+export interface AnimationFacts {
+    frames: number
+    durationMs: number
+    /** Times to play the animation; 0 is forever in both containers. */
+    loop: number
+}
+
+/** A stored GIF delay, in hundredths of a second, as the frame actually plays. */
+function gifDelayMs(hundredths: number): number {
+    const ms = hundredths * 10
+    return ms < 20 ? 100 : ms
+}
+
+/**
+ * Frames, playback duration and loop count declared by a GIF's own container.
+ *
+ * The walk skips extension blocks and each frame's LZW sub-blocks by their
+ * length bytes, so it costs a handful of jumps per frame, not a decode. Anything
+ * it cannot follow ends the walk and reports what it read so far, which fails
+ * the check at the call site rather than passing on a guess.
+ */
+export function readGifAnimation(buffer: Buffer): AnimationFacts {
+    const facts: AnimationFacts = {frames: 0, durationMs: 0, loop: 1}
+    if (buffer.length < 13 || buffer.toString('ascii', 0, 3) !== 'GIF') { return facts }
     const packed = buffer[10]
     let p = 13
     // Global colour table, when the screen descriptor says there is one
@@ -54,17 +99,27 @@ export function countGifFrames(buffer: Buffer): number {
         while (p < buffer.length && buffer[p] !== 0) { p += buffer[p] + 1 }
         p++
     }
-    let frames = 0
+    // The delay a Graphic Control Extension sets for the frame that follows it.
+    let pending = 0
     while (p < buffer.length) {
         const block = buffer[p]
         if (block === 0x3b) { break }           // trailer
         if (block === 0x21) {                   // extension: label + sub-blocks
+            const label = buffer[p + 1]
+            if (label === 0xf9 && p + 7 < buffer.length) {
+                pending = buffer.readUInt16LE(p + 4)
+            } else if (label === 0xff && buffer.toString('ascii', p + 3, p + 14) === 'NETSCAPE2.0' &&
+                       p + 19 < buffer.length && buffer[p + 14] === 0x03 && buffer[p + 15] === 0x01) {
+                facts.loop = buffer.readUInt16LE(p + 16)
+            }
             p += 2
             skipSubBlocks()
             continue
         }
         if (block === 0x2c) {                   // image descriptor: one frame
-            frames++
+            facts.frames++
+            facts.durationMs += gifDelayMs(pending)
+            pending = 0
             const localPacked = buffer[p + 9]
             p += 10
             if (localPacked & 0x80) { p += 3 * (1 << ((localPacked & 0x07) + 1)) }
@@ -74,37 +129,78 @@ export function countGifFrames(buffer: Buffer): number {
         }
         break                                   // not a block boundary any more
     }
-    return frames
+    return facts
 }
 
 /**
- * Frames declared by a WebP's own RIFF container: one per ANMF chunk, and only
- * when the ANIM chunk that makes the file an animation is present.
+ * Frames, playback duration and loop count declared by a WebP's own RIFF
+ * container: one ANMF chunk per frame, carrying its own duration, and the ANIM
+ * chunk that makes the file an animation at all.
  */
-export function countWebpFrames(buffer: Buffer): number {
+export function readWebpAnimation(buffer: Buffer): AnimationFacts {
+    const facts: AnimationFacts = {frames: 0, durationMs: 0, loop: 1}
     if (buffer.length < 16 ||
         buffer.toString('ascii', 0, 4) !== 'RIFF' ||
-        buffer.toString('ascii', 8, 12) !== 'WEBP') { return 0 }
+        buffer.toString('ascii', 8, 12) !== 'WEBP') { return facts }
     let p = 12
-    let frames = 0
     let isAnimation = false
     while (p + 8 <= buffer.length) {
         const tag = buffer.toString('ascii', p, p + 4)
         const size = buffer.readUInt32LE(p + 4)
-        if (tag === 'ANIM') { isAnimation = true }
-        if (tag === 'ANMF') { frames++ }
+        if (tag === 'ANIM' && p + 14 <= buffer.length) {
+            isAnimation = true
+            facts.loop = buffer.readUInt16LE(p + 12)   // after a 4-byte background colour
+        }
+        if (tag === 'ANMF' && p + 24 <= buffer.length) {
+            facts.frames++
+            // 3+3 byte offset, 3+3 byte size, then a 24-bit little-endian duration
+            facts.durationMs += buffer.readUIntLE(p + 20, 3)
+        }
         p += 8 + size + (size % 2)              // chunks are padded to even length
     }
-    return isAnimation ? frames : 0
+    return isAnimation ? facts : {frames: 0, durationMs: 0, loop: 1}
 }
 
-/** Frames the given bytes declare, for the output types we encode animations to. */
-export function countAnimationFrames(buffer: Buffer, contentType: string): number {
+/** What the given bytes declare, for the containers this file reads and writes. */
+export function readAnimation(buffer: Buffer, contentType: string): AnimationFacts {
     switch (contentType) {
-        case 'image/gif': return countGifFrames(buffer)
-        case 'image/webp': return countWebpFrames(buffer)
-        default: return 0
+        case 'image/gif': return readGifAnimation(buffer)
+        case 'image/webp': return readWebpAnimation(buffer)
+        default: return {frames: 0, durationMs: 0, loop: 1}
     }
+}
+
+/** The container a Sharp `metadata.format` names, for the two we can read. */
+function sourceContainerType(format?: string): string {
+    return format === 'gif' ? 'image/gif' : format === 'webp' ? 'image/webp' : ''
+}
+
+/**
+ * Why the rendered bytes are not the source's animation, or undefined when they
+ * are.
+ *
+ * Frame count is deliberately NOT the test. libwebp merges consecutive identical
+ * frames and adds their delays together, so a correct re-encode of a GIF that
+ * holds a pose routinely comes back with far fewer frames than it went in with
+ * (measured in production: 150 -> 35, and 167 -> 91, both playing identically).
+ * Judging those by count threw the whole render away and served multi-MB sources
+ * instead. What has to survive is the animation as it plays: still animated,
+ * same total running time, same loop count.
+ *
+ * A source container this file cannot read leaves nothing to compare against, so
+ * that case keeps the old exact-count check rather than trusting the render.
+ */
+function animationLost(source: AnimationFacts, rendered: AnimationFacts, planned: number):
+        'de-animated' | 'duration' | 'loop' | 'frames' | undefined {
+    // Whatever else changed, bytes that are no longer an animation are the
+    // failure this path exists to catch: a still where a moving image belongs.
+    if (rendered.frames < 2) { return 'de-animated' }
+    if (source.frames < 1) {
+        return rendered.frames === planned ? undefined : 'frames'
+    }
+    if (rendered.durationMs !== source.durationMs) { return 'duration' }
+    if (rendered.loop !== source.loop) { return 'loop' }
+    return undefined
 }
 
 /**
@@ -177,7 +273,14 @@ export async function renderAnimatedVariant(input: {
     acceptHeader: string,
     encode: (image: Sharp.Sharp) => Promise<Buffer>,
     log: any,
-    onFramesDropped?: (info: {expected: number, got: number, outputType: AnimatedOutputType}) => void
+    onFramesDropped?: (info: {
+        reason: string,
+        expected: number,
+        got: number,
+        expectedDurationMs?: number,
+        gotDurationMs: number,
+        outputType: AnimatedOutputType,
+    }) => void
     /**
      * The encoder threw. Distinct from every other `undefined` this returns: those
      * are deliberate passthroughs whose result is worth caching, while this one may
@@ -212,15 +315,22 @@ export async function renderAnimatedVariant(input: {
         return undefined
     }
 
-    const frames = countAnimationFrames(buffer, plan.outputType)
-    if (frames !== plan.frames) {
+    const rendered = readAnimation(buffer, plan.outputType)
+    const source = readAnimation(input.bytes, sourceContainerType(input.metadata.format))
+    const reason = animationLost(source, rendered, plan.frames)
+    if (reason) {
         // The one outcome this whole path exists to prevent. Serve the source and
         // tell someone: it means this libvips no longer round-trips animation.
-        input.log.error({expected: plan.frames, got: frames, outputType: plan.outputType},
-            'animated render lost frames, serving source untouched')
-        if (input.onFramesDropped) {
-            input.onFramesDropped({expected: plan.frames, got: frames, outputType: plan.outputType})
+        const info = {
+            reason,
+            expected: plan.frames,
+            got: rendered.frames,
+            expectedDurationMs: source.frames > 0 ? source.durationMs : undefined,
+            gotDurationMs: rendered.durationMs,
+            outputType: plan.outputType,
         }
+        input.log.error(info, 'animated render lost the animation, serving source untouched')
+        if (input.onFramesDropped) { input.onFramesDropped(info) }
         return undefined
     }
 

--- a/test/animated-gif-fixture.ts
+++ b/test/animated-gif-fixture.ts
@@ -82,6 +82,15 @@ export interface AnimatedGifOptions {
      * which is what a gifsicle-optimised GIF from a post body looks like.
      */
     localPalette?: boolean
+    /**
+     * Repeat each drawn pose this many times, so the GIF holds still between
+     * moves. Real animations do this constantly (a talking head between words, a
+     * loop that pauses on its punchline) and it is what makes an encoder merge
+     * frames: libwebp writes one frame carrying the whole held delay.
+     */
+    hold?: number
+    /** Times to play the animation, as the NETSCAPE2.0 block stores it; 0 is forever. */
+    loop?: number
 }
 
 export function makeAnimatedGif(options: AnimatedGifOptions = {}): Buffer {
@@ -91,6 +100,8 @@ export function makeAnimatedGif(options: AnimatedGifOptions = {}): Buffer {
     const delay = options.delay ?? 10
     const noisy = options.noisy ?? true
     const localPalette = options.localPalette ?? false
+    const hold = Math.max(1, options.hold ?? 1)
+    const loop = options.loop ?? 0
 
     const palette = Buffer.alloc(256 * 3)
     for (let i = 0; i < 256; i++) {
@@ -107,25 +118,29 @@ export function makeAnimatedGif(options: AnimatedGifOptions = {}): Buffer {
     screen[4] = 0x80 | (7 << 4) | 7  // global colour table, 8-bit colour, 256 entries
     parts.push(screen, palette)
 
-    // NETSCAPE2.0 application extension: loop forever
-    parts.push(Buffer.from([0x21, 0xff, 0x0b]), Buffer.from('NETSCAPE2.0', 'ascii'),
-               Buffer.from([0x03, 0x01, 0x00, 0x00, 0x00]))
+    // NETSCAPE2.0 application extension: how many times to play, 0 being forever
+    const netscape = Buffer.from([0x03, 0x01, 0x00, 0x00, 0x00])
+    netscape.writeUInt16LE(loop, 2)
+    parts.push(Buffer.from([0x21, 0xff, 0x0b]), Buffer.from('NETSCAPE2.0', 'ascii'), netscape)
 
+    const poses = Math.ceil(frames / hold)
     for (let f = 0; f < frames; f++) {
+        // Frames within one hold are drawn identically, byte for byte.
+        const pose = Math.floor(f / hold)
         const pixels = Buffer.alloc(width * height)
         for (let y = 0; y < height; y++) {
             const row = y * width
             if (noisy) {
                 for (let x = 0; x < width; x++) {
-                    pixels[row + x] = (((x * 7919 + y * 104729 + f * 15485863) ^ (x * y)) >>> 3) & 0xff
+                    pixels[row + x] = (((x * 7919 + y * 104729 + pose * 15485863) ^ (x * y)) >>> 3) & 0xff
                 }
             } else {
                 pixels.fill(((y >> 4) * 16) & 0xff, row, row + width)
             }
         }
-        // A block that moves between frames, so the frames differ from each other
+        // A block that moves between poses, so the poses differ from each other
         const blockSize = Math.max(4, Math.floor(Math.min(width, height) / 5))
-        const left = Math.floor((f / frames) * (width - blockSize))
+        const left = Math.floor((pose / poses) * (width - blockSize))
         const top = Math.floor(height / 3)
         for (let y = top; y < Math.min(top + blockSize, height); y++) {
             pixels.fill(200, y * width + left, y * width + left + blockSize)

--- a/test/animated.ts
+++ b/test/animated.ts
@@ -182,9 +182,48 @@ describe('animated sources', function() {
             assert.deepEqual(readGifAnimation(gif), {frames: 5, durationMs: 600, loop: 0})
         })
 
-        it('reads a finite loop count', function() {
+        // A GIF's NETSCAPE2.0 block stores REPEATS AFTER the first play; a WebP's
+        // ANIM chunk stores TOTAL plays. libvips does that conversion when it
+        // transcodes, so a reader that returned the stored 3 here would compare
+        // it against the WebP's 4 and reject every correct render of a
+        // finite-loop GIF. Both readers report plays.
+        it('reads a finite loop count as the number of plays', function() {
             const gif = makeAnimatedGif({frames: 4, delay: 10, noisy: false, loop: 3})
-            assert.equal(readGifAnimation(gif).loop, 3)
+            assert.equal(readGifAnimation(gif).loop, 4)
+        })
+
+        it('agrees with the WebP a finite-loop GIF transcodes into', async function() {
+            this.timeout(20000)
+            const gif = makeAnimatedGif({width: 120, height: 90, frames: 5, delay: 10, noisy: true, loop: 3})
+            const webp = await sharp(gif, {animated: true}).resize(60)
+                .webp({quality: 80, force: true}).toBuffer()
+            assert.equal(readWebpAnimation(webp).loop, readGifAnimation(gif).loop)
+        })
+
+        // Bytes past the endpoint the RIFF header declares are not chunks. Reading
+        // them as chunks would let anything chunk-shaped rewrite the frame count
+        // or the loop, and reject a render that is perfectly good.
+        it('stops where the RIFF header says the file ends', async function() {
+            this.timeout(20000)
+            const gif = makeAnimatedGif({width: 120, height: 90, frames: 6, delay: 10, noisy: true})
+            const webp = await sharp(gif, {animated: true}).resize(60)
+                .webp({quality: 80, force: true}).toBuffer()
+            const clean = readWebpAnimation(webp)
+            assert.equal(clean.frames, 6)
+
+            // An ANIM chunk claiming a loop of 9, and an extra frame, appended
+            // after the container's own end.
+            const anim = Buffer.alloc(8 + 6)
+            anim.write('ANIM', 0, 'ascii')
+            anim.writeUInt32LE(6, 4)
+            anim.writeUInt16LE(9, 8 + 4)
+            const anmf = Buffer.alloc(8 + 16)
+            anmf.write('ANMF', 0, 'ascii')
+            anmf.writeUInt32LE(16, 4)
+            anmf.writeUIntLE(5000, 8 + 12, 3)
+
+            const trailing = Buffer.concat([webp, anim, anmf])
+            assert.deepEqual(readWebpAnimation(trailing), clean)
         })
 
         // A GIF that asks for 0 or 1 hundredths does not play that fast anywhere:

--- a/test/animated.ts
+++ b/test/animated.ts
@@ -6,7 +6,8 @@ import sharp from 'sharp'
 
 import {app} from './../src/app'
 import {
-    animatedOutputType, animatedRenderPlan, countGifFrames, countWebpFrames, renderAnimatedVariant,
+    animatedOutputType, animatedRenderPlan, countGifFrames, countWebpFrames, readAnimation,
+    readGifAnimation, readWebpAnimation, renderAnimatedVariant,
 } from './../src/animated'
 import {ANIMATED_PASSTHROUGH_MAX_SIZE} from './../src/constants'
 import {base58Enc, OutputFormat, ProxyOptions, ScalingMode} from './../src/utils'
@@ -168,6 +169,57 @@ describe('animated sources', function() {
         })
     })
 
+    /**
+     * The guard's real subject. What has to survive a re-encode is the animation
+     * AS IT PLAYS, and libwebp reaches that by merging consecutive identical
+     * frames and adding their delays together. Counting frames called those
+     * correct renders failures and served multi-MB sources instead of them.
+     */
+    describe('reading an animation off its own container', function() {
+
+        it('reads frames, running time and loop count from a GIF', function() {
+            const gif = makeAnimatedGif({frames: 5, delay: 12, noisy: false, loop: 0})
+            assert.deepEqual(readGifAnimation(gif), {frames: 5, durationMs: 600, loop: 0})
+        })
+
+        it('reads a finite loop count', function() {
+            const gif = makeAnimatedGif({frames: 4, delay: 10, noisy: false, loop: 3})
+            assert.equal(readGifAnimation(gif).loop, 3)
+        })
+
+        // A GIF that asks for 0 or 1 hundredths does not play that fast anywhere:
+        // browsers have clamped anything under 20ms to 100ms for decades, and
+        // libwebp writes that same 100ms when it re-encodes one. Reading the
+        // stored value instead would call a correct re-encode a mismatch.
+        it('reads a sub-20ms frame as the 100ms it actually plays at', function() {
+            for (const delay of [0, 1]) {
+                const gif = makeAnimatedGif({frames: 5, delay, noisy: false})
+                assert.equal(readGifAnimation(gif).durationMs, 500, `delay ${delay}`)
+            }
+            // 2 hundredths is exactly at the boundary and is left alone
+            assert.equal(readGifAnimation(makeAnimatedGif({frames: 5, delay: 2, noisy: false})).durationMs, 100)
+        })
+
+        it('reads them back off a WebP the encoder wrote', async function() {
+            this.timeout(20000)
+            const gif = makeAnimatedGif({width: 120, height: 90, frames: 6, delay: 10, noisy: true})
+            const webp = await sharp(gif, {animated: true}).resize(60).webp({quality: 80, force: true}).toBuffer()
+            const facts = readWebpAnimation(webp)
+            assert.equal(facts.frames, 6)
+            assert.equal(facts.durationMs, readGifAnimation(gif).durationMs)
+            assert.equal(facts.loop, 0)
+        })
+
+        it('reports a still as no animation at all', async function() {
+            this.timeout(20000)
+            const still = await sharp({create: {width: 20, height: 20, channels: 3,
+                background: {r: 1, g: 2, b: 3}}}).webp().toBuffer()
+            assert.equal(readWebpAnimation(still).frames, 0)
+            assert.equal(readAnimation(Buffer.from('not an image'), 'image/gif').frames, 0)
+            assert.equal(readAnimation(still, 'image/jpeg').frames, 0)
+        })
+    })
+
     describe('rendering keeps the animation', function() {
         const encode = (image: sharp.Sharp) => image.toBuffer()
 
@@ -221,6 +273,70 @@ describe('animated sources', function() {
             assert.equal(rendered.loop, metadata.loop)
         })
 
+        /**
+         * The regression this guard change exists for. A GIF that holds a pose
+         * comes back from libwebp with fewer, longer frames: the same animation,
+         * fewer container entries. Counting frames threw these away and served
+         * the source, which on the GIF that started this work meant 1.5MB instead
+         * of 169KB.
+         */
+        it('accepts a render whose frames were merged, as long as it still plays the same', async function() {
+            this.timeout(20000)
+            const held = makeAnimatedGif({width: 200, height: 150, frames: 32, hold: 4, delay: 10, noisy: true})
+            const source = readGifAnimation(held)
+            const metadata = await sharp(held).metadata()
+            const out = await renderAnimatedVariant({
+                bytes: held, metadata, options: negotiatedWebp({width: 100}),
+                acceptHeader: WEBP_ACCEPT, encode, log: console,
+            })
+            assert.ok(out, 'expected a render, got a passthrough')
+            const facts = readWebpAnimation(out!.buffer)
+            // The merge really happened, so this is not a vacuous pass...
+            assert.ok(facts.frames < source.frames,
+                `expected fewer than ${source.frames} frames, got ${facts.frames}`)
+            // ...and what matters survived it.
+            assert.ok(facts.frames >= 2, 'still an animation')
+            assert.equal(facts.durationMs, source.durationMs)
+            assert.equal(facts.loop, source.loop)
+            assert.ok(out!.buffer.length < held.length / 2)
+        })
+
+        it('hands the source back when the render would play for a different length of time', async function() {
+            this.timeout(20000)
+            const metadata = await sharp(bigGif).metadata()
+            // A real animated WebP of the right shape, and the wrong duration:
+            // same eight frames, each declaring five times the delay.
+            const slower = makeAnimatedGif({width: 200, height: 150, frames: 8, delay: 50, noisy: true})
+            const dropped: any[] = []
+            const out = await renderAnimatedVariant({
+                bytes: bigGif, metadata, options: negotiatedWebp({width: 100}), acceptHeader: WEBP_ACCEPT,
+                encode: () => sharp(slower, {animated: true}).resize(100)
+                    .webp({quality: 80, force: true}).toBuffer(),
+                log: {warn: () => undefined, error: () => undefined, debug: () => undefined},
+                onFramesDropped: (info) => dropped.push(info),
+            })
+            assert.equal(out, undefined)
+            assert.equal(dropped[0].reason, 'duration')
+            assert.equal(dropped[0].expectedDurationMs, readGifAnimation(bigGif).durationMs)
+        })
+
+        it('hands the source back when the render would stop looping', async function() {
+            this.timeout(20000)
+            const metadata = await sharp(bigGif).metadata()
+            const once = makeAnimatedGif({width: 200, height: 150, frames: 8, delay: 10, noisy: true, loop: 1})
+            const dropped: any[] = []
+            const out = await renderAnimatedVariant({
+                bytes: bigGif, metadata, options: negotiatedWebp({width: 100}), acceptHeader: WEBP_ACCEPT,
+                // Same frames, same running time, plays through once instead of forever.
+                encode: () => sharp(once, {animated: true}).resize(100)
+                    .webp({quality: 80, force: true, loop: 1}).toBuffer(),
+                log: {warn: () => undefined, error: () => undefined, debug: () => undefined},
+                onFramesDropped: (info) => dropped.push(info),
+            })
+            assert.equal(out, undefined)
+            assert.equal(dropped[0].reason, 'loop')
+        })
+
         it('hands the source back when the render would not be smaller', async function() {
             this.timeout(20000)
             const metadata = await sharp(bigGif).metadata()
@@ -247,7 +363,10 @@ describe('animated sources', function() {
                 onFramesDropped: (info) => dropped.push(info),
             })
             assert.equal(out, undefined)
-            assert.deepEqual(dropped, [{expected: 8, got: 0, outputType: 'image/webp'}])
+            assert.equal(dropped.length, 1)
+            assert.equal(dropped[0].reason, 'de-animated')
+            assert.equal(dropped[0].got, 0)
+            assert.equal(dropped[0].outputType, 'image/webp')
         })
 
         it('hands the source back when Sharp cannot render it', async function() {


### PR DESCRIPTION
Closes #48.

The animated render guard compared frame counts, and served the source whenever the render came back with a different number. libwebp merges consecutive identical frames and adds their delays together, so a correct re-encode of any GIF that holds a pose has fewer frames than its source. Every one of those renders was discarded.

Measured on live sources, all rejected before this change, all playing identically to their source:

| source | frames | duration | bytes |
|---|---|---|---|
| the GIF behind ecency/vision-web#1802 | 150 -> 35 | 5000 -> 5000 ms | 1,572,008 -> 169,154 |
| media.giphy.com/media/3o7bubN2mBtGd5wgBq | 167 -> 91 | 6680 -> 6680 ms | 478,870 -> 125,512 |
| cdn.steemitimages.com/DQmPjozVq... | 367 -> 363 | 11010 -> 11010 ms | 6,081,332 -> 1,587,078 |
| files.peakd.com/.../tattoodjay.gif | 175 -> 153 | 7000 -> 7000 ms | 3,455,261 -> 813,550 |

The guard fired 12 times in 25 minutes of production traffic, four of those losing between one and four frames out of hundreds.

## What changed

The comparison is now the animation as it plays: still an animation, same total running time, same loop count. A render that genuinely drops frames changes the running time, so it still fails, and a render that produces a still is caught by its own branch.

Reading stays at the container level. That was the point of the original design and it still holds: asking libvips whether libvips lost an animation is not an independent answer. `readGifAnimation` and `readWebpAnimation` walk the same block and chunk structures the frame counters already walked, and the counters now delegate to them so the two cannot drift apart.

Duration means playback time, not the sum of stored delays. A GIF frame declaring under 20ms plays at 100ms in every browser, and libwebp writes that same 100ms when it re-encodes one, so a raw comparison would call a correct render a mismatch. Verified against libvips: it reads 0 and 1 hundredths literally, the WebP encoder clamps both to 100ms.

## Verification

The readers were checked against seven real animated GIFs before anything was wired up. In all seven the duration they read off the GIF container matched libvips' own delay sum exactly, and matched the duration read back off the rendered WebP.

The fixture gained a `hold` option, so a test source can hold a pose the way real animations do, and a `loop` option. The merge case is exercised through the real encoder rather than a stub: 32 frames in, 24 out, 3200ms both ways.

Reverting the guard to the old frame-count comparison fails the two new behaviour tests, so they are not vacuous.

`36 passing` in `test/animated.ts`; full suite `412 passing, 3 failing`, and those three fail identically on a clean `main` checkout (`internal service URL helpers`, which needs public hosts this local config does not set).

## Note on ordering

ecency/imagehoster#49 depends on this. Raising the pixel budget without this change lets the large GIFs reach the encoder and then rejects their renders on frame count, so it would deliver nothing on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved animated image rendering validation by checking playback duration and looping behavior, not just frame counts.
  - Prevents rendered GIF and WebP variants from replacing the source when animation timing or looping would change.
  - Allows optimized outputs with merged frames when their playback remains equivalent to the original animation.
  - Improved reporting when animation is lost or playback behavior differs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->