### PR TITLE
Give animated sources their own pixel budget

### DIFF
--- a/src/animated.ts
+++ b/src/animated.ts
@@ -35,7 +35,7 @@
 
 import Sharp from 'sharp'
 
-import {ANIMATED_PASSTHROUGH_MAX_SIZE, MAX_INPUT_PIXELS} from './constants'
+import {ANIMATED_PASSTHROUGH_MAX_SIZE, MAX_ANIMATED_INPUT_PIXELS, MAX_INPUT_PIXELS} from './constants'
 import {isEncodeAborted} from './encode-limit'
 import {applyProxyResize, buildSharpPipeline, OutputFormat, ProxyOptions, supportsWebP} from './utils'
 
@@ -270,10 +270,14 @@ export function animatedRenderPlan(input: {
     // Not worth the encode. A sticker is already small and a re-encode of one
     // saves a few KB at the price of a full multi-frame decode.
     if (input.byteLength <= ANIMATED_PASSTHROUGH_MAX_SIZE) { return undefined }
-    // An animated decode is the whole "toilet roll" of frames at once, so the
-    // pixel budget applies to every frame together. Past it there is no safe
-    // render, and the passthrough is what the request already got yesterday.
-    if (pages * width * height > MAX_INPUT_PIXELS) { return undefined }
+    // Each FRAME still answers to the still-image budget: one enormous frame is
+    // the decompression bomb that budget was written for, animated or not.
+    if (width * height > MAX_INPUT_PIXELS) { return undefined }
+    // The frames together answer to their own, much larger budget. libvips
+    // streams an animated pipeline rather than holding every frame at once, so
+    // adding frames costs time, not memory, and the time is already bounded by
+    // the encode slot gate and the abort signal. See MAX_ANIMATED_INPUT_PIXELS.
+    if (pages * width * height > MAX_ANIMATED_INPUT_PIXELS) { return undefined }
     return {frames: pages, outputType: animatedOutputType(input.options)}
 }
 

--- a/src/animated.ts
+++ b/src/animated.ts
@@ -275,8 +275,8 @@ export function animatedRenderPlan(input: {
     if (width * height > MAX_INPUT_PIXELS) { return undefined }
     // The frames together answer to their own, much larger budget. libvips
     // streams an animated pipeline rather than holding every frame at once, so
-    // adding frames costs time, not memory, and the time is already bounded by
-    // the encode slot gate and the abort signal. See MAX_ANIMATED_INPUT_PIXELS.
+    // adding frames costs time rather than memory, and time is what that budget
+    // is sized against. See MAX_ANIMATED_INPUT_PIXELS.
     if (pages * width * height > MAX_ANIMATED_INPUT_PIXELS) { return undefined }
     return {frames: pages, outputType: animatedOutputType(input.options)}
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,6 +44,39 @@ export const MAX_INPUT_PIXELS = (() => {
 })()
 
 /**
+ * Maximum input pixels an ANIMATED source may total across all its frames.
+ *
+ * MAX_INPUT_PIXELS is sized for a still decode, where the pixel count IS the
+ * memory: one 16000x16000 frame becomes ~1GB of raw RGBA. Applying that same
+ * number to the frames of an animation summed together does not measure the same
+ * thing. libvips streams an animated pipeline frame by frame instead of holding
+ * the whole strip, so cost stays flat as frames are added. Measured on this
+ * build (sharp 0.33.5 / libvips 8.15.3), resizing to a feed thumbnail:
+ *
+ *   1.9 MP,  22 frames -> 70MB peak RSS, 0.3s
+ *   46 MP,   69 frames -> 82MB peak RSS, 0.8s
+ *   59 MP,  367 frames -> 82MB peak RSS, 3.9s
+ *   219 MP, 150 frames -> 84MB peak RSS, 2.7s
+ *
+ * against a 60MB baseline for the process with sharp loaded: 10 to 25MB of
+ * marginal memory whatever the pixel count. What does grow is TIME, and that is
+ * already bounded elsewhere, by the encode slot gate every animated encode has
+ * to queue for and by the abort signal that drops the render when the client
+ * leaves.
+ *
+ * So this exists to keep the pathological out, not to protect memory: the still
+ * budget still applies to each individual frame, and this caps the total work.
+ * The default is roughly twice the largest animation seen in production traffic.
+ * Configurable via `max_animated_input_pixels`.
+ */
+export const MAX_ANIMATED_INPUT_PIXELS = (() => {
+    if (!config.has('max_animated_input_pixels')) { return 500_000_000 }
+    // TOML parses this as a number; Number() also tolerates a string override.
+    const v = Number(config.get('max_animated_input_pixels'))
+    return Number.isSafeInteger(v) && v > 0 ? v : 500_000_000
+})()
+
+/**
  * Largest original the proxy will keep a cached copy of, in bytes.
  *
  * On a proxy miss we store two things: the rendered variant we are about to

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -66,14 +66,28 @@ export const MAX_INPUT_PIXELS = (() => {
  *
  * So this exists to keep the pathological out, not to protect memory: the still
  * budget still applies to each individual frame, and this caps the total work.
- * The default is roughly twice the largest animation seen in production traffic.
- * Configurable via `max_animated_input_pixels`.
+ *
+ * Aggregate, for production (12 cores, num_workers 6, UV_THREADPOOL_SIZE 16):
+ * resolveEncodeBudget gives floor(12/6) = 2 encode slots per worker, so 12
+ * service-wide, and every animated encode has to hold one. All 12 running an
+ * animation at this ceiling at once is 12 x ~25MB = ~300MB of marginal memory on
+ * a 62GB box. Memory is not the binding constraint at any plausible limit.
+ *
+ * TIME is what this number really buys, so it is set at 300 MP rather than
+ * generously: ~37% above the largest animation seen in production traffic
+ * (219 MP), and about 3.6s of encode at the measurements above. That matters
+ * because an encode slot is held until the encode FINISHES. `withEncodeSlot`
+ * checks the abort signal before starting and never again, and Sharp's toBuffer
+ * cannot be cancelled once running, so a client that leaves mid-encode still
+ * costs the full render (see the queued-only wording of ENCODE_ABORTED). Setting
+ * this higher lengthens the worst case a live request can queue behind an
+ * abandoned one. Configurable via `max_animated_input_pixels`.
  */
 export const MAX_ANIMATED_INPUT_PIXELS = (() => {
-    if (!config.has('max_animated_input_pixels')) { return 500_000_000 }
+    if (!config.has('max_animated_input_pixels')) { return 300_000_000 }
     // TOML parses this as a number; Number() also tolerates a string override.
     const v = Number(config.get('max_animated_input_pixels'))
-    return Number.isSafeInteger(v) && v > 0 ? v : 500_000_000
+    return Number.isSafeInteger(v) && v > 0 ? v : 300_000_000
 })()
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ import Sharp from 'sharp'
 import { URL } from 'url'
 
 import { domainBlacklist, imageBlacklist } from './blacklist'
-import { INTERNAL_SERVICE_ORIGINS, isEmptyImageUrl, MAX_INPUT_PIXELS } from './constants'
+import { INTERNAL_SERVICE_ORIGINS, isEmptyImageUrl, MAX_ANIMATED_INPUT_PIXELS, MAX_INPUT_PIXELS } from './constants'
 import { APIError } from './error'
 import {fetchImageWithFallbacks} from './fetch-image'
 import { logger } from './logger'
@@ -946,7 +946,11 @@ export function applyProxyResize(
 
 export function buildSharpPipeline(buffer: Buffer, animated: boolean = false, page?: number) {
     return Sharp(buffer, {
-        failOnError: false, animated, limitInputPixels: MAX_INPUT_PIXELS,
+        failOnError: false, animated,
+        // An animated read loads every frame, so it is measured against the
+        // budget written for that: the still one describes a single frame's
+        // memory and rejects perfectly ordinary animations when summed.
+        limitInputPixels: animated ? MAX_ANIMATED_INPUT_PIXELS : MAX_INPUT_PIXELS,
         ...(page !== undefined ? { page } : {}),
     })
 }

--- a/test/animated.ts
+++ b/test/animated.ts
@@ -133,14 +133,38 @@ describe('animated sources', function() {
             }), undefined)
         })
 
-        it('passes through when every frame together blows the pixel budget', function() {
+        it('passes through a source with one enormous frame', function() {
+            // The still-image budget is about ONE frame's memory, and this is the
+            // decompression bomb it was written for.
             assert.equal(plan({
                 byteLength: bigGif.length,
-                // one frame is fine, 4000 of them are not
-                metadata: {pages: 4000, width: 1000, height: 1000},
+                metadata: {pages: 4, width: 16000, height: 16000},
                 options: fitOptions(),
                 acceptHeader: WEBP_ACCEPT,
             }), undefined)
+        })
+
+        it('passes through when every frame together blows the animated budget', function() {
+            assert.equal(plan({
+                byteLength: bigGif.length,
+                // Each frame is ordinary; a thousand of them is not.
+                metadata: {pages: 1000, width: 1000, height: 1000},
+                options: fitOptions(),
+                acceptHeader: WEBP_ACCEPT,
+            }), undefined)
+        })
+
+        // The case this budget split exists for. Every frame is a normal photo
+        // and there are a lot of them, which is exactly what a heavy post-body
+        // GIF looks like: 1080x1350 over 150 frames is 219 MP, and the still
+        // budget rejected it while resizing 200KB stickers happily.
+        it('transforms an animation whose frames are ordinary but numerous', function() {
+            assert.deepEqual(plan({
+                byteLength: 1_572_008,
+                metadata: {pages: 150, width: 1080, height: 1350},
+                options: negotiatedWebp(),
+                acceptHeader: WEBP_ACCEPT,
+            }), {frames: 150, outputType: 'image/webp'})
         })
     })
 


### PR DESCRIPTION
Closes #49. **Stacked on #50** (base is `fix/animated-guard-duration`, not `main`), because it delivers nothing on its own: raising the budget lets the big GIFs reach the encoder, and the old frame-count guard then rejects their renders anyway.

The GIF that motivated this whole path was excluded from it. `MAX_INPUT_PIXELS` was applied to an animation's frames summed together, and 1080x1350 over 150 frames is 219 MP against a 100 MP budget, so it was passed through at 1,572,008 bytes at every size. The heaviest animations were exactly the ones kept out, while 200KB stickers were resized.

## Why the old rule was wrong, not just tight

The premise was that an animated decode holds the whole strip of frames at once. It does not. libvips streams an animated pipeline frame by frame, so frames cost time, not memory. Measured on this build (sharp 0.33.5 / libvips 8.15.3), resizing to a feed thumbnail, against a 60MB baseline for a process with sharp loaded:

| total pixels | frames | peak RSS | elapsed |
|---|---|---|---|
| 1.9 MP | 22 | 70 MB | 0.3 s |
| 46 MP | 69 | 82 MB | 0.8 s |
| 59 MP | 367 | 82 MB | 3.9 s |
| 219 MP | 150 | 84 MB | 2.7 s |

10 to 25 MB of marginal memory whatever the pixel count. What grows is time, and time is already bounded: every animated encode queues for an encode slot, and the abort signal drops the render when the client leaves.

## What changed

The budget is split rather than raised.

- Each individual **frame** still answers to `MAX_INPUT_PIXELS`. One 16000x16000 frame is the decompression bomb that number was written for, and it stays rejected whether or not it is animated.
- The frames **together** answer to a new `MAX_ANIMATED_INPUT_PIXELS`, default 500 MP, roughly twice the largest animation seen in production traffic. Configurable via `max_animated_input_pixels`.
- `buildSharpPipeline` uses the animated limit when it is building an animated pipeline. That is where the render actually threw: the plan could allow a source and Sharp would still refuse it.

## Verification

End to end through `renderAnimatedVariant` on the real source: 1,572,008 bytes and 150 frames in, 195,318 bytes and 40 frames out, 5000 ms of playback both ways, loop preserved. An 88% saving with the animation intact.

`38 passing` in `test/animated.ts`, including a test that the still budget still rejects a single enormous frame and one that an animation of ordinary-but-numerous frames is now transformed. Full suite `414 passing, 3 failing`, those three failing identically on a clean `main` checkout (`internal service URL helpers`, which needs public hosts this local config does not set).
