### PR TITLE
Budget an animated render against the encoder that will write it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,8 @@ Key configuration sections:
 - `max_image_size`, `max_image_width`, `max_image_height` - Size limits (`max_image_size` defaults to 20MB)
 - `max_cached_original_size` - Largest original the proxy cache keeps a copy of (default 1MB, `0` disables). Does not apply to avatar/cover originals, which are a bounded, frequently re-read set worth ~0.1% of the store
 - `animated_passthrough_max_size` - Largest animated source served through untouched (default 100KB). Above it the animation is re-rendered at the requested size; see src/animated.ts
+- `max_animated_input_pixels` - Frames x source width x height an animated source may be READ at (default 300M)
+- `max_animated_output_pixels_webp`, `max_animated_output_pixels_gif` - Frames x output width x height an animated render may WRITE, per output encoder (defaults 50M and 15M). Two numbers because GIF has to quantise every frame to 256 colours and WebP does not: measured over 144 renders of 13 real post GIFs, GIF costs 1.7x WebP at the median, 8x at p95 and ~18x on the same source at the same box. Past ~15 MP a re-encoded GIF saves a median 7% for several seconds of work. Replaces the single `max_animated_output_pixels` (removed, not aliased)
 - `default_avatar`, `default_cover` - Fallback images
 - `sentry_dsn` - Optional Sentry DSN for error tracking
 - `invalidate_token` - Optional token for cache invalidation API

