### PR TITLE
Budget what an animated render writes, not just what it reads

### DIFF
--- a/src/animated.ts
+++ b/src/animated.ts
@@ -140,12 +140,15 @@ export function readGifAnimation(buffer: Buffer): AnimationFacts {
                 // libvips reads a GIF's stored 3 as 4 and writes ANIM 4, so an
                 // unnormalised reader rejects every correct render of a
                 // finite-loop GIF. 0 means forever in both and stays 0.
+                // Every non-zero count normalises the same way, 65535 included.
+                // It is tempting to read the maximum as "forever", but libvips
+                // does not: it reads 65535 as 65536 plays, and writing that to
+                // WebP's 16-bit ANIM field truncates to 0, which DOES mean
+                // forever. Special-casing it here would wave through exactly the
+                // conversion this guard exists to catch. Such a GIF renders to
+                // GIF (where the count survives) and is passed through for WebP.
                 const stored = buffer.readUInt16LE(p + 16)
-                // 65535 is a "loop forever" idiom, and it is also the largest
-                // value the field holds: +1 would not survive the 16-bit ANIM
-                // field of a WebP render, which reads back as 0. Treat it as the
-                // forever it is meant to be rather than reject every render of it.
-                facts.loop = stored === 0 || stored === 0xffff ? 0 : stored + 1
+                facts.loop = stored === 0 ? 0 : stored + 1
             }
             p += 2
             skipSubBlocks()
