### PR TITLE
Keep a variant's width and height apart in its cache key

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -337,7 +337,24 @@ export function getImageKey(origKey: string, options: ProxyOptions): string {
         return `${origKey}_${options.width || 0}x${options.height || 0}${options.blur ? '_blur' : ''}`
     }
     const rv = [origKey, ScalingMode[options.mode], OutputFormat[options.format]]
-    if (options.width) { rv.push(options.width.toFixed(0)) }
+    // Both dimensions are POSITIONAL, so a missing width has to hold its place.
+    // Without the placeholder `?width=100` and `?height=100` built the same key,
+    // and the first of the two to render was then served to the other under
+    // `immutable, max-age=1y` with the variant's own ETag: a different image,
+    // pinned for a year at the edge and in the store.
+    //
+    // The placeholder is only written when there is a height to disambiguate
+    // from, so every key that already existed for a width, or for both, keeps
+    // the bytes it has. Only height-only variants get a new key, and a new key
+    // is a miss and a re-render, never a wrong answer.
+    //
+    // Deliberately NOT normalised to always-both (`..._600_0`). That reads more
+    // consistently with the fit+match form above, which has always written both
+    // axes and so never collided, but it would rename every width-only variant
+    // in the store: a 15-minute sample of production keys is roughly 15-20%
+    // `Fit_AVIF_600`, `Fit_AVIF_1280`, `Fit_AVIF_800` and friends, all of which
+    // would re-render on next request to buy nothing a reader can see.
+    if (options.width) { rv.push(options.width.toFixed(0)) } else if (options.height) { rv.push('0') }
     if (options.height) { rv.push(options.height.toFixed(0)) }
     if (options.blur) { rv.push('blur') }
     return rv.join('_')

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -36,6 +36,7 @@ import {
     isInternalUploadUrl,
     ScalingMode,
     OutputFormat,
+    ProxyOptions,
     redactUrlForLog,
     storeRemoveByPrefix,
     storeWrite,
@@ -1261,5 +1262,50 @@ describe('redactUrlForLog', function() {
         assert.equal(redactUrlForLog(''), '')
         assert.equal(redactUrlForLog(undefined), '')
         assert.equal(redactUrlForLog(null), '')
+    })
+})
+
+describe('variant keys keep the two dimensions apart', function() {
+    const key = (o: Partial<ProxyOptions>) =>
+        getImageKey('DQmFIXTURE', {mode: ScalingMode.Cover, format: OutputFormat.WEBP, ...o} as ProxyOptions)
+
+    // Both dimensions are positional. A width-only and a height-only request used
+    // to build the same key, so whichever rendered first was served to the other
+    // under `immutable, max-age=1y` with the real variant's ETag.
+    it('gives a width-only and a height-only request different keys', function() {
+        assert.notEqual(key({width: 100}), key({height: 100}))
+    })
+
+    it('does the same once blurred, where the suffix used to hide it', function() {
+        assert.notEqual(key({width: 100, blur: true}), key({height: 100, blur: true}))
+    })
+
+    it('holds the width position open so the height cannot read as one', function() {
+        assert.equal(key({height: 100}), 'DQmFIXTURE_Cover_WEBP_0_100')
+    })
+
+    // The fix is only worth having if it does not invalidate the whole store, so
+    // these pin the forms that must NOT move.
+    it('leaves every key that already had a width exactly as it was', function() {
+        assert.equal(key({width: 100}), 'DQmFIXTURE_Cover_WEBP_100')
+        assert.equal(key({width: 100, height: 200}), 'DQmFIXTURE_Cover_WEBP_100_200')
+        assert.equal(key({width: 100, blur: true}), 'DQmFIXTURE_Cover_WEBP_100_blur')
+        assert.equal(key({}), 'DQmFIXTURE_Cover_WEBP')
+    })
+
+    // Avatars and covers always pass both dimensions, so nothing they stored moves.
+    it('leaves the avatar and cover key shapes alone', function() {
+        assert.equal(
+            getImageKey('U123', {width: 256, height: 256, mode: ScalingMode.Cover, format: OutputFormat.WEBP} as ProxyOptions),
+            'U123_Cover_WEBP_256_256')
+    })
+
+    // The fit+match route already wrote both axes, and is untouched.
+    it('keeps the fit+match form, which never collided', function() {
+        const fit = (o: Partial<ProxyOptions>) =>
+            getImageKey('DQmFIXTURE', {mode: ScalingMode.Fit, format: OutputFormat.Match, ...o} as ProxyOptions)
+        assert.equal(fit({width: 100}), 'DQmFIXTURE_100x0')
+        assert.equal(fit({height: 100}), 'DQmFIXTURE_0x100')
+        assert.notEqual(fit({width: 100}), fit({height: 100}))
     })
 })