--- a/src/animated.ts
+++ b/src/animated.ts
@@ -36,7 +36,8 @@
 import Sharp from 'sharp'
 
 import {
-    ANIMATED_PASSTHROUGH_MAX_SIZE, MAX_ANIMATED_INPUT_PIXELS, MAX_ANIMATED_OUTPUT_PIXELS, MAX_INPUT_PIXELS,
+    ANIMATED_PASSTHROUGH_MAX_SIZE, MAX_ANIMATED_INPUT_PIXELS, MAX_ANIMATED_OUTPUT_PIXELS_GIF,
+    MAX_ANIMATED_OUTPUT_PIXELS_WEBP, MAX_INPUT_PIXELS,
 } from './constants'
 import {isEncodeAborted} from './encode-limit'
 import {
@@ -321,10 +322,21 @@ export function animatedRenderPlan(input: {
     // animated resize never enlarges (see resolveProxyResize), so this is also
     // bounded by the source, but it is the multiplication by frames that makes
     // it worth checking rather than assuming.
+    //
+    // That budget belongs to the ENCODER, not to the request: writing a
+    // megapixel as GIF costs several times what writing it as WebP does, because
+    // GIF has to quantise every frame to 256 colours. Deciding the output type
+    // first is free - it is a pure function of options, which parseOptions has
+    // already folded Accept into - and it is what keeps one number from being
+    // simultaneously too tight for WebP and too loose for GIF (#57).
+    const outputType = animatedOutputType(input.options)
+    const outputBudget = outputType === 'image/webp'
+        ? MAX_ANIMATED_OUTPUT_PIXELS_WEBP
+        : MAX_ANIMATED_OUTPUT_PIXELS_GIF
     const box = resolveOutputBox(input.metadata, resolveProxyResize(input.metadata, input.options, true))
-    if (!box || pages * box.width * box.height > MAX_ANIMATED_OUTPUT_PIXELS) { return undefined }
+    if (!box || pages * box.width * box.height > outputBudget) { return undefined }
 
-    return {frames: pages, outputType: animatedOutputType(input.options)}
+    return {frames: pages, outputType}
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -92,37 +92,81 @@ export const MAX_ANIMATED_INPUT_PIXELS = (() => {
 
 /**
  * Maximum pixels an animated render may PRODUCE: frames x output width x height.
+ * One budget per output encoder, because the two do not cost remotely the same.
  *
  * The input budget above cannot see this. What an animated encode costs is set
  * by the box it writes, multiplied by the frame count, and the box is chosen by
- * whoever wrote the URL (`?width`/`?height`). Measured on this build with
- * photographic frames, both encoders cost roughly 240ms per megapixel of OUTPUT:
+ * whoever wrote the URL (`?width`/`?height`). A single number covered both
+ * encoders until #57. It was calibrated on synthetic fixtures that put GIF and
+ * WebP within a few percent of each other; real sources do not behave that way.
  *
- *   400x400  x40  =  6.4 MP out -> 1.6s (gif) / 1.7s (webp)
- *   800x800  x40  = 25.6 MP out -> 5.8s (gif) / 6.1s (webp)
- *   800x800 x120  = 76.8 MP out -> (webp) 18.3s
+ * Re-measured through the whole renderAnimatedVariant path on 13 real animated
+ * GIFs taken from live posts, six output boxes each, sharp_concurrency 1
+ * (144 renders; a slower box than production, so these are upper bounds):
  *
- * (Flat, poster-like frames are an order of magnitude cheaper, which is why a
- * synthetic fixture makes this look free. Real post GIFs are not flat.)
+ *                    WebP        GIF
+ *   cheapest        22 ms/MP   127 ms/MP
+ *   p50            170 ms/MP   290 ms/MP
+ *   p95            293 ms/MP  2474 ms/MP
+ *   worst          644 ms/MP  4583 ms/MP
+ *   renders kept     68/78       39/66
+ *   median saving      83%         22%
  *
- * 50 MP therefore buys roughly 12 seconds in the worst case, and comfortably
- * admits the case this whole path exists for: the 1.57MB feed GIF is
- * 1080x1350 over 150 frames, and the feed's 600x500 thumbnail resolves to a
- * 400x500 box, so 30 MP of output, which renders in 2.7s. A full-size render of
- * a long animation lands above the ceiling and is passed through, which is what
- * it did before any of this existed. Configurable via `max_animated_output_pixels`.
+ * Three things follow, and only the first was visible before:
  *
- * This is a proxy for a wall-clock bound, which is the thing actually wanted; an
+ *  - GIF is the dearer encoder at every percentile, because it has to quantise
+ *    every frame down to a 256-colour palette and WebP never does. Same source,
+ *    same box, two sources measured at the 30 MP feed thumbnail: 2.8s vs 49.0s
+ *    and 6.0s vs 105.1s. Roughly 18x, twice. One budget therefore has to be
+ *    wrong in both directions at once.
+ *  - Cost per megapixel is NOT a property of the format. It spans 29x between
+ *    sources for WebP and 36x for GIF, driven by frame CONTENT rather than by
+ *    frame count or box size, so no single number is tight for every source.
+ *    #53 and #57 each sized this from one source and reached opposite answers.
+ *  - For GIF, cost and size have come apart completely: the dearest renders
+ *    measured are DOWNSCALES at SMALL output (4583 ms/MP at 7.4 MP, 34s), because
+ *    interpolating frames invents colours the palette then has to fit. A pixel
+ *    budget cannot see that case, and this one does not pretend to.
+ *
+ * WebP keeps the 50 MP it already had. It is deliberately NOT raised to the
+ * ~150 MP #57 proposed: that figure came from the #1802 source, which measures
+ * 23-92 ms/MP and is the cheapest in the sample, and 150 MP of a p95 source is
+ * 44s of encode against an edge that gives up at 20s.
+ *
+ * GIF drops to 15 MP, which is where its VALUE stops rather than where its cost
+ * starts. Above that line the sample spent 468s of encode across 21 renders, kept
+ * 15 of them (the rest came out bigger than the source and were thrown away), and
+ * those 15 saved a median of 7%. Below it a re-encoded GIF still earns its slot,
+ * saving 60-97%. The drop also closes a live hazard rather than only lost savings:
+ * a 30 MP feed thumbnail sits inside the old shared budget, and as GIF that is a
+ * 49-105s encode holding one of twelve service-wide slots long after the edge
+ * has hung up on the client that asked for it.
+ *
+ * Configurable via `max_animated_output_pixels_webp` and
+ * `max_animated_output_pixels_gif`. These replace the single
+ * `max_animated_output_pixels` #53 added a day earlier, which is gone rather
+ * than aliased: it was never documented as a knob, and neither production.toml
+ * nor the running container's environment set it.
+ *
+ * These stand in for a wall-clock bound, which is the thing actually wanted; an
  * encode cannot be interrupted once started (see the queued-only cancellation in
  * encode-limit.ts). Until it can, the size of the work has to be decided before
  * it starts.
  */
-export const MAX_ANIMATED_OUTPUT_PIXELS = (() => {
-    if (!config.has('max_animated_output_pixels')) { return 50_000_000 }
+function animatedOutputBudget(key: string, fallback: number): number {
+    if (!config.has(key)) { return fallback }
     // TOML parses this as a number; Number() also tolerates a string override.
-    const v = Number(config.get('max_animated_output_pixels'))
-    return Number.isSafeInteger(v) && v > 0 ? v : 50_000_000
-})()
+    const v = Number(config.get(key))
+    return Number.isSafeInteger(v) && v > 0 ? v : fallback
+}
+
+/** WebP: the cheaper encoder, and the one nearly every client resolves to. */
+export const MAX_ANIMATED_OUTPUT_PIXELS_WEBP =
+    animatedOutputBudget('max_animated_output_pixels_webp', 50_000_000)
+
+/** GIF: only reached by a client that refused WebP, and several times dearer. */
+export const MAX_ANIMATED_OUTPUT_PIXELS_GIF =
+    animatedOutputBudget('max_animated_output_pixels_gif', 15_000_000)
 
 /**
  * Largest original the proxy will keep a cached copy of, in bytes.

--- a/src/encode-limit.ts
+++ b/src/encode-limit.ts
@@ -205,7 +205,7 @@ function release(): void {
  * against a thread that is still busy and oversubscribe the pool — the exact
  * starvation RESERVED_POOL_SLOTS exists to prevent. Wasted work is bounded at
  * the other end instead, by not admitting an encode too big to finish quickly
- * (see MAX_ANIMATED_OUTPUT_PIXELS and the size gate below).
+ * (see MAX_ANIMATED_OUTPUT_PIXELS_WEBP / _GIF and the size gate below).
  */
 export async function withEncodeSlot<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
     await acquire(signal)

--- a/test/animated.ts
+++ b/test/animated.ts
@@ -9,7 +9,9 @@ import {
     animatedOutputType, animatedRenderPlan, countGifFrames, countWebpFrames, readAnimation,
     readGifAnimation, readWebpAnimation, renderAnimatedVariant,
 } from './../src/animated'
-import {ANIMATED_PASSTHROUGH_MAX_SIZE} from './../src/constants'
+import {
+    ANIMATED_PASSTHROUGH_MAX_SIZE, MAX_ANIMATED_OUTPUT_PIXELS_GIF, MAX_ANIMATED_OUTPUT_PIXELS_WEBP,
+} from './../src/constants'
 import {
     base58Enc, OutputFormat, ProxyOptions, resolveOutputBox, resolveProxyResize, ScalingMode,
 } from './../src/utils'
@@ -270,6 +272,56 @@ describe('animated sources', function() {
         it('declines to guess when the source dimensions are unknown', function() {
             assert.equal(resolveOutputBox({}, {width: 600, fit: 'inside', withoutEnlargement: true}), undefined)
             assert.equal(plan({width: 600}, {pages: 8, width: undefined, height: undefined}), undefined)
+        })
+
+        // #57. GIF costs several times what WebP does to write the same
+        // megapixel, because it has to quantise every frame to 256 colours,
+        // so one budget was too tight for one encoder and too loose for the
+        // other. The budget belongs to the encoder that is about to run.
+        describe('the budget belongs to the output encoder', function() {
+            // The #1802 source at the feed's own box: 400x500 over 150 frames,
+            // 30 MP of output. Inside WebP's budget, well over GIF's.
+            const feedSource = {pages: 150, width: 1080, height: 1350}
+            const atFeedBox = (format: OutputFormat) => animatedRenderPlan({
+                byteLength: 1_572_008,
+                metadata: feedSource,
+                options: {mode: ScalingMode.Fit, format, width: 600, height: 500},
+                acceptHeader: WEBP_ACCEPT,
+            })
+
+            const feedBoxPixels = (() => {
+                const box = resolveOutputBox(feedSource, resolveProxyResize(feedSource,
+                    {mode: ScalingMode.Fit, format: OutputFormat.WEBP, width: 600, height: 500}, true))
+                return feedSource.pages * box!.width * box!.height
+            })()
+
+            it('is not one number for both encoders', function() {
+                assert.ok(MAX_ANIMATED_OUTPUT_PIXELS_WEBP > MAX_ANIMATED_OUTPUT_PIXELS_GIF,
+                    'WebP is the cheaper encoder, so it is the one that may write more')
+                // Without this the fixture below proves nothing.
+                assert.ok(feedBoxPixels <= MAX_ANIMATED_OUTPUT_PIXELS_WEBP &&
+                          feedBoxPixels > MAX_ANIMATED_OUTPUT_PIXELS_GIF,
+                    `the 30 MP feed box must straddle the two budgets; it is ${feedBoxPixels}`)
+            })
+
+            it('renders the feed thumbnail for a client that takes WebP', function() {
+                assert.deepEqual(atFeedBox(OutputFormat.WEBP), {frames: 150, outputType: 'image/webp'})
+            })
+
+            it('passes the same box through for a client that refused WebP', function() {
+                // Measured over 54 real GIF renders: past ~15 MP a re-encoded GIF
+                // saves a median of 7% for several seconds of quantisation, and
+                // half the results come out bigger than the source and are thrown
+                // away. Not worth an encode slot.
+                assert.equal(atFeedBox(OutputFormat.Match), undefined)
+            })
+
+            it('reads the budget for the format the request resolved to, not the one it asked for', function() {
+                // AVIF cannot hold an animation, so it renders as WebP (see
+                // animatedOutputType), so it must spend WebP's budget,
+                // not the GIF budget its own name would suggest.
+                assert.deepEqual(atFeedBox(OutputFormat.AVIF), {frames: 150, outputType: 'image/webp'})
+            })
         })
     })
 


### PR DESCRIPTION
Closes #57.

`MAX_ANIMATED_OUTPUT_PIXELS` was one number for both output formats. #53 sized it from synthetic fixtures that put GIF and WebP within a few percent of each other. Re-measured through the whole `renderAnimatedVariant` path on 13 real animated GIFs pulled from live posts, six output boxes each (144 renders, `sharp_concurrency` 1):

| | WebP | GIF |
|---|---|---|
| cheapest | 22 ms/MP | 127 ms/MP |
| p50 | 170 ms/MP | 290 ms/MP |
| p95 | 293 ms/MP | 2474 ms/MP |
| worst | 644 ms/MP | 4583 ms/MP |
| renders kept | 68/78 | 39/66 |
| median saving when kept | 83% | 22% |

GIF has to quantise every frame to a 256-colour palette and WebP never does, so one budget was too tight for one encoder and too loose for the other. This splits it per output encoder, picked from the output type the request already resolves to (so an AVIF request, which cannot hold an animation and renders as WebP, spends WebPs budget).

**WebP keeps 50 MP.** It is deliberately not raised to the ~150 MP the issue proposed. That figure came from the #1802 source, which measures 23-92 ms/MP and is the cheapest in the sample; 150 MP of a p95 source is 44s of encode against an edge that gives up at 20s. #53 and #57 each sized this from a single source and reached opposite answers, which is the real lesson: cost per megapixel is a property of frame content, not of the format, and it spans 29x between sources for WebP and 36x for GIF.

**GIF drops to 15 MP**, which is where its value stops rather than where its cost starts. Above that line the sample spent 468s of encode across 21 renders, kept only 15 of them (the rest came out bigger than the source and were thrown away) and those 15 saved a median of 7%. Below it a re-encoded GIF still saves 60-97%.

That turns out to close a live hazard, not just recover lost savings. A 30 MP feed thumbnail sits inside the old shared budget, so a client that refused WebP could trigger a **49s** encode on the #1802 source and a **105s** encode on another, each holding one of twelve service-wide encode slots long after the edge had hung up on the client that asked. Verified against the shipped config on both sources:

```
#1802 source        webp -> image/webp   195,318 B (source 1,572,008)  2769ms
#1802 source        gif  -> PASSTHROUGH                                   0ms   (was 49,027ms)
second slow source  webp -> image/webp 4,055,678 B (source 18,343,157) 6024ms
second slow source  gif  -> PASSTHROUGH                                   0ms   (was 105,068ms)
```

One caveat worth recording: for GIF, cost and output size have come apart entirely. The dearest renders measured are downscales at *small* output (4583 ms/MP at 7.4 MP, 34s), because interpolating frames invents colours the palette then has to fit. A pixel budget cannot see that case and this one does not pretend to; the constant says so.

### Test plan
- `test/animated.ts`: four new cases pinning that the budgets differ, that the 30 MP feed box renders as WebP and passes through as GIF, and that an AVIF request reads the WebP budget rather than the GIF one.
- Full suite: 441 passing. The 3 failures in `constants / internal service URL helpers` are pre-existing on `main` (they assert `i.ecency.com` is internal while `config/test.toml` sets `service_url` to localhost) and are unrelated to this change.
- `tsc --noEmit` clean. `eslint src/**/*.ts` reports only the pre-existing `no-empty` in `sharded-fs-store.ts`.
- Measurement repeatability: 33 boxes were measured twice across two runs and agreed within 6%, mostly within 1%.

Note that `max_animated_output_pixels` is removed rather than aliased. It was one day old, undocumented as a knob, and set neither in `production.toml` nor in the running container's environment (both checked).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Animated image processing now applies separate output pixel limits for WebP and GIF formats.
  - Added a configurable limit for reading animated sources.
  - Animated output limits are selected based on the encoder used, including cases where AVIF requests are rendered as WebP.

- **Bug Fixes**
  - Improved animated image handling so format-specific pixel budgets are applied consistently, allowing valid WebP output while preventing oversized GIF output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->