@@ -284,7 +287,7 @@ export function animatedOutputType(options: ProxyOptions): AnimatedOutputType {
  */
 export function animatedRenderPlan(input: {
     byteLength: number,
-    metadata: {pages?: number, width?: number, height?: number},
+    metadata: {pages?: number, width?: number, height?: number, orientation?: number},
     options: ProxyOptions,
     acceptHeader: string,
 }): {frames: number, outputType: AnimatedOutputType} | undefined {
@@ -292,6 +295,14 @@ export function animatedRenderPlan(input: {
     // libvips has to have seen the frames: an APNG, which it loads as a single
     // page, must never reach an encoder that would write that page as a still.
     if (typeof pages !== 'number' || pages < 2 || !width || !height) { return undefined }
+    // An EXIF orientation that swaps the axes cannot be applied to an animation:
+    // libvips answers `rotate()` on a multi-page pipeline with "Rotate is not
+    // supported for multi-page images" (5 to 8 throw; 1 to 4 are fine). Deciding
+    // it here makes it the passthrough it is, rather than an exception the caller
+    // has to read as one — and a thrown render is deliberately NOT cached, on the
+    // grounds that it may be transient, which this never is.
+    const orientation = input.metadata.orientation
+    if (typeof orientation === 'number' && orientation >= 5 && orientation <= 8) { return undefined }
     // Not worth the encode. A sticker is already small and a re-encode of one
     // saves a few KB at the price of a full multi-frame decode.
     if (input.byteLength <= ANIMATED_PASSTHROUGH_MAX_SIZE) { return undefined }

--- a/src/animated.ts
+++ b/src/animated.ts
@@ -35,9 +35,14 @@
 
 import Sharp from 'sharp'
 
-import {ANIMATED_PASSTHROUGH_MAX_SIZE, MAX_ANIMATED_INPUT_PIXELS, MAX_INPUT_PIXELS} from './constants'
+import {
+    ANIMATED_PASSTHROUGH_MAX_SIZE, MAX_ANIMATED_INPUT_PIXELS, MAX_ANIMATED_OUTPUT_PIXELS, MAX_INPUT_PIXELS,
+} from './constants'
 import {isEncodeAborted} from './encode-limit'
-import {applyProxyResize, buildSharpPipeline, OutputFormat, ProxyOptions, supportsWebP} from './utils'
+import {
+    applyProxyResize, buildSharpPipeline, OutputFormat, ProxyOptions, resolveOutputBox, resolveProxyResize,
+    supportsWebP,
+} from './utils'
 
 /** The only output types that can carry an animation here. */
 export type AnimatedOutputType = 'image/webp' | 'image/gif'
@@ -85,6 +90,22 @@ function gifDelayMs(hundredths: number): number {
 }
 
 /**
+ * A stored WebP frame duration as the frame actually plays.
+ *
+ * The same clamp as gifDelayMs and for the same reason, at the boundary libwebp
+ * itself uses: a duration of 10ms or less is written back as 100ms. Verified on
+ * this build by rewriting the ANMF durations of a real animated WebP and
+ * re-encoding it: 5ms and 10ms come back as 100ms, 15ms and 20ms unchanged.
+ *
+ * Without this an animated WebP SOURCE from an encoder that does not clamp is
+ * measured on a different scale from the render made out of it, and every such
+ * source is rejected as "duration changed" and served whole.
+ */
+function webpDurationMs(stored: number): number {
+    return stored <= 10 ? 100 : stored
+}
+
+/**
  * Frames, playback duration and loop count declared by a GIF's own container.
  *
  * The walk skips extension blocks and each frame's LZW sub-blocks by their
@@ -120,7 +141,11 @@ export function readGifAnimation(buffer: Buffer): AnimationFacts {
                 // unnormalised reader rejects every correct render of a
                 // finite-loop GIF. 0 means forever in both and stays 0.
                 const stored = buffer.readUInt16LE(p + 16)
-                facts.loop = stored === 0 ? 0 : stored + 1
+                // 65535 is a "loop forever" idiom, and it is also the largest
+                // value the field holds: +1 would not survive the 16-bit ANIM
+                // field of a WebP render, which reads back as 0. Treat it as the
+                // forever it is meant to be rather than reject every render of it.
+                facts.loop = stored === 0 || stored === 0xffff ? 0 : stored + 1
             }
             p += 2
             skipSubBlocks()
@@ -174,7 +199,7 @@ export function readWebpAnimation(buffer: Buffer): AnimationFacts {
         if (tag === 'ANMF' && size >= 16) {
             facts.frames++
             // 3+3 byte offset, 3+3 byte size, then a 24-bit little-endian duration
-            facts.durationMs += buffer.readUIntLE(payload + 12, 3)
+            facts.durationMs += webpDurationMs(buffer.readUIntLE(payload + 12, 3))
         }
         p = payload + size + (size % 2)         // chunks are padded to even length
     }
@@ -275,9 +300,19 @@ export function animatedRenderPlan(input: {
     if (width * height > MAX_INPUT_PIXELS) { return undefined }
     // The frames together answer to their own, much larger budget. libvips
     // streams an animated pipeline rather than holding every frame at once, so
-    // adding frames costs time rather than memory, and time is what that budget
-    // is sized against. See MAX_ANIMATED_INPUT_PIXELS.
+    // adding frames costs time rather than memory. See MAX_ANIMATED_INPUT_PIXELS.
     if (pages * width * height > MAX_ANIMATED_INPUT_PIXELS) { return undefined }
+
+    // And the frames we are about to WRITE answer to a budget of their own. The
+    // two are not the same number and the source cannot stand in for the output:
+    // the output box comes from the request, so without this a small animation
+    // and a large `?width` buy an encode the source budget never sees. An
+    // animated resize never enlarges (see resolveProxyResize), so this is also
+    // bounded by the source, but it is the multiplication by frames that makes
+    // it worth checking rather than assuming.
+    const box = resolveOutputBox(input.metadata, resolveProxyResize(input.metadata, input.options, true))
+    if (!box || pages * box.width * box.height > MAX_ANIMATED_OUTPUT_PIXELS) { return undefined }
+
     return {frames: pages, outputType: animatedOutputType(input.options)}
 }
 
@@ -323,7 +358,7 @@ export async function renderAnimatedVariant(input: {
     let buffer: Buffer
     try {
         const image = buildSharpPipeline(input.bytes, true)
-        applyProxyResize(image, input.metadata, input.options)
+        applyProxyResize(image, input.metadata, input.options, true)
         if (plan.outputType === 'image/webp') {
             // Same quality as the still WebP path, and libvips carries the
             // source's frame delays and loop count across on its own.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -91,6 +91,40 @@ export const MAX_ANIMATED_INPUT_PIXELS = (() => {
 })()
 
 /**
+ * Maximum pixels an animated render may PRODUCE: frames x output width x height.
+ *
+ * The input budget above cannot see this. What an animated encode costs is set
+ * by the box it writes, multiplied by the frame count, and the box is chosen by
+ * whoever wrote the URL (`?width`/`?height`). Measured on this build with
+ * photographic frames, both encoders cost roughly 240ms per megapixel of OUTPUT:
+ *
+ *   400x400  x40  =  6.4 MP out -> 1.6s (gif) / 1.7s (webp)
+ *   800x800  x40  = 25.6 MP out -> 5.8s (gif) / 6.1s (webp)
+ *   800x800 x120  = 76.8 MP out -> (webp) 18.3s
+ *
+ * (Flat, poster-like frames are an order of magnitude cheaper, which is why a
+ * synthetic fixture makes this look free. Real post GIFs are not flat.)
+ *
+ * 50 MP therefore buys roughly 12 seconds in the worst case, and comfortably
+ * admits the case this whole path exists for: the 1.57MB feed GIF is
+ * 1080x1350 over 150 frames, and the feed's 600x500 thumbnail resolves to a
+ * 400x500 box, so 30 MP of output, which renders in 2.7s. A full-size render of
+ * a long animation lands above the ceiling and is passed through, which is what
+ * it did before any of this existed. Configurable via `max_animated_output_pixels`.
+ *
+ * This is a proxy for a wall-clock bound, which is the thing actually wanted; an
+ * encode cannot be interrupted once started (see the queued-only cancellation in
+ * encode-limit.ts). Until it can, the size of the work has to be decided before
+ * it starts.
+ */
+export const MAX_ANIMATED_OUTPUT_PIXELS = (() => {
+    if (!config.has('max_animated_output_pixels')) { return 50_000_000 }
+    // TOML parses this as a number; Number() also tolerates a string override.
+    const v = Number(config.get('max_animated_output_pixels'))
+    return Number.isSafeInteger(v) && v > 0 ? v : 50_000_000
+})()
+
+/**
  * Largest original the proxy will keep a cached copy of, in bytes.
  *
  * On a proxy miss we store two things: the rendered variant we are about to

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -891,11 +891,19 @@ export function primaryPageOf(metadata: {format?: string, pagePrimary?: number})
  * neither. Shared by the still and the animated render so an animation is sized
  * by exactly the same rules as the still it replaced.
  */
-export function applyProxyResize(
-    image: Sharp.Sharp,
+/**
+ * The resize this request resolves to, without applying it.
+ *
+ * Split out of applyProxyResize so a caller can know the size it is about to
+ * encode BEFORE paying for it. The animated path needs that: its cost is the
+ * output box multiplied by the frame count, and a budget that reads the source
+ * alone cannot see it.
+ */
+export function resolveProxyResize(
     metadata: {width?: number, height?: number},
     options: ProxyOptions,
-): void {
+    animated: boolean = false,
+): {width?: number, height?: number, fit: 'cover' | 'inside', withoutEnlargement: boolean} {
     const { maxWidth, maxHeight, maxCustomWidth, maxCustomHeight } = getProxyImageLimits()
     let width: number | undefined = safeParseInt(options.width)
     let height: number | undefined = safeParseInt(options.height)
@@ -926,22 +934,67 @@ export function applyProxyResize(
         case ScalingMode.Cover:
             if (bothUnspecified) {
                 // User didn't request specific dimensions — preserve aspect ratio
-                image.rotate().resize(width, height, { fit: 'inside', withoutEnlargement: true })
-            } else {
-                image.rotate().resize(width, height, {fit: 'cover'})
+                return {width, height, fit: 'inside', withoutEnlargement: true}
             }
-            break
+            // A requested box is honoured for a still, enlargement included: that
+            // is what a cover crop means and callers depend on it. An ANIMATION
+            // is never enlarged, because doing so multiplies the encode by the
+            // square of the scale on EVERY frame while adding no detail, and the
+            // scale is chosen by whoever wrote the URL.
+            return {width, height, fit: 'cover', withoutEnlargement: animated}
         case ScalingMode.Fit:
+        default:
             // Only set defaults if BOTH dimensions are undefined
             // If one dimension is defined, Sharp will auto-calculate the other
             if (width === undefined && height === undefined) {
                 width = maxWidth
                 height = maxHeight
             }
-
-            image.rotate().resize(width, height, { fit: 'inside', withoutEnlargement: true })
-            break
+            return {width, height, fit: 'inside', withoutEnlargement: true}
     }
+}
+
+/**
+ * The pixel box a resolved resize will actually produce, given the source.
+ *
+ * Exact for `inside` (the mode a feed thumbnail uses), where the scale is the
+ * smallest of the requested ratios; `cover` is bounded rather than modelled,
+ * which is enough for a budget and never under-counts. Undefined when the source
+ * dimensions are unknown, so the caller can decide rather than assume.
+ */
+export function resolveOutputBox(
+    metadata: {width?: number, height?: number},
+    resize: {width?: number, height?: number, fit: 'cover' | 'inside', withoutEnlargement: boolean},
+): {width: number, height: number} | undefined {
+    const srcW = metadata.width
+    const srcH = metadata.height
+    if (!srcW || !srcH) { return undefined }
+
+    if (resize.fit === 'cover') {
+        const w = resize.width ?? srcW
+        const h = resize.height ?? srcH
+        return {
+            width: Math.max(1, resize.withoutEnlargement ? Math.min(w, srcW) : w),
+            height: Math.max(1, resize.withoutEnlargement ? Math.min(h, srcH) : h),
+        }
+    }
+
+    const ratios: number[] = []
+    if (resize.width) { ratios.push(resize.width / srcW) }
+    if (resize.height) { ratios.push(resize.height / srcH) }
+    if (resize.withoutEnlargement) { ratios.push(1) }
+    const scale = ratios.length > 0 ? Math.min(...ratios) : 1
+    return {width: Math.max(1, Math.round(srcW * scale)), height: Math.max(1, Math.round(srcH * scale))}
+}
+
+export function applyProxyResize(
+    image: Sharp.Sharp,
+    metadata: {width?: number, height?: number},
+    options: ProxyOptions,
+    animated: boolean = false,
+): void {
+    const {width, height, fit, withoutEnlargement} = resolveProxyResize(metadata, options, animated)
+    image.rotate().resize(width, height, {fit, withoutEnlargement})
 }
 
 export function buildSharpPipeline(buffer: Buffer, animated: boolean = false, page?: number) {

--- a/test/animated.ts
+++ b/test/animated.ts
@@ -184,6 +184,37 @@ describe('animated sources', function() {
     // a 500x500 x300 source (75 MP in, inside every input budget) answered
     // `?width=2000` by upscaling every frame to 2000x2000, 1.2 GP of output and
     // 187 seconds of one of the service's ~12 encode slots, for an anonymous GET.
+        // libvips cannot auto-orient an animation: `rotate()` on a multi-page
+        // pipeline answers "Rotate is not supported for multi-page images" for
+        // the four orientations that swap the axes. Letting the render throw
+        // works, but a thrown render is deliberately not cached because it may be
+        // transient, and this one never is: every request pays the fetch again.
+        it('passes through an animation whose EXIF orientation cannot be applied', function() {
+            for (const orientation of [5, 6, 7, 8]) {
+                assert.equal(
+                    animatedRenderPlan({
+                        byteLength: bigGif.length,
+                        metadata: {pages: 8, width: 200, height: 150, orientation},
+                        options: negotiatedWebp({width: 100}),
+                        acceptHeader: WEBP_ACCEPT,
+                    }),
+                    undefined, `orientation ${orientation}`)
+            }
+        })
+
+        it('still transforms the orientations libvips can apply', function() {
+            for (const orientation of [undefined, 1, 2, 3, 4]) {
+                assert.deepEqual(
+                    animatedRenderPlan({
+                        byteLength: bigGif.length,
+                        metadata: {pages: 8, width: 200, height: 150, orientation},
+                        options: negotiatedWebp({width: 100}),
+                        acceptHeader: WEBP_ACCEPT,
+                    }),
+                    {frames: 8, outputType: 'image/webp'}, `orientation ${orientation}`)
+            }
+        })
+
     describe('what may be PRODUCED, not just consumed', function() {
         const plan = (over: Partial<ProxyOptions>, metadata: any, byteLength = bigGif.length) =>
             animatedRenderPlan({byteLength, metadata, options: {mode: ScalingMode.Cover, format: OutputFormat.Match, ...over},
@@ -391,18 +422,36 @@ describe('animated sources', function() {
             assert.ok(out, 'a WebP source with fast frames must still be rendered, not passed through')
         })
 
-        // 65535 is the largest a NETSCAPE2.0 block holds and a "forever" idiom.
-        // Normalising it to 65536 plays would not survive WebP's 16-bit ANIM
-        // field, so every render of such a GIF came back looking wrong.
-        it('treats the maximum stored loop count as forever', async function() {
-            this.timeout(30000)
-            const gif = makeAnimatedGif({width: 80, height: 60, frames: 4, delay: 5, noisy: true, loop: 65535})
-            assert.equal(readGifAnimation(gif).loop, 0)
-            const webp = await sharp(gif, {animated: true}).resize(40).webp({quality: 80, force: true}).toBuffer()
-            assert.equal(readWebpAnimation(webp).loop, readGifAnimation(gif).loop)
-            // One below the maximum still fits, and is still counted as plays.
-            const near = makeAnimatedGif({width: 80, height: 60, frames: 4, delay: 5, noisy: true, loop: 65534})
+        // The maximum stored count is a finite 65536 plays, not "forever", and
+        // that is how libvips reads it. WebP's ANIM loop is 16 bits, so a WebP
+        // render of such a GIF carries 0 — which DOES mean forever. Normalising
+        // it to forever here would wave that conversion through.
+        it('normalises the maximum stored loop count without calling it forever', function() {
+            const max = makeAnimatedGif({width: 80, height: 60, frames: 4, delay: 5, noisy: false, loop: 65535})
+            assert.equal(readGifAnimation(max).loop, 65536)
+            const near = makeAnimatedGif({width: 80, height: 60, frames: 4, delay: 5, noisy: false, loop: 65534})
             assert.equal(readGifAnimation(near).loop, 65535)
+            const forever = makeAnimatedGif({width: 80, height: 60, frames: 4, delay: 5, noisy: false, loop: 0})
+            assert.equal(readGifAnimation(forever).loop, 0)
+        })
+
+        it('refuses a WebP render that would turn 65536 plays into an endless loop', async function() {
+            this.timeout(30000)
+            const gif = makeAnimatedGif({width: 200, height: 150, frames: 8, delay: 10, noisy: true, loop: 65535})
+            const metadata = await sharp(gif).metadata()
+            const out = await renderAnimatedVariant({
+                bytes: gif, metadata, options: negotiatedWebp({width: 100}), acceptHeader: WEBP_ACCEPT,
+                encode, log: {warn: () => undefined, error: () => undefined, debug: () => undefined},
+            })
+            // libvips writes 65536 into a 16-bit field, and it reads back as 0.
+            assert.equal(out, undefined)
+            // The same source still renders to GIF, where the count survives.
+            const asGif = await renderAnimatedVariant({
+                bytes: gif, metadata, options: fitOptions({width: 100}), acceptHeader: 'image/*',
+                encode, log: console,
+            })
+            assert.ok(asGif, 'a GIF render keeps the loop count and must still happen')
+            assert.equal(readGifAnimation(asGif!.buffer).loop, readGifAnimation(gif).loop)
         })
 
         it('reads them back off a WebP the encoder wrote', async function() {

--- a/test/animated.ts
+++ b/test/animated.ts
@@ -10,7 +10,9 @@ import {
     readGifAnimation, readWebpAnimation, renderAnimatedVariant,
 } from './../src/animated'
 import {ANIMATED_PASSTHROUGH_MAX_SIZE} from './../src/constants'
-import {base58Enc, OutputFormat, ProxyOptions, ScalingMode} from './../src/utils'
+import {
+    base58Enc, OutputFormat, ProxyOptions, resolveOutputBox, resolveProxyResize, ScalingMode,
+} from './../src/utils'
 
 import {makeAnimatedGif} from './animated-gif-fixture'
 
@@ -35,6 +37,10 @@ const negotiatedWebp = (over: Partial<ProxyOptions> = {}): ProxyOptions =>
     fitOptions({format: OutputFormat.WEBP, ...over})
 
 describe('animated sources', function() {
+
+    /** The caller's encode runner, ungated: the queueing is not what these test. */
+    const encode = (image: sharp.Sharp) => image.toBuffer()
+
 
     it('the fixture really is an animation, and big enough to be worth transforming', async function() {
         const meta = await sharp(bigGif).metadata()
@@ -156,15 +162,83 @@ describe('animated sources', function() {
 
         // The case this budget split exists for. Every frame is a normal photo
         // and there are a lot of them, which is exactly what a heavy post-body
-        // GIF looks like: 1080x1350 over 150 frames is 219 MP, and the still
-        // budget rejected it while resizing 200KB stickers happily.
+        // GIF looks like: 1080x1350 over 150 frames is 219 MP of input, and the
+        // still budget rejected it while resizing 200KB stickers happily.
+        //
+        // Asked for at a size the service will actually write. What it may
+        // PRODUCE is a separate budget with its own tests below: at full size
+        // this same source is refused, because 219 MP of output is a two-minute
+        // encode holding one of twelve slots.
         it('transforms an animation whose frames are ordinary but numerous', function() {
             assert.deepEqual(plan({
                 byteLength: 1_572_008,
                 metadata: {pages: 150, width: 1080, height: 1350},
-                options: negotiatedWebp(),
+                options: negotiatedWebp({width: 320}),
                 acceptHeader: WEBP_ACCEPT,
             }), {frames: 150, outputType: 'image/webp'})
+        })
+    })
+
+    // #47 admitted an animated source on its INPUT size alone, while the encode it
+    // then paid for was sized by the request. Measured before this budget existed:
+    // a 500x500 x300 source (75 MP in, inside every input budget) answered
+    // `?width=2000` by upscaling every frame to 2000x2000, 1.2 GP of output and
+    // 187 seconds of one of the service's ~12 encode slots, for an anonymous GET.
+    describe('what may be PRODUCED, not just consumed', function() {
+        const plan = (over: Partial<ProxyOptions>, metadata: any, byteLength = bigGif.length) =>
+            animatedRenderPlan({byteLength, metadata, options: {mode: ScalingMode.Cover, format: OutputFormat.Match, ...over},
+                                acceptHeader: WEBP_ACCEPT})
+
+        it('passes through a render whose frames together would be too big to write', function() {
+            // 150 frames of 1080x1350 asked for at full size: 219 MP of output.
+            assert.equal(plan({}, {pages: 150, width: 1080, height: 1350}, 1_572_008), undefined)
+        })
+
+        it('still transforms the feed thumbnail that motivated the path', function() {
+            // The same source at the feed's box resolves to 400x500, so 30 MP.
+            assert.deepEqual(
+                animatedRenderPlan({
+                    byteLength: 1_572_008,
+                    metadata: {pages: 150, width: 1080, height: 1350},
+                    options: {mode: ScalingMode.Fit, format: OutputFormat.WEBP, width: 600, height: 500},
+                    acceptHeader: WEBP_ACCEPT,
+                }),
+                {frames: 150, outputType: 'image/webp'})
+        })
+
+        // The output box is what the budget is about, so a request that cannot
+        // grow the source cannot spend more than the source's own size either.
+        it('never enlarges an animated source, whatever width is asked for', async function() {
+            this.timeout(30000)
+            const metadata = await sharp(bigGif).metadata()
+            const out = await renderAnimatedVariant({
+                bytes: bigGif, metadata, options: {mode: ScalingMode.Cover, format: OutputFormat.WEBP, width: 2000},
+                acceptHeader: WEBP_ACCEPT, encode, log: console,
+            })
+            assert.ok(out, 'expected a render')
+            const rendered = await sharp(out!.buffer).metadata()
+            assert.equal(rendered.width, metadata.width,
+                `asked for 2000 on a ${metadata.width}px source and got ${rendered.width}`)
+        })
+
+        // A still is a different bargain: a cover crop is expected to fill the box
+        // it was given, and callers rely on that. Only the animated path refuses.
+        it('leaves the still-image cover crop free to enlarge', function() {
+            const still = {width: 100, height: 100}
+            const opts = {mode: ScalingMode.Cover, format: OutputFormat.WEBP, width: 800} as ProxyOptions
+            assert.equal(resolveProxyResize(still, opts, false).withoutEnlargement, false)
+            assert.equal(resolveProxyResize(still, opts, true).withoutEnlargement, true)
+        })
+
+        it('measures the box a fit resize actually lands on, not the one requested', function() {
+            const box = resolveOutputBox({width: 1080, height: 1350},
+                {width: 600, height: 500, fit: 'inside', withoutEnlargement: true})
+            assert.deepEqual(box, {width: 400, height: 500})
+        })
+
+        it('declines to guess when the source dimensions are unknown', function() {
+            assert.equal(resolveOutputBox({}, {width: 600, fit: 'inside', withoutEnlargement: true}), undefined)
+            assert.equal(plan({width: 600}, {pages: 8, width: undefined, height: undefined}), undefined)
         })
     })
 
@@ -263,6 +337,74 @@ describe('animated sources', function() {
             assert.equal(readGifAnimation(makeAnimatedGif({frames: 5, delay: 2, noisy: false})).durationMs, 100)
         })
 
+        // The GIF side clamps a sub-20ms delay to the 100ms it plays at; the WebP
+        // side has to do the same at libwebp's own boundary, or a source from an
+        // encoder that did not clamp is measured on a different scale from the
+        // render made out of it and is rejected as "duration changed".
+        it('reads a sub-10ms WebP frame as the 100ms it actually plays at', async function() {
+            this.timeout(30000)
+            const gif = makeAnimatedGif({width: 100, height: 80, frames: 6, delay: 4, noisy: true})
+            const normal = await sharp(gif, {animated: true}).webp({quality: 80, force: true}).toBuffer()
+
+            /** Rewrite every ANMF duration, the way another encoder might have. */
+            const withDuration = (ms: number) => {
+                const b = Buffer.from(normal)
+                const end = Math.min(b.readUInt32LE(4) + 8, b.length)
+                let p = 12
+                while (p + 8 <= end) {
+                    const size = b.readUInt32LE(p + 4)
+                    if (b.toString('ascii', p, p + 4) === 'ANMF') { b.writeUIntLE(ms, p + 8 + 12, 3) }
+                    p = p + 8 + size + (size % 2)
+                }
+                return b
+            }
+
+            for (const ms of [0, 5, 10]) {
+                assert.equal(readWebpAnimation(withDuration(ms)).durationMs, 600, `${ms}ms frames`)
+            }
+            // Above the boundary the stored value is what plays, and is left alone.
+            assert.equal(readWebpAnimation(withDuration(15)).durationMs, 90)
+            assert.equal(readWebpAnimation(withDuration(40)).durationMs, 240)
+        })
+
+        it('accepts a render of an animated WebP whose frames declare under 10ms', async function() {
+            this.timeout(30000)
+            // Big enough to be worth transforming, or it is passed through for
+            // its size and the test proves nothing about durations.
+            const gif = makeAnimatedGif({width: 400, height: 300, frames: 30, delay: 4, noisy: true})
+            const normal = await sharp(gif, {animated: true}).webp({quality: 80, force: true}).toBuffer()
+            assert.ok(normal.length > ANIMATED_PASSTHROUGH_MAX_SIZE,
+                `fixture is ${normal.length} bytes, under the ${ANIMATED_PASSTHROUGH_MAX_SIZE} ceiling`)
+            const source = Buffer.from(normal)
+            const end = Math.min(source.readUInt32LE(4) + 8, source.length)
+            let p = 12
+            while (p + 8 <= end) {
+                const size = source.readUInt32LE(p + 4)
+                if (source.toString('ascii', p, p + 4) === 'ANMF') { source.writeUIntLE(5, p + 8 + 12, 3) }
+                p = p + 8 + size + (size % 2)
+            }
+            const metadata = await sharp(source).metadata()
+            const out = await renderAnimatedVariant({
+                bytes: source, metadata, options: negotiatedWebp({width: 50}),
+                acceptHeader: WEBP_ACCEPT, encode, log: console,
+            })
+            assert.ok(out, 'a WebP source with fast frames must still be rendered, not passed through')
+        })
+
+        // 65535 is the largest a NETSCAPE2.0 block holds and a "forever" idiom.
+        // Normalising it to 65536 plays would not survive WebP's 16-bit ANIM
+        // field, so every render of such a GIF came back looking wrong.
+        it('treats the maximum stored loop count as forever', async function() {
+            this.timeout(30000)
+            const gif = makeAnimatedGif({width: 80, height: 60, frames: 4, delay: 5, noisy: true, loop: 65535})
+            assert.equal(readGifAnimation(gif).loop, 0)
+            const webp = await sharp(gif, {animated: true}).resize(40).webp({quality: 80, force: true}).toBuffer()
+            assert.equal(readWebpAnimation(webp).loop, readGifAnimation(gif).loop)
+            // One below the maximum still fits, and is still counted as plays.
+            const near = makeAnimatedGif({width: 80, height: 60, frames: 4, delay: 5, noisy: true, loop: 65534})
+            assert.equal(readGifAnimation(near).loop, 65535)
+        })
+
         it('reads them back off a WebP the encoder wrote', async function() {
             this.timeout(20000)
             const gif = makeAnimatedGif({width: 120, height: 90, frames: 6, delay: 10, noisy: true})
@@ -284,7 +426,6 @@ describe('animated sources', function() {
     })
 
     describe('rendering keeps the animation', function() {
-        const encode = (image: sharp.Sharp) => image.toBuffer()
 
         it('renders an animated WebP with every frame, materially smaller', async function() {
             this.timeout(20000)


### PR DESCRIPTION
An adversarial review of #47/#50/#51 found that the pixel budgets bound what an animated render **reads** while the encode they admit is sized by what it **writes**, and the request chooses that.

`applyProxyResize`'s cover branch is the default mode and the only one without `withoutEnlargement`, so `?width=2000` upscales every frame.

Measured on the merged code, with the repo's own fixture and pipeline:

| request | output | encode |
|---|---|---|
| `?width=2000` on 500x500 x300 (75 MP in) | 2000x2000 x300 = **1.2 GP** | **187,807 ms** |
| bare GET on 1080x1350 x150 | 1080x1350 x49 = 71 MP | **112,624 ms** |

There are 12 encode slots service-wide (12 cores / 6 workers, 2 each), an encode cannot be interrupted once started (#52), and `?width` is part of the variant key, so one source yields thousands of equally expensive uncached keys.

**This is not new to #51.** The second row is reachable on the build in production right now: the source is 75 MP, inside the deployed 100 MP aggregate budget. #51 raised the ceiling from 100 MP to 300 MP, which widens it, but the shape shipped with #47.

## What changed

**An animated resize never enlarges.** A still keeps the old bargain, because a cover crop is expected to fill the box it was given and callers rely on that. An animation does not: enlarging multiplies every frame by the square of a scale the URL author picked, and adds no detail. That alone takes the first row from 187s to 9s.

**The frames about to be written answer to `MAX_ANIMATED_OUTPUT_PIXELS`** (default 50 MP), checked before the encode starts. On photographic frames both encoders cost ~240 ms per megapixel of output:

| output | gif | webp |
|---|---|---|
| 400x400 x40 = 6.4 MP | 1.6 s | 1.7 s |
| 800x800 x40 = 25.6 MP | 5.8 s | 6.1 s |
| 800x800 x120 = 76.8 MP | | 18.3 s |

So the ceiling is about twelve seconds. Flat synthetic fixtures are an order of magnitude cheaper, which is what made this look free; real post GIFs are not flat.

`resolveProxyResize` and `resolveOutputBox` are split out of `applyProxyResize` so the size of the work can be known before it is paid for. No behaviour change for stills.

**The motivating case is unaffected**: the 1.57 MB feed GIF resolves to a 400x500 box over 150 frames, 30 MP, and still renders 1,572,008 -> 195,318 bytes in 2.7 s. A *full-size* render of that same animation is now a passthrough, which is what it was before any of this existed.

## Two smaller findings from the same review

An animated WebP source whose frames declare 10ms or less was rejected as "duration changed": libwebp writes those back as 100ms while the reader summed the stored value. The WebP side now clamps at libwebp's own boundary, as the GIF side already did at its. Verified by rewriting the ANMF durations of a real animated WebP: 0/5/10ms come back as 100ms, 15ms and 20ms unchanged.

A GIF storing the maximum NETSCAPE loop count, 65535, normalised to 65536 plays, which does not fit WebP's 16-bit ANIM field and read back as 0. It is a "loop forever" idiom and is now read as forever. 65534 still normalises to 65535 plays and round-trips.

## Verification

`49 passing` in `test/animated.ts`; full suite `425 passing, 3 failing`, those three failing identically on a clean `main` (`internal service URL helpers`, which needs public hosts this local config does not set).

Each new guard was mutated to confirm its test bites: removing the output budget, allowing animated enlargement, and dropping the WebP clamp each fail their own tests and nothing else.

## Still open

The review also confirmed that `getImageKey` gives `?width=100` and `?height=100` the **same cache key** for every mode/format except Fit+Match, under `immutable, max-age=1y`. That is pre-existing, affects stills too, and is filed separately as #54 rather than fixed here.


## Review round 2 (acb897e)

**The maximum loop count.** I had this backwards, and the reviewer was right. libvips reads a stored 65535 as **65536 plays** (finite) and truncates that into WebP's 16-bit ANIM field as 0, which means forever:

```
GIF stored 65535 | libvips READS 65536 | webp ANIM=0     | gif-out stored=65535
GIF stored 65534 | libvips READS 65535 | webp ANIM=65535 | gif-out stored=65534
```

Reading it as "forever" waved through exactly the conversion this guard exists to catch. Every non-zero count now normalises as `stored + 1`, so such a GIF renders to GIF (where the count survives) and passes through for WebP (where it cannot). This came from an adversarial review flagging "65535 is never resized to WebP" as a defect; the passthrough was correct behaviour and I fixed the symptom.

**EXIF orientation.** The claim was that `resolveOutputBox` reads raw dimensions while the pipeline auto-orients, letting a rotated source exceed the budget. That consequence cannot happen, but it led to a real defect: libvips will not auto-orient an animation at all. Measured on an animated WebP carrying a hand-built EXIF chunk:

```
orientation 1..4 -> ok, renders
orientation 5..8 -> THROWS: Rotate is not supported for multi-page images
```

So the render never happens. Instead it throws, and a thrown render is deliberately not cached because it may be transient — this one is permanent, so every request repeated the upstream fetch and the failed decode indefinitely. `animatedRenderPlan` now returns a planned passthrough for orientations 5-8, which is what it always was in substance.

`52 passing` in `test/animated.ts`, full suite `428 passing` with the same 3 pre-existing config failures. Both new guards mutated to confirm their tests bite.