### PR DESCRIPTION
Closes #54.

`getImageKey` appends both dimensions positionally and skips a falsy one, so a width-only and a height-only request built the same key:

```
width=100  -> DQm..._Cover_WEBP_100
height=100 -> DQm..._Cover_WEBP_100
```

Those are different images. Whichever rendered first was stored and then served to the other under `public, max-age=31536000, immutable` with the real variant's ETag, so the wrong image is pinned at the edge and in the proxy store for a year.

## The fix, and what it deliberately does not do

A missing width now holds its place with a `0`, **but only when there is a height to disambiguate from**:

| request | key | |
|---|---|---|
| `?width=600` | `Fit_AVIF_600` | unchanged |
| `?width=600&height=500` | `Fit_AVIF_600_500` | unchanged |
| no dimensions | `Fit_AVIF` | unchanged |
| `?height=100` | `Fit_AVIF_0_100` | new (was `Fit_AVIF_100`) |

So nothing currently in the store is invalidated. Only height-only variants get a new key, and a new key is a miss and a re-render, never a wrong answer.

It is **not** normalised to always-both (`Fit_AVIF_600_0`). That would read more consistently with the fit+match branch, which has always written both axes (`600x0`, `0x377`, `1200x630`) and so never collided. But it would rename every width-only variant in the store. A 15-minute sample of live production keys:

```
6518  0x377            <- fit+match: both axes, already safe
 789  Fit_AVIF_600     <- would be renamed
 746  Fit_AVIF_92_92
 656  Fit_AVIF_1280    <- would be renamed
 488  Fit_AVIF_800     <- would be renamed
```

Roughly 15-20% of keys re-rendering to buy nothing a reader can see. The collision is fixed either way, so the cheaper one wins.

## Verification

Six tests in `test/utils.ts`: the two collide cases (plain and blurred), the new height-only form, and three that pin the shapes which must NOT move, including the avatar/cover shape (both always pass width and height, so nothing they stored moves) and the fit+match form.

Removing the placeholder fails exactly the three collision tests and nothing else.

Full suite `434 passing, 3 failing`, those three failing identically on a clean `main` (`internal service URL helpers`, which needs public hosts this local config does not set).

## Is the collision actually being hit?

No. Measured against ~14 days of rotated edge access logs, **29,727,968 requests to `/p/`**:

```
height-only /p/ requests total:          595,283
  of those mode=fit AND format=match:    595,283
height-only reaching the colliding branch:     0
```

Every height-only request in production takes the fit+match branch, which writes both axes (`0x377` alone is 6,518 of a 15-minute key sample) and never collided. Not one reaches the branch this PR fixes.

That follows from how callers are built: `format=match&mode=fit` is what vision-web emits for a bare sized request, its srcsets are width-based, and the legacy `/{w}x{h}/` route always fills both axes. Hitting the collision needs a height, no width, and a non-match format or non-fit mode.

**Residual, stated plainly:** a poisoned entry created before this log window cannot be ruled out, since `/p/` variants are immutable for a year. Keeping width-only keys stable means such an entry, if one exists, keeps being served. The always-both form would clear it at the cost of re-rendering 15-20% of the store; that trade was put to the repo owner with these numbers and this is the form chosen. If a height-only non-fit+match request ever shows up in the logs, that is the signal to revisit.
