### PR TITLE
Never spend an encode slot on a client that has already gone

### DIFF
--- a/src/encode-limit.ts
+++ b/src/encode-limit.ts
@@ -190,9 +190,34 @@ function release(): void {
  * matters under load: the cache in front of us gives up long before a deep queue
  * drains, so without it the queue fills with work for dead sockets while live
  * requests wait behind it.
+ *
+ * The signal covers everything up to the moment work STARTS: already aborted at
+ * the door, aborted while queued, and aborted in the hand-off. It does not, and
+ * cannot, abandon an encode already running. Measured on the sharp/libvips this
+ * repo pins (0.33.5 / 8.15.3), calling `.destroy()` on the instance 402ms into a
+ * 7.0s encode changed nothing: the promise RESOLVED with the full buffer at
+ * 6,987ms, having burnt 7.1s of CPU. There is no cancellation to propagate, so
+ * do not add an abort listener here expecting one.
+ *
+ * That is also why the slot is held to the end rather than released on abort.
+ * The native encode keeps its libuv threadpool thread whether or not anyone is
+ * still waiting for the result, so releasing early would admit another encode
+ * against a thread that is still busy and oversubscribe the pool — the exact
+ * starvation RESERVED_POOL_SLOTS exists to prevent. Wasted work is bounded at
+ * the other end instead, by not admitting an encode too big to finish quickly
+ * (see MAX_ANIMATED_OUTPUT_PIXELS and the size gate below).
  */
 export async function withEncodeSlot<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
     await acquire(signal)
+    // The slot is ours, but a queued client can go away in the moment between the
+    // hand-off and this line resuming: `grant()` drops the abort listener, so
+    // nothing else would notice, and the encode would run for a closed socket.
+    // Checking here is what makes the contract exact — a slot is never SPENT on
+    // work for a client that has already gone.
+    if (signal && signal.aborted) {
+        release()
+        throw abortedError()
+    }
     try {
         return await fn()
     } finally {

--- a/test/encode-limit.ts
+++ b/test/encode-limit.ts
@@ -145,6 +145,48 @@ describe('encode concurrency limit', function() {
         assert.equal(encodeLimitStats().queued, 0)
     })
 
+    // The signal is checked at the door and while queued. It also has to be
+    // checked in the HAND-OFF: `grant()` drops the abort listener when it gives
+    // the slot away, so a client that leaves in the moment between being granted
+    // a slot and the await resuming would otherwise have its encode start anyway.
+    it('does not start work for a client that left during the hand-off', async function() {
+        const ac = new AbortController()
+        let ran = false
+        const p = withEncodeSlot(async () => { ran = true; return 'done' }, ac.signal)
+        ac.abort()
+        await assert.rejects(p, (e: any) => isEncodeAborted(e))
+        assert.equal(ran, false, 'Sharp must not have been called for a closed socket')
+    })
+
+    it('gives the slot back when it refuses that hand-off', async function() {
+        const before = encodeLimitStats().active
+        const ac = new AbortController()
+        const p = withEncodeSlot(async () => 'done', ac.signal)
+        ac.abort()
+        await assert.rejects(p, (e: any) => isEncodeAborted(e))
+        assert.equal(encodeLimitStats().active, before, 'a refused hand-off must not leak its slot')
+        // ...and the gate still works afterwards.
+        assert.equal(await withEncodeSlot(async () => 'ok'), 'ok')
+    })
+
+    // The other half of the contract, and the reason the slot is held to the end:
+    // an encode already running cannot be abandoned, so the result is still
+    // produced and the slot is still returned exactly once.
+    it('completes work already running when the client leaves, and still frees the slot', async function() {
+        const before = encodeLimitStats().active
+        const ac = new AbortController()
+        let finished = false
+        const p = withEncodeSlot(async () => {
+            await new Promise((r) => setTimeout(r, 50))
+            finished = true
+            return 'done'
+        }, ac.signal)
+        setTimeout(() => ac.abort(), 10)
+        assert.equal(await p, 'done')
+        assert.equal(finished, true)
+        assert.equal(encodeLimitStats().active, before)
+    })
+
     it('rejects immediately when the signal is already aborted', async function() {
         const controller = new AbortController()
         controller.abort()


### PR DESCRIPTION
Closes #52, though not in the way the issue proposed. The proposed fix turned out not to be possible, and the measurement that shows why is now in the code.

## What the issue asked for

> register an abort listener when the Sharp operation starts, destroying the Sharp pipeline when the signal fires, and propagating the existing tagged cancellation error

**There is no cancellation to propagate.** Measured on the sharp/libvips this repo pins (0.33.5 / 8.15.3), on a 700x700 x60 animated source:

```
baseline encode:            7,004 ms
destroy() called at:          402 ms
promise settled at:         6,987 ms  -> RESOLVED, full 31,884,624 B buffer
CPU burnt in that window:   7,103 ms
```

`.destroy()` is the Duplex stream method; it does not reach the libvips pipeline. The encode ran to completion and succeeded. So an abort listener would achieve nothing except making the code look like it cancels.

**And releasing the slot on abort would be actively harmful.** The native encode keeps its libuv threadpool thread whether or not anyone is still waiting for the result. Releasing the slot early would admit another encode against a thread that is still busy and oversubscribe the pool — the exact starvation `RESERVED_POOL_SLOTS` exists to prevent. Holding the slot to the end is correct.

## What was actually wrong

The signal covered the door and the queue but not the **hand-off**. `grant()` drops the abort listener when it gives a slot away, so a client that closed its socket between being granted a slot and the `await` resuming had its encode started anyway. Probed on the merged code before changing it:

```
granted-then-aborted: fn ran=true, result=done      <- should never have run
aborted-mid-work:     work completed=true            <- unavoidable, correct
```

`withEncodeSlot` now re-checks when it takes the slot and gives it straight back if the client has gone.

## Where the real bound lives

Wasted work is limited at the admission end, not the cancellation end: `MAX_ANIMATED_OUTPUT_PIXELS` (#53) caps an animated encode at roughly twelve seconds, and `encodeNeedsSlot` keeps cheap encodes out of the queue entirely. That is the honest mitigation and the contract now says so, so nobody re-attempts the destroy-the-pipeline approach.

## Verification

Three tests: the hand-off no longer starts Sharp, the refused hand-off returns its slot rather than leaking it, and an encode already running still completes and still frees its slot exactly once.

Both halves mutated to confirm they bite. Removing the check fails the first two; removing just the `release()` fails 8 tests, because a leaked slot cascades into every later test that needs the gate — which is what the leak would do in production.

Full suite `437 passing, 3 failing`, those three failing identically on a clean `main` (`internal service URL helpers`, which needs public hosts this local config does not set).

## Not included

A queue-wait deadline — giving up on a queued encode once it has waited longer than the edge will tolerate, and serving the source instead — would convert some remaining waste into a useful response. It changes what a request answers with, so it wants its own change and its own decision rather than riding along here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented encoding from starting when a client aborts during slot hand-off.
  * Ensured aborted requests release their reserved capacity without leaks.
  * Preserved completion of encoding already in progress, with capacity returned exactly once.

* **Tests**
  * Added coverage for aborts during hand-off, refused hand-offs, and completion of active encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->